### PR TITLE
home: fix build paths for lua and zip filesystem

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -34,15 +34,21 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: home
-          path: results/bin/home
+          name: home-binaries
+          path: results/bin/home-*
 
   test:
     runs-on: ${{ matrix.os }}
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
+        include:
+          - os: ubuntu-latest
+            binary: home-linux-x86_64
+          - os: macos-latest
+            binary: home-darwin-arm64
+          - os: ubuntu-24.04-arm
+            binary: home-linux-arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -50,24 +56,24 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: home
+          name: home-binaries
           path: results/bin/
 
       - name: Make binary executable
-        run: chmod +x results/bin/home
+        run: chmod +x results/bin/${{ matrix.binary }}
 
       - name: Test help command
-        run: results/bin/home || test $? -eq 1
+        run: results/bin/${{ matrix.binary }} || test $? -eq 1
 
       - name: Test unpack outputs zip
         run: |
-          results/bin/home unpack > /tmp/test.zip
+          results/bin/${{ matrix.binary }} unpack > /tmp/test.zip
           unzip -l /tmp/test.zip | head -20
 
       - name: Test extraction
         run: |
           mkdir -p /tmp/test-home
-          results/bin/home unpack > /tmp/dotfiles.zip
+          results/bin/${{ matrix.binary }} unpack > /tmp/dotfiles.zip
           unzip -q /tmp/dotfiles.zip -d /tmp/test-home
           test -f /tmp/test-home/.zshenv
 
@@ -81,7 +87,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: home
+          name: home-binaries
           path: results/bin/
 
       - name: Get version
@@ -92,7 +98,7 @@ jobs:
       - name: Create checksums
         run: |
           cd results/bin
-          sha256sum home > SHA256SUMS
+          sha256sum home-* > SHA256SUMS
           cat SHA256SUMS
 
       - name: Create release
@@ -101,5 +107,7 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: home ${{ steps.version.outputs.tag }}
           files: |
-            results/bin/home
+            results/bin/home-darwin-arm64
+            results/bin/home-linux-arm64
+            results/bin/home-linux-x86_64
             results/bin/SHA256SUMS

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -67,7 +67,8 @@ jobs:
       - name: Test extraction
         run: |
           mkdir -p /tmp/test-home
-          results/bin/home unpack | unzip -d /tmp/test-home
+          results/bin/home unpack > /tmp/dotfiles.zip
+          unzip -q /tmp/dotfiles.zip -d /tmp/test-home
           test -f /tmp/test-home/.zshenv
 
   release:

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -1,0 +1,104 @@
+name: Build home
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Register APE binfmt
+        run: |
+          sudo wget -q -O /usr/bin/ape https://cosmo.zip/pub/cosmos/bin/ape-$(uname -m).elf
+          sudo chmod +x /usr/bin/ape
+          sudo sh -c "echo ':APE:M::MZqFpD::/usr/bin/ape:' >/proc/sys/fs/binfmt_misc/register" || true
+
+      - name: Cache tools
+        uses: actions/cache@v4
+        with:
+          path: |
+            o/3p/cosmocc
+            o/3p/cosmos
+          key: tools-${{ hashFiles('3p/cosmocc/cook.mk', '3p/cosmos/cook.mk') }}
+
+      - name: Build home binary
+        run: make home -j$(nproc)
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: home
+          path: results/bin/home
+
+  test:
+    runs-on: ${{ matrix.os }}
+    needs: build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: home
+          path: results/bin/
+
+      - name: Make binary executable
+        run: chmod +x results/bin/home
+
+      - name: Test help command
+        run: results/bin/home || test $? -eq 1
+
+      - name: Test unpack outputs zip
+        run: |
+          results/bin/home unpack > /tmp/test.zip
+          unzip -l /tmp/test.zip | head -20
+
+      - name: Test extraction
+        run: |
+          mkdir -p /tmp/test-home
+          results/bin/home unpack | unzip -d /tmp/test-home
+          test -f /tmp/test-home/.zshenv
+
+  release:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: home
+          path: results/bin/
+
+      - name: Get version
+        id: version
+        run: |
+          echo "tag=home-$(date -u +%Y-%m-%d)-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
+      - name: Create checksums
+        run: |
+          cd results/bin
+          sha256sum home > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: home ${{ steps.version.outputs.tag }}
+          files: |
+            results/bin/home
+            results/bin/SHA256SUMS

--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,7 @@ extras
 .duckdb/
 .duckdb_history
 dist/
+3p/*/digest
+3p/*/fetch
+o/
+results/

--- a/3p/cook.mk
+++ b/3p/cook.mk
@@ -1,0 +1,19 @@
+o := $(CURDIR)/o
+3p := $(o)/3p
+
+curl := curl -fsSL
+sha256sum := shasum -a 256
+unzip := unzip -q -DD
+zip := zip -q
+tar := tar -m
+lua := lua
+
+include 3p/cosmocc/cook.mk
+include 3p/cosmos/cook.mk
+
+export PATH := $(dir $(cosmos_bin)):$(dir $(cosmocc_bin)):$(PATH)
+export CC := $(cosmocc_bin)
+export AR := $(dir $(cosmocc_bin))cosmocc-ar
+export RANLIB := $(dir $(cosmocc_bin))cosmocc-ranlib
+
+make := make COSMOCC=$(cosmocc_dir)

--- a/3p/cosmocc/cook.mk
+++ b/3p/cosmocc/cook.mk
@@ -1,0 +1,15 @@
+cosmocc_url := https://github.com/jart/cosmopolitan/releases/download/4.0.2/cosmocc-4.0.2.zip
+cosmocc_sha256 := 85b8c37a406d862e656ad4ec14be9f6ce474c1b436b9615e91a55208aced3f44
+cosmocc_dir := $(3p)/cosmocc
+cosmocc_zip := $(cosmocc_dir)/cosmocc.zip
+cosmocc_bin := $(cosmocc_dir)/bin/cosmocc
+
+$(cosmocc_bin): $(cosmocc_zip)
+	$(unzip) -o $< -d $(cosmocc_dir)
+
+$(cosmocc_zip): | $(cosmocc_dir)
+	$(curl) -o $@ $(cosmocc_url)
+	cd $(dir $@) && echo "$(cosmocc_sha256)  $(notdir $@)" | $(sha256sum) -c
+
+$(cosmocc_dir):
+	mkdir -p $@

--- a/3p/cosmocc/test
+++ b/3p/cosmocc/test
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "cosmocc tests: ✓"

--- a/3p/cosmopolitan/cook.mk
+++ b/3p/cosmopolitan/cook.mk
@@ -1,0 +1,15 @@
+cosmopolitan_url = https://github.com/jart/cosmopolitan/releases/download/4.0.2/cosmopolitan-4.0.2.tar.gz
+cosmopolitan_sha256 = e466106b18064e0c996ef64d261133af867bccd921ad14e54975d89aa17a8717
+cosmopolitan_dir := $(3p)/cosmopolitan
+cosmopolitan_tarball := $(cosmopolitan_dir)/cosmopolitan.tar.gz
+cosmopolitan_src := $(cosmopolitan_dir)/cosmopolitan-4.0.2/Makefile
+
+$(cosmopolitan_src): $(cosmopolitan_tarball)
+	cd $(cosmopolitan_dir) && $(tar) -xzf $(notdir $<)
+
+$(cosmopolitan_tarball): | $(cosmopolitan_dir)
+	$(curl) -o $@ $(cosmopolitan_url)
+	cd $(dir $@) && echo "$(cosmopolitan_sha256)  $(notdir $@)" | $(sha256sum) -c
+
+$(cosmopolitan_dir):
+	mkdir -p $@

--- a/3p/cosmopolitan/test
+++ b/3p/cosmopolitan/test
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "cosmopolitan tests: ✓"

--- a/3p/cosmos/cook.mk
+++ b/3p/cosmos/cook.mk
@@ -1,0 +1,15 @@
+cosmos_url := https://github.com/jart/cosmopolitan/releases/download/4.0.2/cosmos-4.0.2.zip
+cosmos_sha256 := 494ecbd87c2f2f622f91066d4fe5d9ffc1aaaa13de02db1714dd84d014ed398f
+cosmos_dir := $(3p)/cosmos
+cosmos_zip := $(cosmos_dir)/cosmos.zip
+cosmos_bin := $(cosmos_dir)/bin/make
+
+$(cosmos_bin): $(cosmos_zip)
+	$(unzip) -o $< -d $(cosmos_dir)
+
+$(cosmos_zip): | $(cosmos_dir)
+	$(curl) -o $@ $(cosmos_url)
+	cd $(dir $@) && echo "$(cosmos_sha256)  $(notdir $@)" | $(sha256sum) -c
+
+$(cosmos_dir):
+	mkdir -p $@

--- a/3p/cosmos/test
+++ b/3p/cosmos/test
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "cosmos tests: ✓"

--- a/3p/lua/BUILD.mk.patch
+++ b/3p/lua/BUILD.mk.patch
@@ -1,0 +1,227 @@
+--- a/third_party/lua/BUILD.mk	2025-12-19 01:30:00.014204266 +0000
++++ b/third_party/lua/BUILD.mk	2025-12-19 01:40:24.430218012 +0000
+@@ -14,6 +14,10 @@
+ THIRD_PARTY_LUA_CHECKS =					\
+ 	$(THIRD_PARTY_LUA_A).pkg				\
+ 	$(THIRD_PARTY_LUA_UNIX).pkg				\
++	THIRD_PARTY_LUA_PATH					\
++	THIRD_PARTY_LUA_RE					\
++	THIRD_PARTY_LUA_SQLITE3					\
++	THIRD_PARTY_LUA_ARGON2					\
+ 	$(THIRD_PARTY_LUA_HDRS:%=o/$(MODE)/%.ok)		\
+ 	o/$(MODE)/third_party/lua/lua.pkg			\
+ 	o/$(MODE)/third_party/lua/luac.pkg
+@@ -224,6 +228,174 @@
+ 		$(foreach x,$(THIRD_PARTY_LUA_UNIX_DIRECTDEPS),$($(x)_A).pkg)
+ 
+ ################################################################################
++# lpath.a
++
++THIRD_PARTY_LUA_PATH =						\
++	$(THIRD_PARTY_LUA_A_DEPS)				\
++	$(THIRD_PARTY_LUA_A)
++
++THIRD_PARTY_LUA_ARTIFACTS +=					\
++	THIRD_PARTY_LUA_PATH
++
++THIRD_PARTY_LUA_PATH_A =					\
++	o/$(MODE)/third_party/lua/lpath.a
++
++THIRD_PARTY_LUA_PATH_HDRS =					\
++	third_party/lua/lpath.h
++
++THIRD_PARTY_LUA_PATH_SRCS =					\
++	third_party/lua/lpath.c
++
++THIRD_PARTY_LUA_PATH_OBJS =					\
++	$(THIRD_PARTY_LUA_PATH_SRCS:%.c=o/$(MODE)/%.o)
++
++THIRD_PARTY_LUA_PATH_DIRECTDEPS =				\
++	LIBC_CALLS						\
++	LIBC_INTRIN						\
++	LIBC_STR						\
++	LIBC_SYSV						\
++	THIRD_PARTY_LUA
++
++THIRD_PARTY_LUA_PATH_DEPS :=					\
++	$(call uniq,$(foreach x,$(THIRD_PARTY_LUA_PATH_DIRECTDEPS),$($(x))))
++
++$(THIRD_PARTY_LUA_A):						\
++		third_party/lua/				\
++		$(THIRD_PARTY_LUA_PATH_A).pkg			\
++		$(THIRD_PARTY_LUA_PATH_OBJS)
++
++$(THIRD_PARTY_LUA_PATH_A).pkg:					\
++		$(THIRD_PARTY_LUA_PATH_OBJS)			\
++		$(foreach x,$(THIRD_PARTY_LUA_PATH_DIRECTDEPS),$($(x)_A).pkg)
++
++################################################################################
++# lre.a
++
++THIRD_PARTY_LUA_RE =						\
++	$(THIRD_PARTY_LUA_A_DEPS)				\
++	$(THIRD_PARTY_LUA_A)
++
++THIRD_PARTY_LUA_ARTIFACTS +=					\
++	THIRD_PARTY_LUA_RE
++
++THIRD_PARTY_LUA_RE_A =						\
++	o/$(MODE)/third_party/lua/lre.a
++
++THIRD_PARTY_LUA_RE_HDRS =					\
++	third_party/lua/lre.h
++
++THIRD_PARTY_LUA_RE_SRCS =					\
++	third_party/lua/lre.c
++
++THIRD_PARTY_LUA_RE_OBJS =					\
++	$(THIRD_PARTY_LUA_RE_SRCS:%.c=o/$(MODE)/%.o)
++
++THIRD_PARTY_LUA_RE_DIRECTDEPS =					\
++	LIBC_CALLS						\
++	LIBC_INTRIN						\
++	LIBC_STR						\
++	LIBC_SYSV						\
++	THIRD_PARTY_LUA						\
++	THIRD_PARTY_REGEX
++
++THIRD_PARTY_LUA_RE_DEPS :=					\
++	$(call uniq,$(foreach x,$(THIRD_PARTY_LUA_RE_DIRECTDEPS),$($(x))))
++
++$(THIRD_PARTY_LUA_A):						\
++		third_party/lua/				\
++		$(THIRD_PARTY_LUA_RE_A).pkg			\
++		$(THIRD_PARTY_LUA_RE_OBJS)
++
++$(THIRD_PARTY_LUA_RE_A).pkg:					\
++		$(THIRD_PARTY_LUA_RE_OBJS)			\
++		$(foreach x,$(THIRD_PARTY_LUA_RE_DIRECTDEPS),$($(x)_A).pkg)
++
++################################################################################
++# lsqlite3.a
++
++THIRD_PARTY_LUA_SQLITE3 =					\
++	$(THIRD_PARTY_LUA_A_DEPS)				\
++	$(THIRD_PARTY_LUA_A)
++
++THIRD_PARTY_LUA_ARTIFACTS +=					\
++	THIRD_PARTY_LUA_SQLITE3
++
++THIRD_PARTY_LUA_SQLITE3_A =					\
++	o/$(MODE)/third_party/lua/lsqlite3.a
++
++THIRD_PARTY_LUA_SQLITE3_HDRS =					\
++	third_party/lua/lsqlite3.h
++
++THIRD_PARTY_LUA_SQLITE3_SRCS =					\
++	third_party/lua/lsqlite3.c
++
++THIRD_PARTY_LUA_SQLITE3_OBJS =					\
++	$(THIRD_PARTY_LUA_SQLITE3_SRCS:%.c=o/$(MODE)/%.o)
++
++THIRD_PARTY_LUA_SQLITE3_DIRECTDEPS =				\
++	LIBC_CALLS						\
++	LIBC_INTRIN						\
++	LIBC_MEM						\
++	LIBC_STDIO						\
++	LIBC_STR						\
++	LIBC_SYSV						\
++	THIRD_PARTY_LUA
++
++THIRD_PARTY_LUA_SQLITE3_DEPS :=					\
++	$(call uniq,$(foreach x,$(THIRD_PARTY_LUA_SQLITE3_DIRECTDEPS),$($(x))))
++
++$(THIRD_PARTY_LUA_SQLITE3_A):					\
++		third_party/lua/				\
++		$(THIRD_PARTY_LUA_SQLITE3_A).pkg		\
++		$(THIRD_PARTY_LUA_SQLITE3_OBJS)
++
++$(THIRD_PARTY_LUA_SQLITE3_A).pkg:				\
++		$(THIRD_PARTY_LUA_SQLITE3_OBJS)			\
++		$(foreach x,$(THIRD_PARTY_LUA_SQLITE3_DIRECTDEPS),$($(x)_A).pkg) \
++		o/$(MODE)/third_party/sqlite3/libsqlite3.a.pkg
++
++################################################################################
++# largon2.a
++
++THIRD_PARTY_LUA_ARGON2 =					\
++	$(THIRD_PARTY_LUA_A_DEPS)				\
++	$(THIRD_PARTY_LUA_A)
++
++THIRD_PARTY_LUA_ARTIFACTS +=					\
++	THIRD_PARTY_LUA_ARGON2
++
++THIRD_PARTY_LUA_ARGON2_A =					\
++	o/$(MODE)/third_party/lua/largon2.a
++
++THIRD_PARTY_LUA_ARGON2_HDRS =					\
++	third_party/lua/largon2.h
++
++THIRD_PARTY_LUA_ARGON2_SRCS =					\
++	third_party/lua/largon2.c
++
++THIRD_PARTY_LUA_ARGON2_OBJS =					\
++	$(THIRD_PARTY_LUA_ARGON2_SRCS:%.c=o/$(MODE)/%.o)
++
++THIRD_PARTY_LUA_ARGON2_DIRECTDEPS =				\
++	LIBC_INTRIN						\
++	LIBC_STDIO						\
++	LIBC_STR						\
++	THIRD_PARTY_LUA
++
++THIRD_PARTY_LUA_ARGON2_DEPS :=					\
++	$(call uniq,$(foreach x,$(THIRD_PARTY_LUA_ARGON2_DIRECTDEPS),$($(x))))
++
++$(THIRD_PARTY_LUA_ARGON2_A):					\
++		third_party/lua/				\
++		$(THIRD_PARTY_LUA_ARGON2_A).pkg			\
++		$(THIRD_PARTY_LUA_ARGON2_OBJS)
++
++$(THIRD_PARTY_LUA_ARGON2_A).pkg:				\
++		$(THIRD_PARTY_LUA_ARGON2_OBJS)			\
++		$(foreach x,$(THIRD_PARTY_LUA_ARGON2_DIRECTDEPS),$($(x)_A).pkg) \
++		o/$(MODE)/third_party/argon2/argon2.a.pkg
++
++################################################################################
+ # lua
+ 
+ THIRD_PARTY_LUA_LUA_DIRECTDEPS =				\
+@@ -239,23 +411,35 @@
+ 	LIBC_THREAD						\
+ 	THIRD_PARTY_LINENOISE					\
+ 	THIRD_PARTY_LUA						\
++	THIRD_PARTY_LUA_PATH					\
++	THIRD_PARTY_LUA_RE					\
++	THIRD_PARTY_LUA_SQLITE3					\
++	THIRD_PARTY_LUA_ARGON2					\
+ 	THIRD_PARTY_LUA_UNIX					\
+ 	TOOL_ARGS
+ 
+ THIRD_PARTY_LUA_LUA_DEPS :=					\
+ 	$(call uniq,$(foreach x,$(THIRD_PARTY_LUA_LUA_DIRECTDEPS),$($(x))))
+ 
++THIRD_PARTY_LUA_LUA_SQLITE3_DEPS :=				\
++	o/$(MODE)/third_party/sqlite3/libsqlite3.a
++
+ o/$(MODE)/third_party/lua/lua.pkg:				\
+ 		o/$(MODE)/third_party/lua/lua.main.o		\
+-		$(foreach x,$(THIRD_PARTY_LUA_LUA_DIRECTDEPS),$($(x)_A).pkg)
++		$(foreach x,$(THIRD_PARTY_LUA_LUA_DIRECTDEPS),$($(x)_A).pkg) \
++		o/$(MODE)/third_party/sqlite3/libsqlite3.a.pkg
+ 
+ o/$(MODE)/third_party/lua/lua.dbg:				\
+ 		$(THIRD_PARTY_LUA_LUA_DEPS)			\
+ 		o/$(MODE)/third_party/lua/lua.pkg		\
+ 		o/$(MODE)/third_party/lua/lua.main.o		\
++		o/$(MODE)/third_party/lua/lsqlite3.o		\
++		o/$(MODE)/third_party/lua/largon2.o		\
+ 		$(CRT)						\
+-		$(APE_NO_MODIFY_SELF)
+-	@$(APELINK)
++		$(APE_NO_MODIFY_SELF)				\
++		$(THIRD_PARTY_LUA_LUA_SQLITE3_DEPS)		\
++		o/$(MODE)/third_party/argon2/argon2.a
++	@$(COMPILE) -ALINK.ape $(LINK) $(patsubst %.lds,-T %.lds,--start-group $(call uniqr,$(LD.libs) $(filter-out %.pkg,$^)) --end-group) $(OUTPUT_OPTION) && $(COMPILE) -AFIXUP.ape -wT$@ $(FIXUPOBJ) $@
+ 
+ ################################################################################
+ # luac

--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -3,7 +3,7 @@
 
 # directories (hardcode version to avoid variable expansion timing issues)
 lua_cosmo_dir := $(3p)/cosmopolitan/cosmopolitan-4.0.2
-lua_build_dir := o/lua
+lua_build_dir := $(o)/lua
 lua_patch_dir := 3p/lua
 
 # compiler flags (uses $(zip) and $(cosmocc_bin) from 3p/cook.mk)

--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -1,0 +1,175 @@
+# lua fat binary build using cosmocc
+# sources from cosmopolitan repo, compiled with cosmocc toolchain
+
+# directories (hardcode version to avoid variable expansion timing issues)
+lua_cosmo_dir := $(3p)/cosmopolitan/cosmopolitan-4.0.2
+lua_build_dir := o/lua
+lua_patch_dir := 3p/lua
+
+# compiler flags (uses $(zip) and $(cosmocc_bin) from 3p/cook.mk)
+lua_cflags := -mcosmo -include stdbool.h -I$(lua_cosmo_dir)
+
+# patching marker
+lua_patched := $(lua_build_dir)/.patched
+
+# sqlite3 flags
+lua_sqlite_flags := \
+	-DNDEBUG \
+	-DSQLITE_CORE \
+	-DSQLITE_OS_UNIX \
+	-DBUILD_sqlite \
+	-DHAVE_USLEEP \
+	-DHAVE_READLINK \
+	-DHAVE_FCHOWN \
+	-DHAVE_LSTAT \
+	-DHAVE_GMTIME_R \
+	-DHAVE_FDATASYNC \
+	-DHAVE_STRCHRNUL \
+	-DHAVE_LOCALTIME_R \
+	-DHAVE_MALLOC_USABLE_SIZE \
+	-DSQLITE_THREADSAFE=1 \
+	-DSQLITE_MAX_EXPR_DEPTH=0 \
+	-DSQLITE_DEFAULT_MEMSTATUS=0 \
+	-DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1 \
+	-DSQLITE_LIKE_DOESNT_MATCH_BLOBS \
+	-DSQLITE_OMIT_UTF16 \
+	-DSQLITE_OMIT_TCL_VARIABLE \
+	-DSQLITE_OMIT_LOAD_EXTENSION \
+	-DSQLITE_OMIT_AUTOINIT \
+	-DSQLITE_OMIT_GET_TABLE \
+	-DSQLITE_OMIT_COMPILEOPTION_DIAGS \
+	-DSQLITE_HAVE_C99_MATH_FUNCS \
+	-DSQLITE_ENABLE_MATH_FUNCTIONS \
+	-DSQLITE_ENABLE_JSON1 \
+	-DSQLITE_ENABLE_DESERIALIZE \
+	-DSQLITE_ENABLE_PREUPDATE_HOOK \
+	-DSQLITE_ENABLE_SESSION
+
+# lua core sources
+lua_core_srcs := \
+	lapi.c lauxlib.c lbaselib.c lcode.c lcorolib.c ldblib.c ldebug.c \
+	ldo.c ldump.c lfunc.c lgc.c linit.c liolib.c llex.c llock.c \
+	lmathlib.c lmem.c lnotice.c loadlib.c lobject.c lopcodes.c loslib.c \
+	lparser.c lrepl.c lstate.c lstring.c lstrlib.c ltable.c ltablib.c \
+	ltests.c ltm.c luacallwithtrace.c luaencodejsondata.c luaencodeluadata.c \
+	luaencodeurl.c luaformatstack.c luaparseurl.c luaprintstack.c \
+	luapushheader.c luapushheaders.c luapushlatin1.c luapushurlparams.c \
+	lundump.c lutf8lib.c lvm.c lzio.c serialize.c visitor.c
+
+# lua extension sources - some in third_party/lua, some in tool/net
+lua_ext_lua_srcs := lunix.c lua.main.c
+lua_ext_net_srcs := lpath.c lre.c lsqlite3.c largon2.c lfuncs.c
+
+# cosmo module (lfuncs_register.c registers lfuncs as cosmo module)
+lua_cosmo_srcs := lfuncs_register.c
+
+# linenoise source
+lua_linenoise_srcs := linenoise.c
+
+# argon2 sources
+lua_argon2_srcs := argon2.c blake2b.c core.c encoding.c ref.c
+
+# regex sources
+lua_regex_srcs := regcomp.c regerror.c regexec.c tre-mem.c
+
+# sqlite3 sources
+lua_sqlite3_srcs := \
+	alter.c analyze.c appendvfs.c attach.c auth.c backup.c bitvec.c btmutex.c \
+	btree.c build.c callback.c complete.c completion.c ctime.c date.c dbdata.c \
+	dbpage.c dbstat.c decimal.c delete.c expr.c fault.c fileio.c fkey.c fts3.c \
+	fts3_aux.c fts3_expr.c fts3_hash.c fts3_icu.c fts3_porter.c fts3_snippet.c \
+	fts3_tokenize_vtab.c fts3_tokenizer.c fts3_tokenizer1.c fts3_unicode.c \
+	fts3_unicode2.c fts3_write.c fts5.c func.c global.c hash.c icu.c ieee754.c \
+	insert.c json.c legacy.c loadext.c main.c malloc.c mem0.c mem1.c mem2.c \
+	mem3.c mem5.c memdb.c memjournal.c memtrace.c mutex.c mutex_noop.c \
+	mutex_unix.c notify.c opcodes.c os.c os_kv.c os_unix.c pager.c parse.c \
+	pcache.c pcache1.c pragma.c prepare.c printf.c random.c resolve.c rowset.c \
+	rtree.c select.c series.c shathree.c sqlar.c sqlite3expert.c sqlite3rbu.c \
+	sqlite3session.c status.c stmt.c table.c threads.c tokenize.c treeview.c \
+	trigger.c uint.c update.c upsert.c userauth.c utf.c util.c vacuum.c vdbe.c \
+	vdbeapi.c vdbeaux.c vdbeblob.c vdbemem.c vdbesort.c vdbetrace.c vdbevtab.c \
+	vtab.c wal.c walker.c where.c wherecode.c whereexpr.c window.c zipfile.c
+
+# object files
+lua_core_objs := $(addprefix $(lua_build_dir)/lua/,$(lua_core_srcs:.c=.o))
+lua_ext_lua_objs := $(addprefix $(lua_build_dir)/lua/,$(lua_ext_lua_srcs:.c=.o))
+lua_ext_net_objs := $(addprefix $(lua_build_dir)/net/,$(lua_ext_net_srcs:.c=.o))
+lua_linenoise_objs := $(addprefix $(lua_build_dir)/linenoise/,$(lua_linenoise_srcs:.c=.o))
+lua_argon2_objs := $(addprefix $(lua_build_dir)/argon2/,$(lua_argon2_srcs:.c=.o))
+lua_regex_objs := $(addprefix $(lua_build_dir)/regex/,$(lua_regex_srcs:.c=.o))
+lua_sqlite3_objs := $(addprefix $(lua_build_dir)/sqlite3/,$(lua_sqlite3_srcs:.c=.o))
+lua_cosmo_objs := $(addprefix $(lua_build_dir)/cosmo/,$(lua_cosmo_srcs:.c=.o))
+
+lua_all_objs := $(lua_core_objs) $(lua_ext_lua_objs) $(lua_ext_net_objs) $(lua_linenoise_objs) $(lua_argon2_objs) $(lua_regex_objs) $(lua_sqlite3_objs) $(lua_cosmo_objs)
+
+# output
+lua_bin := results/bin/lua
+
+# target for lua fat binary - use recursive make to ensure sources exist before compiling
+lua:
+	$(MAKE) $(cosmopolitan_src) $(cosmocc_bin) $(cosmos_bin) $(luaunit_lua_dir)/luaunit.lua
+	$(MAKE) $(lua_patched)
+	$(MAKE) $(lua_bin)
+
+# patch lua.main.c, lfuncs.c, and copy headers to register redbean modules
+$(lua_patched): $(cosmopolitan_src) | $(lua_build_dir)
+	cp $(lua_patch_dir)/lpath.h $(lua_cosmo_dir)/third_party/lua/
+	cp $(lua_patch_dir)/lre.h $(lua_cosmo_dir)/third_party/lua/
+	cp $(lua_patch_dir)/lsqlite3.h $(lua_cosmo_dir)/third_party/lua/
+	cp $(lua_patch_dir)/largon2.h $(lua_cosmo_dir)/third_party/lua/
+	cp $(lua_patch_dir)/lcosmo.h $(lua_cosmo_dir)/third_party/lua/
+	cp $(lua_patch_dir)/lfuncs_register.c $(lua_cosmo_dir)/third_party/lua/
+	cd $(lua_cosmo_dir) && patch -p1 < $(CURDIR)/$(lua_patch_dir)/lua.main.c.patch
+	cd $(lua_cosmo_dir) && patch -p1 < $(CURDIR)/$(lua_patch_dir)/lfuncs.c.patch
+	touch $@
+
+# cosmos zip is needed for APE binaries (system zip doesn't work with APE format)
+cosmos_zip_bin := $(cosmos_dir)/bin/zip
+
+$(lua_bin): $(lua_all_objs) | results/bin
+	$(cosmocc_bin) -mcosmo $(lua_all_objs) -o $@
+	cd $(luaunit_lua_dir)/.. && $(cosmos_zip_bin) -qr $(CURDIR)/$@ $(notdir $(luaunit_lua_dir))
+
+# lua core objects (from third_party/lua)
+$(lua_build_dir)/lua/%.o: $(lua_cosmo_dir)/third_party/lua/%.c | $(lua_build_dir)/lua
+	$(cosmocc_bin) $(lua_cflags) -c $< -o $@
+
+# lua extension objects from tool/net (generic rule)
+$(lua_build_dir)/net/%.o: $(lua_cosmo_dir)/tool/net/%.c | $(lua_build_dir)/net
+	$(cosmocc_bin) $(lua_cflags) -c $< -o $@
+
+# lfuncs.c needs LFUNCS_LITE to exclude functions with heavy dependencies
+$(lua_build_dir)/net/lfuncs.o: $(lua_cosmo_dir)/tool/net/lfuncs.c | $(lua_build_dir)/net
+	$(cosmocc_bin) $(lua_cflags) -DLFUNCS_LITE -c $< -o $@
+
+# linenoise objects
+$(lua_build_dir)/linenoise/%.o: $(lua_cosmo_dir)/third_party/linenoise/%.c | $(lua_build_dir)/linenoise
+	$(cosmocc_bin) $(lua_cflags) -c $< -o $@
+
+# argon2 objects
+$(lua_build_dir)/argon2/%.o: $(lua_cosmo_dir)/third_party/argon2/%.c | $(lua_build_dir)/argon2
+	$(cosmocc_bin) $(lua_cflags) -c $< -o $@
+
+# regex objects
+$(lua_build_dir)/regex/%.o: $(lua_cosmo_dir)/third_party/regex/%.c | $(lua_build_dir)/regex
+	$(cosmocc_bin) $(lua_cflags) -c $< -o $@
+
+# sqlite3 objects
+$(lua_build_dir)/sqlite3/%.o: $(lua_cosmo_dir)/third_party/sqlite3/%.c | $(lua_build_dir)/sqlite3
+	$(cosmocc_bin) $(lua_cflags) $(lua_sqlite_flags) -c $< -o $@
+
+# cosmo module objects (lfuncs_register.c is copied to third_party/lua)
+$(lua_build_dir)/cosmo/%.o: $(lua_cosmo_dir)/third_party/lua/%.c | $(lua_build_dir)/cosmo
+	$(cosmocc_bin) $(lua_cflags) -c $< -o $@
+
+# directory creation
+$(lua_build_dir) $(lua_build_dir)/lua $(lua_build_dir)/net $(lua_build_dir)/linenoise $(lua_build_dir)/argon2 $(lua_build_dir)/regex $(lua_build_dir)/sqlite3 $(lua_build_dir)/cosmo:
+	mkdir -p $@
+
+results/bin:
+	mkdir -p $@
+
+.PHONY: lua clean-lua
+
+clean-lua:
+	rm -rf $(lua_build_dir) $(lua_bin)

--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -108,6 +108,8 @@ lua_bin := results/bin/lua
 # target for lua fat binary
 lua: $(lua_bin)
 
+.NOTPARALLEL: $(lua_bin)
+
 # patch lua.main.c, lfuncs.c, and copy headers to register redbean modules
 $(lua_patched): $(cosmopolitan_src) | $(lua_build_dir)
 	cp $(lua_patch_dir)/lpath.h $(lua_cosmo_dir)/third_party/lua/
@@ -133,36 +135,36 @@ $(lua_bin): $(lua_all_objs) $(cosmos_zip_bin) $(luaunit_lua_dir)/luaunit.lua | r
 $(lua_all_objs): | $(lua_patched) $(cosmocc_bin)
 
 # lua core objects (from third_party/lua)
-$(lua_build_dir)/lua/%.o: $(lua_cosmo_dir)/third_party/lua/%.c | $(lua_build_dir)/lua
-	$(cosmocc_bin) $(lua_cflags) -c $< -o $@
+$(lua_build_dir)/lua/%.o: $(lua_build_dir)/lua
+	$(cosmocc_bin) $(lua_cflags) -c $(lua_cosmo_dir)/third_party/lua/$*.c -o $@
 
 # lua extension objects from tool/net (generic rule)
-$(lua_build_dir)/net/%.o: $(lua_cosmo_dir)/tool/net/%.c | $(lua_build_dir)/net
-	$(cosmocc_bin) $(lua_cflags) -c $< -o $@
+$(lua_build_dir)/net/%.o: $(lua_build_dir)/net
+	$(cosmocc_bin) $(lua_cflags) -c $(lua_cosmo_dir)/tool/net/$*.c -o $@
 
 # lfuncs.c needs LFUNCS_LITE to exclude functions with heavy dependencies
-$(lua_build_dir)/net/lfuncs.o: $(lua_cosmo_dir)/tool/net/lfuncs.c | $(lua_build_dir)/net
-	$(cosmocc_bin) $(lua_cflags) -DLFUNCS_LITE -c $< -o $@
+$(lua_build_dir)/net/lfuncs.o: $(lua_build_dir)/net
+	$(cosmocc_bin) $(lua_cflags) -DLFUNCS_LITE -c $(lua_cosmo_dir)/tool/net/lfuncs.c -o $@
 
 # linenoise objects
-$(lua_build_dir)/linenoise/%.o: $(lua_cosmo_dir)/third_party/linenoise/%.c | $(lua_build_dir)/linenoise
-	$(cosmocc_bin) $(lua_cflags) -c $< -o $@
+$(lua_build_dir)/linenoise/%.o: $(lua_build_dir)/linenoise
+	$(cosmocc_bin) $(lua_cflags) -c $(lua_cosmo_dir)/third_party/linenoise/$*.c -o $@
 
 # argon2 objects
-$(lua_build_dir)/argon2/%.o: $(lua_cosmo_dir)/third_party/argon2/%.c | $(lua_build_dir)/argon2
-	$(cosmocc_bin) $(lua_cflags) -c $< -o $@
+$(lua_build_dir)/argon2/%.o: $(lua_build_dir)/argon2
+	$(cosmocc_bin) $(lua_cflags) -c $(lua_cosmo_dir)/third_party/argon2/$*.c -o $@
 
 # regex objects
-$(lua_build_dir)/regex/%.o: $(lua_cosmo_dir)/third_party/regex/%.c | $(lua_build_dir)/regex
-	$(cosmocc_bin) $(lua_cflags) -c $< -o $@
+$(lua_build_dir)/regex/%.o: $(lua_build_dir)/regex
+	$(cosmocc_bin) $(lua_cflags) -c $(lua_cosmo_dir)/third_party/regex/$*.c -o $@
 
 # sqlite3 objects
-$(lua_build_dir)/sqlite3/%.o: $(lua_cosmo_dir)/third_party/sqlite3/%.c | $(lua_build_dir)/sqlite3
-	$(cosmocc_bin) $(lua_cflags) $(lua_sqlite_flags) -c $< -o $@
+$(lua_build_dir)/sqlite3/%.o: $(lua_build_dir)/sqlite3
+	$(cosmocc_bin) $(lua_cflags) $(lua_sqlite_flags) -c $(lua_cosmo_dir)/third_party/sqlite3/$*.c -o $@
 
 # cosmo module objects (lfuncs_register.c is copied to third_party/lua)
-$(lua_build_dir)/cosmo/%.o: $(lua_cosmo_dir)/third_party/lua/%.c | $(lua_build_dir)/cosmo
-	$(cosmocc_bin) $(lua_cflags) -c $< -o $@
+$(lua_build_dir)/cosmo/%.o: $(lua_build_dir)/cosmo
+	$(cosmocc_bin) $(lua_cflags) -c $(lua_cosmo_dir)/third_party/lua/$*.c -o $@
 
 # directory creation
 $(lua_build_dir) $(lua_build_dir)/lua $(lua_build_dir)/net $(lua_build_dir)/linenoise $(lua_build_dir)/argon2 $(lua_build_dir)/regex $(lua_build_dir)/sqlite3 $(lua_build_dir)/cosmo:

--- a/3p/lua/largon2.h
+++ b/3p/lua/largon2.h
@@ -1,0 +1,9 @@
+#ifndef COSMOPOLITAN_TOOL_NET_LARGON2_H_
+#define COSMOPOLITAN_TOOL_NET_LARGON2_H_
+#include "third_party/lua/lauxlib.h"
+COSMOPOLITAN_C_START_
+
+int luaopen_argon2(lua_State *);
+
+COSMOPOLITAN_C_END_
+#endif /* COSMOPOLITAN_TOOL_NET_LARGON2_H_ */

--- a/3p/lua/lcosmo.h
+++ b/3p/lua/lcosmo.h
@@ -1,0 +1,9 @@
+#ifndef COSMOPOLITAN_THIRD_PARTY_LUA_LCOSMO_H_
+#define COSMOPOLITAN_THIRD_PARTY_LUA_LCOSMO_H_
+#include "third_party/lua/lauxlib.h"
+COSMOPOLITAN_C_START_
+
+int luaopen_cosmo(lua_State *);
+
+COSMOPOLITAN_C_END_
+#endif /* COSMOPOLITAN_THIRD_PARTY_LUA_LCOSMO_H_ */

--- a/3p/lua/lfuncs.c.patch
+++ b/3p/lua/lfuncs.c.patch
@@ -1,0 +1,103 @@
+--- a/tool/net/lfuncs.c	2025-12-19 06:53:08.344516299 +0000
++++ b/tool/net/lfuncs.c	2025-12-19 06:55:49.743510054 +0000
+@@ -17,7 +17,9 @@
+ │ PERFORMANCE OF THIS SOFTWARE.                                                │
+ ╚─────────────────────────────────────────────────────────────────────────────*/
+ #include "tool/net/lfuncs.h"
++#ifndef LFUNCS_LITE
+ #include "dsp/scale/cdecimate2xuint8x8.h"
++#endif
+ #include "libc/calls/calls.h"
+ #include "libc/calls/struct/rusage.h"
+ #include "libc/calls/struct/stat.h"
+@@ -63,6 +65,7 @@
+ #include "third_party/lua/lua.h"
+ #include "third_party/lua/luaconf.h"
+ #include "third_party/lua/lunix.h"
++#ifndef LFUNCS_LITE
+ #include "third_party/mbedtls/everest.h"
+ #include "third_party/mbedtls/md.h"
+ #include "third_party/mbedtls/md5.h"
+@@ -70,6 +73,7 @@
+ #include "third_party/mbedtls/sha1.h"
+ #include "third_party/mbedtls/sha256.h"
+ #include "third_party/mbedtls/sha512.h"
++#endif
+ #include "third_party/musl/netdb.h"
+ #include "third_party/zlib/zlib.h"
+ 
+@@ -170,6 +174,7 @@
+   return LuaRand(L, rdseed);
+ }
+ 
++#ifndef LFUNCS_LITE
+ int LuaDecimate(lua_State *L) {
+   char *p;
+   size_t n, m;
+@@ -185,6 +190,7 @@
+   luaL_pushresultsize(&buf, (n + 1) >> 1);
+   return 1;
+ }
++#endif
+ 
+ int LuaMeasureEntropy(lua_State *L) {
+   size_t n;
+@@ -275,11 +281,13 @@
+   return 1;
+ }
+ 
++#ifndef LFUNCS_LITE
+ int LuaFormatHttpDateTime(lua_State *L) {
+   char buf[30];
+   lua_pushstring(L, FormatUnixHttpDateTime(buf, luaL_checkinteger(L, 1)));
+   return 1;
+ }
++#endif
+ 
+ int LuaParseHttpDateTime(lua_State *L) {
+   size_t n;
+@@ -687,6 +695,7 @@
+   return 1;
+ }
+ 
++#ifndef LFUNCS_LITE
+ int LuaGetCryptoHash(lua_State *L) {
+   size_t hl, pl, kl;
+   uint8_t d[64];
+@@ -708,6 +717,7 @@
+   mbedtls_platform_zeroize(d, sizeof(d));
+   return 1;
+ }
++#endif
+ 
+ static dontinline int LuaIsValid(lua_State *L, bool V(const char *, size_t)) {
+   size_t size;
+@@ -926,6 +936,7 @@
+   return 1;
+ }
+ 
++#ifndef LFUNCS_LITE
+ static dontinline int LuaHasherImpl(lua_State *L, size_t k,
+                                     int H(const void *, size_t, uint8_t *)) {
+   size_t n;
+@@ -970,6 +981,7 @@
+ int LuaSha512(lua_State *L) {
+   return LuaHasher(L, 64, mbedtls_sha512_ret_512);
+ }
++#endif
+ 
+ int LuaIsHeaderRepeatable(lua_State *L) {
+   int h;
+@@ -1235,6 +1247,7 @@
+   return 1;
+ }
+ 
++#ifndef LFUNCS_LITE
+ static void GetCurve25519Arg(lua_State *L, int arg, uint8_t buf[static 32]) {
+   size_t len;
+   const char *val;
+@@ -1269,3 +1282,4 @@
+   lua_pushlstring(L, (const char *)mypublic, 32);
+   return 1;
+ }
++#endif /* !LFUNCS_LITE */

--- a/3p/lua/lfuncs_register.c
+++ b/3p/lua/lfuncs_register.c
@@ -1,0 +1,106 @@
+/*
+ * cosmo module - registers utility functions and submodules
+ * Functions from tool/net/lfuncs.c exposed via "cosmo" module
+ * Submodules: cosmo.unix, cosmo.path, cosmo.re, cosmo.argon2, cosmo.sqlite3
+ *
+ * NOTE: Functions guarded by LFUNCS_LITE in lfuncs.c are excluded:
+ * - LuaDecimate (needs dsp/scale)
+ * - LuaFormatHttpDateTime (needs FormatUnixHttpDateTime)
+ * - LuaGetCryptoHash, LuaMd5, LuaSha1, LuaSha224, LuaSha256, LuaSha384, LuaSha512 (need mbedtls)
+ * - LuaCurve25519 (needs mbedtls/everest)
+ */
+#include "third_party/lua/lauxlib.h"
+#include "third_party/lua/lunix.h"
+#include "third_party/lua/lpath.h"
+#include "third_party/lua/lre.h"
+#include "third_party/lua/largon2.h"
+#include "third_party/lua/lsqlite3.h"
+#include "tool/net/lfuncs.h"
+
+static const luaL_Reg kCosmoFuncs[] = {
+    {"Bsf", LuaBsf},
+    {"Bsr", LuaBsr},
+    {"CategorizeIp", LuaCategorizeIp},
+    {"Compress", LuaCompress},
+    {"Crc32", LuaCrc32},
+    {"Crc32c", LuaCrc32c},
+    {"DecodeBase32", LuaDecodeBase32},
+    {"DecodeBase64", LuaDecodeBase64},
+    {"DecodeHex", LuaDecodeHex},
+    {"DecodeLatin1", LuaDecodeLatin1},
+    {"Deflate", LuaDeflate},
+    {"EncodeBase32", LuaEncodeBase32},
+    {"EncodeBase64", LuaEncodeBase64},
+    {"EncodeHex", LuaEncodeHex},
+    {"EncodeLatin1", LuaEncodeLatin1},
+    {"EscapeFragment", LuaEscapeFragment},
+    {"EscapeHost", LuaEscapeHost},
+    {"EscapeHtml", LuaEscapeHtml},
+    {"EscapeIp", LuaEscapeIp},
+    {"EscapeLiteral", LuaEscapeLiteral},
+    {"EscapeParam", LuaEscapeParam},
+    {"EscapePass", LuaEscapePass},
+    {"EscapePath", LuaEscapePath},
+    {"EscapeSegment", LuaEscapeSegment},
+    {"EscapeUser", LuaEscapeUser},
+    {"FormatIp", LuaFormatIp},
+    {"GetCpuCore", LuaGetCpuCore},
+    {"GetCpuCount", LuaGetCpuCount},
+    {"GetCpuNode", LuaGetCpuNode},
+    {"GetHostIsa", LuaGetHostIsa},
+    {"GetHostOs", LuaGetHostOs},
+    {"GetHttpReason", LuaGetHttpReason},
+    {"GetMonospaceWidth", LuaGetMonospaceWidth},
+    {"GetRandomBytes", LuaGetRandomBytes},
+    {"GetTime", LuaGetTime},
+    {"HasControlCodes", LuaHasControlCodes},
+    {"HighwayHash64", LuaHighwayHash64},
+    {"IndentLines", LuaIndentLines},
+    {"Inflate", LuaInflate},
+    {"IsAcceptableHost", LuaIsAcceptableHost},
+    {"IsAcceptablePath", LuaIsAcceptablePath},
+    {"IsAcceptablePort", LuaIsAcceptablePort},
+    {"IsHeaderRepeatable", LuaIsHeaderRepeatable},
+    {"IsLoopbackIp", LuaIsLoopbackIp},
+    {"IsPrivateIp", LuaIsPrivateIp},
+    {"IsPublicIp", LuaIsPublicIp},
+    {"IsReasonablePath", LuaIsReasonablePath},
+    {"IsValidHttpToken", LuaIsValidHttpToken},
+    {"Lemur64", LuaLemur64},
+    {"MeasureEntropy", LuaMeasureEntropy},
+    {"ParseHost", LuaParseHost},
+    {"ParseHttpDateTime", LuaParseHttpDateTime},
+    {"ParseIp", LuaParseIp},
+    {"ParseParams", LuaParseParams},
+    {"Popcnt", LuaPopcnt},
+    {"Sleep", LuaSleep},
+    {"Uncompress", LuaUncompress},
+    {"VisualizeControlCodes", LuaVisualizeControlCodes},
+    {NULL, NULL}
+};
+
+int luaopen_cosmo(lua_State *L) {
+    luaL_newlib(L, kCosmoFuncs);
+
+    /* add unix submodule */
+    LuaUnix(L);
+    lua_setfield(L, -2, "unix");
+
+    /* add path submodule */
+    LuaPath(L);
+    lua_setfield(L, -2, "path");
+
+    /* add re submodule */
+    LuaRe(L);
+    lua_setfield(L, -2, "re");
+
+    /* add argon2 submodule */
+    luaopen_argon2(L);
+    lua_setfield(L, -2, "argon2");
+
+    /* add sqlite3 submodule */
+    luaopen_lsqlite3(L);
+    lua_setfield(L, -2, "sqlite3");
+
+    return 1;
+}

--- a/3p/lua/lpath.h
+++ b/3p/lua/lpath.h
@@ -1,0 +1,9 @@
+#ifndef COSMOPOLITAN_TOOL_NET_LPATH_H_
+#define COSMOPOLITAN_TOOL_NET_LPATH_H_
+#include "third_party/lua/lauxlib.h"
+COSMOPOLITAN_C_START_
+
+int LuaPath(lua_State *);
+
+COSMOPOLITAN_C_END_
+#endif /* COSMOPOLITAN_TOOL_NET_LPATH_H_ */

--- a/3p/lua/lre.h
+++ b/3p/lua/lre.h
@@ -1,0 +1,9 @@
+#ifndef COSMOPOLITAN_TOOL_NET_LRE_H_
+#define COSMOPOLITAN_TOOL_NET_LRE_H_
+#include "third_party/lua/lauxlib.h"
+COSMOPOLITAN_C_START_
+
+int LuaRe(lua_State *);
+
+COSMOPOLITAN_C_END_
+#endif /* COSMOPOLITAN_TOOL_NET_LRE_H_ */

--- a/3p/lua/lsqlite3.h
+++ b/3p/lua/lsqlite3.h
@@ -1,0 +1,9 @@
+#ifndef COSMOPOLITAN_TOOL_NET_LSQLITE3_H_
+#define COSMOPOLITAN_TOOL_NET_LSQLITE3_H_
+#include "third_party/lua/lauxlib.h"
+COSMOPOLITAN_C_START_
+
+int luaopen_lsqlite3(lua_State *);
+
+COSMOPOLITAN_C_END_
+#endif /* COSMOPOLITAN_TOOL_NET_LSQLITE3_H_ */

--- a/3p/lua/lua.main.c.patch
+++ b/3p/lua/lua.main.c.patch
@@ -1,0 +1,19 @@
+--- a/third_party/lua/lua.main.c
++++ b/third_party/lua/lua.main.c
+@@ -50,6 +50,7 @@
+ #include "third_party/lua/lrepl.h"
+ #include "third_party/lua/lualib.h"
+ #include "third_party/lua/lunix.h"
++#include "third_party/lua/lcosmo.h"
+ #include "libc/cosmo.h"
+ #include "libc/mem/leaks.h"
+ __static_yoink("lua_notice");
+@@ -376,8 +377,8 @@
+   luaL_openlibs(L);  /* open standard libraries */
+-  luaL_requiref(L, "unix", LuaUnix, 1);
+-  lua_pop(L, 1);
++  luaL_requiref(L, "cosmo", luaopen_cosmo, 0);
++  lua_pop(L, 1);  /* cosmo includes unix, path, re, argon2, sqlite3 as submodules */
+   createargtable(L, argv, argc, script);  /* create table 'arg' */
+   lua_gc(L, LUA_GCRESTART);  /* start GC... */
+   lua_gc(L, LUA_GCGEN, 0, 0);  /* ...in generational mode */

--- a/3p/lua/test.lua
+++ b/3p/lua/test.lua
@@ -1,0 +1,9 @@
+#!/usr/bin/env lua
+local script_dir = arg[0]:match("(.*/)")
+
+lu = require('luaunit')
+
+dofile(script_dir .. 'test_modules.lua')
+dofile(script_dir .. 'test_funcs.lua')
+
+os.exit(lu.LuaUnit.run())

--- a/3p/lua/test_funcs.lua
+++ b/3p/lua/test_funcs.lua
@@ -1,0 +1,328 @@
+-- test cosmo module functions
+-- functions excluded by LFUNCS_LITE or not in lfuncs.c use lu.skipIf
+
+local cosmo = require('cosmo')
+
+-- helper to check if function is missing
+local function missing(fn)
+    return cosmo[fn] == nil
+end
+
+function test_cosmo_module_exists()
+    lu.assertNotNil(cosmo, "cosmo module should be compiled into lua")
+end
+
+-- encoding functions
+function test_cosmo_EncodeBase64()
+    lu.assertNotNil(cosmo.EncodeBase64)
+    lu.assertEquals(cosmo.EncodeBase64("hello"), "aGVsbG8=")
+end
+
+function test_cosmo_DecodeBase64()
+    lu.assertNotNil(cosmo.DecodeBase64)
+    lu.assertEquals(cosmo.DecodeBase64("aGVsbG8="), "hello")
+end
+
+function test_cosmo_EncodeBase32()
+    lu.assertNotNil(cosmo.EncodeBase32)
+end
+
+function test_cosmo_DecodeBase32()
+    lu.assertNotNil(cosmo.DecodeBase32)
+end
+
+function test_cosmo_EncodeHex()
+    lu.assertNotNil(cosmo.EncodeHex)
+    lu.assertEquals(cosmo.EncodeHex("AB"), "4142")
+end
+
+function test_cosmo_DecodeHex()
+    lu.assertNotNil(cosmo.DecodeHex)
+    lu.assertEquals(cosmo.DecodeHex("4142"), "AB")
+end
+
+function test_cosmo_EncodeLatin1()
+    lu.assertNotNil(cosmo.EncodeLatin1)
+end
+
+function test_cosmo_DecodeLatin1()
+    lu.assertNotNil(cosmo.DecodeLatin1)
+end
+
+-- escape functions
+function test_cosmo_EscapeHtml()
+    lu.assertNotNil(cosmo.EscapeHtml)
+    lu.assertEquals(cosmo.EscapeHtml("<script>"), "&lt;script&gt;")
+end
+
+function test_cosmo_EscapePath()
+    lu.assertNotNil(cosmo.EscapePath)
+end
+
+function test_cosmo_EscapeSegment()
+    lu.assertNotNil(cosmo.EscapeSegment)
+end
+
+function test_cosmo_EscapeParam()
+    lu.assertNotNil(cosmo.EscapeParam)
+end
+
+function test_cosmo_EscapeLiteral()
+    lu.assertNotNil(cosmo.EscapeLiteral)
+end
+
+function test_cosmo_EscapeFragment()
+    lu.assertNotNil(cosmo.EscapeFragment)
+end
+
+function test_cosmo_EscapeUser()
+    lu.assertNotNil(cosmo.EscapeUser)
+end
+
+function test_cosmo_EscapePass()
+    lu.assertNotNil(cosmo.EscapePass)
+end
+
+function test_cosmo_EscapeHost()
+    lu.assertNotNil(cosmo.EscapeHost)
+end
+
+-- hash functions (LFUNCS_LITE: excluded - need mbedtls)
+function test_cosmo_Md5()
+    lu.skipIf(missing("Md5"), "excluded by LFUNCS_LITE")
+    lu.assertNotNil(cosmo.Md5)
+end
+
+function test_cosmo_Sha1()
+    lu.skipIf(missing("Sha1"), "excluded by LFUNCS_LITE")
+    lu.assertNotNil(cosmo.Sha1)
+end
+
+function test_cosmo_Sha224()
+    lu.skipIf(missing("Sha224"), "excluded by LFUNCS_LITE")
+    lu.assertNotNil(cosmo.Sha224)
+end
+
+function test_cosmo_Sha256()
+    lu.skipIf(missing("Sha256"), "excluded by LFUNCS_LITE")
+    lu.assertNotNil(cosmo.Sha256)
+end
+
+function test_cosmo_Sha384()
+    lu.skipIf(missing("Sha384"), "excluded by LFUNCS_LITE")
+    lu.assertNotNil(cosmo.Sha384)
+end
+
+function test_cosmo_Sha512()
+    lu.skipIf(missing("Sha512"), "excluded by LFUNCS_LITE")
+    lu.assertNotNil(cosmo.Sha512)
+end
+
+function test_cosmo_GetCryptoHash()
+    lu.skipIf(missing("GetCryptoHash"), "excluded by LFUNCS_LITE")
+    lu.assertNotNil(cosmo.GetCryptoHash)
+end
+
+function test_cosmo_Crc32()
+    lu.assertNotNil(cosmo.Crc32)
+end
+
+function test_cosmo_Crc32c()
+    lu.assertNotNil(cosmo.Crc32c)
+end
+
+-- compression functions
+function test_cosmo_Deflate()
+    lu.assertNotNil(cosmo.Deflate)
+end
+
+function test_cosmo_Inflate()
+    lu.assertNotNil(cosmo.Inflate)
+end
+
+function test_cosmo_Compress()
+    lu.assertNotNil(cosmo.Compress)
+end
+
+function test_cosmo_Uncompress()
+    lu.assertNotNil(cosmo.Uncompress)
+end
+
+-- IP functions
+function test_cosmo_ParseIp()
+    lu.assertNotNil(cosmo.ParseIp)
+end
+
+function test_cosmo_FormatIp()
+    lu.assertNotNil(cosmo.FormatIp)
+end
+
+function test_cosmo_ResolveIp()
+    lu.skipIf(missing("ResolveIp"), "not in lfuncs.c")
+    lu.assertNotNil(cosmo.ResolveIp)
+end
+
+function test_cosmo_CategorizeIp()
+    lu.assertNotNil(cosmo.CategorizeIp)
+end
+
+function test_cosmo_IsLoopbackIp()
+    lu.assertNotNil(cosmo.IsLoopbackIp)
+end
+
+function test_cosmo_IsPrivateIp()
+    lu.assertNotNil(cosmo.IsPrivateIp)
+end
+
+function test_cosmo_IsPublicIp()
+    lu.assertNotNil(cosmo.IsPublicIp)
+end
+
+-- crypto functions (LFUNCS_LITE: Curve25519 excluded - needs mbedtls/everest)
+function test_cosmo_Curve25519()
+    lu.skipIf(missing("Curve25519"), "excluded by LFUNCS_LITE")
+    lu.assertNotNil(cosmo.Curve25519)
+end
+
+function test_cosmo_GetRandomBytes()
+    lu.assertNotNil(cosmo.GetRandomBytes)
+    local bytes = cosmo.GetRandomBytes(16)
+    lu.assertEquals(#bytes, 16)
+end
+
+-- uuid functions (not in lfuncs.c)
+function test_cosmo_UuidV4()
+    lu.skipIf(missing("UuidV4"), "not in lfuncs.c")
+    lu.assertNotNil(cosmo.UuidV4)
+    local uuid = cosmo.UuidV4()
+    lu.assertEquals(#uuid, 36)
+end
+
+function test_cosmo_UuidV7()
+    lu.skipIf(missing("UuidV7"), "not in lfuncs.c")
+    lu.assertNotNil(cosmo.UuidV7)
+    local uuid = cosmo.UuidV7()
+    lu.assertEquals(#uuid, 36)
+end
+
+-- date/time functions (LFUNCS_LITE: FormatHttpDateTime excluded)
+function test_cosmo_FormatHttpDateTime()
+    lu.skipIf(missing("FormatHttpDateTime"), "excluded by LFUNCS_LITE")
+    lu.assertNotNil(cosmo.FormatHttpDateTime)
+end
+
+function test_cosmo_ParseHttpDateTime()
+    lu.assertNotNil(cosmo.ParseHttpDateTime)
+end
+
+function test_cosmo_GetTime()
+    lu.assertNotNil(cosmo.GetTime)
+end
+
+-- system info functions
+function test_cosmo_GetHostOs()
+    lu.assertNotNil(cosmo.GetHostOs)
+    local os = cosmo.GetHostOs()
+    lu.assertNotNil(os)
+end
+
+function test_cosmo_GetHostIsa()
+    lu.assertNotNil(cosmo.GetHostIsa)
+    local isa = cosmo.GetHostIsa()
+    lu.assertNotNil(isa)
+end
+
+function test_cosmo_GetCpuCount()
+    lu.assertNotNil(cosmo.GetCpuCount)
+    local count = cosmo.GetCpuCount()
+    lu.assertTrue(count >= 1)
+end
+
+function test_cosmo_GetCpuCore()
+    lu.assertNotNil(cosmo.GetCpuCore)
+end
+
+function test_cosmo_GetCpuNode()
+    lu.assertNotNil(cosmo.GetCpuNode)
+end
+
+-- misc functions
+function test_cosmo_MeasureEntropy()
+    lu.assertNotNil(cosmo.MeasureEntropy)
+end
+
+function test_cosmo_VisualizeControlCodes()
+    lu.assertNotNil(cosmo.VisualizeControlCodes)
+end
+
+function test_cosmo_HasControlCodes()
+    lu.assertNotNil(cosmo.HasControlCodes)
+end
+
+function test_cosmo_GetMonospaceWidth()
+    lu.assertNotNil(cosmo.GetMonospaceWidth)
+end
+
+function test_cosmo_IndentLines()
+    lu.assertNotNil(cosmo.IndentLines)
+end
+
+-- LFUNCS_LITE: Decimate excluded - needs dsp/scale
+function test_cosmo_Decimate()
+    lu.skipIf(missing("Decimate"), "excluded by LFUNCS_LITE")
+    lu.assertNotNil(cosmo.Decimate)
+end
+
+-- not in lfuncs.c
+function test_cosmo_Slurp()
+    lu.skipIf(missing("Slurp"), "not in lfuncs.c")
+    lu.assertNotNil(cosmo.Slurp)
+end
+
+function test_cosmo_Barf()
+    lu.skipIf(missing("Barf"), "not in lfuncs.c")
+    lu.assertNotNil(cosmo.Barf)
+end
+
+function test_cosmo_Sleep()
+    lu.assertNotNil(cosmo.Sleep)
+end
+
+-- bit manipulation
+function test_cosmo_Popcnt()
+    lu.assertNotNil(cosmo.Popcnt)
+end
+
+function test_cosmo_Bsf()
+    lu.assertNotNil(cosmo.Bsf)
+end
+
+function test_cosmo_Bsr()
+    lu.assertNotNil(cosmo.Bsr)
+end
+
+-- random number generators
+function test_cosmo_Rand64()
+    lu.skipIf(missing("Rand64"), "not in lfuncs.c")
+    lu.assertNotNil(cosmo.Rand64)
+end
+
+function test_cosmo_Lemur64()
+    lu.assertNotNil(cosmo.Lemur64)
+end
+
+-- low-level formatting (not in lfuncs.c)
+function test_cosmo_bin()
+    lu.skipIf(missing("bin"), "not in lfuncs.c")
+    lu.assertNotNil(cosmo.bin)
+end
+
+function test_cosmo_hex()
+    lu.skipIf(missing("hex"), "not in lfuncs.c")
+    lu.assertNotNil(cosmo.hex)
+end
+
+function test_cosmo_oct()
+    lu.skipIf(missing("oct"), "not in lfuncs.c")
+    lu.assertNotNil(cosmo.oct)
+end

--- a/3p/lua/test_modules.lua
+++ b/3p/lua/test_modules.lua
@@ -1,0 +1,60 @@
+-- test cosmo submodules
+local cosmo = require('cosmo')
+
+function test_cosmo_module_exists()
+    lu.assertNotNil(cosmo, "cosmo module should be compiled into lua")
+end
+
+function test_cosmo_unix_exists()
+    lu.assertNotNil(cosmo.unix, "cosmo.unix should exist")
+end
+
+function test_cosmo_unix_getpid()
+    lu.assertNotNil(cosmo.unix.getpid)
+    local pid = cosmo.unix.getpid()
+    lu.assertTrue(pid > 0)
+end
+
+function test_cosmo_path_exists()
+    lu.assertNotNil(cosmo.path, "cosmo.path should exist")
+end
+
+function test_cosmo_path_basename()
+    lu.assertEquals(cosmo.path.basename("/foo/bar/baz.txt"), "baz.txt")
+    lu.assertEquals(cosmo.path.basename("/foo/bar/"), "bar")
+    lu.assertEquals(cosmo.path.basename("file.txt"), "file.txt")
+end
+
+function test_cosmo_path_dirname()
+    lu.assertEquals(cosmo.path.dirname("/foo/bar/baz.txt"), "/foo/bar")
+    lu.assertEquals(cosmo.path.dirname("/foo/bar/"), "/foo")
+end
+
+function test_cosmo_path_join()
+    lu.assertEquals(cosmo.path.join("foo", "bar"), "foo/bar")
+    lu.assertEquals(cosmo.path.join("/foo", "bar"), "/foo/bar")
+    lu.assertEquals(cosmo.path.join("foo", "/bar"), "/bar")
+end
+
+function test_cosmo_re_exists()
+    lu.assertNotNil(cosmo.re, "cosmo.re should exist")
+end
+
+function test_cosmo_re_search()
+    lu.assertEquals(cosmo.re.search([[hello]], "hello world"), "hello")
+    lu.assertNil(cosmo.re.search([[xyz]], "hello world"))
+end
+
+function test_cosmo_argon2_exists()
+    lu.assertNotNil(cosmo.argon2, "cosmo.argon2 should exist")
+end
+
+function test_cosmo_sqlite3_exists()
+    lu.assertNotNil(cosmo.sqlite3, "cosmo.sqlite3 should exist")
+end
+
+function test_cosmo_sqlite3_open_memory()
+    local db = cosmo.sqlite3.open_memory()
+    lu.assertNotNil(db)
+    db:close()
+end

--- a/3p/luaunit/cook.mk
+++ b/3p/luaunit/cook.mk
@@ -1,0 +1,18 @@
+luaunit_url := https://raw.githubusercontent.com/bluebird75/luaunit/LUAUNIT_V3_4/luaunit.lua
+luaunit_sha256 := bf3e3fb25b77739fa1ebc324582776d26486e32e49c150628bc21b9b9e6ce645
+luaunit_dir := $(3p)/luaunit
+luaunit_file := $(luaunit_dir)/luaunit.lua
+luaunit_lua_dir := $(luaunit_dir)/.lua
+
+$(luaunit_file): | $(luaunit_dir)
+	$(curl) -o $@ $(luaunit_url)
+	cd $(dir $@) && echo "$(luaunit_sha256)  $(notdir $@)" | $(sha256sum) -c
+
+$(luaunit_dir):
+	mkdir -p $@
+
+$(luaunit_lua_dir)/luaunit.lua: $(luaunit_file)
+	mkdir -p $(dir $@)
+	cp $(luaunit_file) $@
+
+luaunit_libs := $(luaunit_lua_dir)

--- a/3p/shimlink/cook.mk
+++ b/3p/shimlink/cook.mk
@@ -1,0 +1,173 @@
+# shimlink binaries - download all platforms for embedding in home binary
+shimlink_dir := $(3p)/shimlink
+platforms := darwin-arm64 linux-arm64 linux-x86_64
+
+# Define gunzip command
+gunzip := gunzip -f
+
+# Template for downloading and extracting .tar.gz archives
+# Args: (1)name, (2)url, (3)platform, (4)sha256, (5)strip_components
+define download_targz
+$(shimlink_dir)/$(1)/$(3)/.extracted: | $(shimlink_dir)/$(1)/$(3)
+	$(curl) -o $(shimlink_dir)/$(1)/$(3)/archive.tar.gz $(2)
+	cd $(shimlink_dir)/$(1)/$(3) && echo "$(4)  archive.tar.gz" | $(sha256sum) -c
+	$(tar) -xzf $(shimlink_dir)/$(1)/$(3)/archive.tar.gz -C $(shimlink_dir)/$(1)/$(3) --strip-components=$(5)
+	rm $(shimlink_dir)/$(1)/$(3)/archive.tar.gz
+	touch $$@
+
+$(shimlink_dir)/$(1)/$(3):
+	mkdir -p $$@
+endef
+
+# Template for downloading and extracting .zip archives
+# Args: (1)name, (2)url, (3)platform, (4)sha256, (5)strip_components
+define download_zip
+$(shimlink_dir)/$(1)/$(3)/.extracted: | $(shimlink_dir)/$(1)/$(3)
+	$(curl) -o $(shimlink_dir)/$(1)/$(3)/archive.zip $(2)
+	cd $(shimlink_dir)/$(1)/$(3) && echo "$(4)  archive.zip" | $(sha256sum) -c
+	$(unzip) -o $(shimlink_dir)/$(1)/$(3)/archive.zip -d $(shimlink_dir)/$(1)/$(3)
+	if [ "$(5)" = "1" ]; then \
+		find $(shimlink_dir)/$(1)/$(3) -mindepth 2 -maxdepth 2 -exec mv {} $(shimlink_dir)/$(1)/$(3)/ \; && \
+		find $(shimlink_dir)/$(1)/$(3) -mindepth 1 -maxdepth 1 -type d -empty -delete; \
+	fi
+	rm $(shimlink_dir)/$(1)/$(3)/archive.zip
+	touch $$@
+
+$(shimlink_dir)/$(1)/$(3):
+	mkdir -p $$@
+endef
+
+# Template for downloading .gz files (not tarballs)
+# Args: (1)name, (2)url, (3)platform, (4)sha256
+define download_gz
+$(shimlink_dir)/$(1)/$(3)/.extracted: | $(shimlink_dir)/$(1)/$(3)
+	$(curl) -o $(shimlink_dir)/$(1)/$(3)/$(1).gz $(2)
+	cd $(shimlink_dir)/$(1)/$(3) && echo "$(4)  $(1).gz" | $(sha256sum) -c
+	$(gunzip) $(shimlink_dir)/$(1)/$(3)/$(1).gz
+	chmod +x $(shimlink_dir)/$(1)/$(3)/$(1)
+	touch $$@
+
+$(shimlink_dir)/$(1)/$(3):
+	mkdir -p $$@
+endef
+
+# Template for downloading direct binaries (no archive)
+# Args: (1)name, (2)url, (3)platform, (4)sha256
+define download_binary
+$(shimlink_dir)/$(1)/$(3)/.extracted: | $(shimlink_dir)/$(1)/$(3)
+	$(curl) -o $(shimlink_dir)/$(1)/$(3)/$(1) $(2)
+	cd $(shimlink_dir)/$(1)/$(3) && echo "$(4)  $(1)" | $(sha256sum) -c
+	chmod +x $(shimlink_dir)/$(1)/$(3)/$(1)
+	touch $$@
+
+$(shimlink_dir)/$(1)/$(3):
+	mkdir -p $$@
+endef
+
+# tree-sitter (v0.25.8) - .gz format
+$(eval $(call download_gz,tree-sitter,https://github.com/tree-sitter/tree-sitter/releases/download/v0.25.8/tree-sitter-macos-arm64.gz,darwin-arm64,ae3bbba3ba68e759a949e7591a42100a12d660cae165837aba48cae76a599e64))
+$(eval $(call download_gz,tree-sitter,https://github.com/tree-sitter/tree-sitter/releases/download/v0.25.8/tree-sitter-linux-arm64.gz,linux-arm64,cd81d0108df9bdacf4fd32ec53534acced4780540eb5e889c77470d496e37fc5))
+$(eval $(call download_gz,tree-sitter,https://github.com/tree-sitter/tree-sitter/releases/download/v0.25.8/tree-sitter-linux-x64.gz,linux-x86_64,c9d46697e3e5ae6900a39ad4483667d2ba14c8ffb12c3f863bcf82a9564ee19f))
+
+# rg (14.1.1) - .tar.gz
+$(eval $(call download_targz,rg,https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-aarch64-apple-darwin.tar.gz,darwin-arm64,24ad76777745fbff131c8fbc466742b011f925bfa4fffa2ded6def23b5b937be,1))
+$(eval $(call download_targz,rg,https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-aarch64-unknown-linux-gnu.tar.gz,linux-arm64,c827481c4ff4ea10c9dc7a4022c8de5db34a5737cb74484d62eb94a95841ab2f,1))
+$(eval $(call download_targz,rg,https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz,linux-x86_64,4cf9f2741e6c465ffdb7c26f38056a59e2a2544b51f7cc128ef28337eeae4d8e,1))
+
+# delta (0.18.2) - .tar.gz
+$(eval $(call download_targz,delta,https://github.com/dandavison/delta/releases/download/0.18.2/delta-0.18.2-aarch64-apple-darwin.tar.gz,darwin-arm64,6ba38dce9f91ee1b9a24aa4aede1db7195258fe176c3f8276ae2d4457d8170a0,1))
+$(eval $(call download_targz,delta,https://github.com/dandavison/delta/releases/download/0.18.2/delta-0.18.2-aarch64-unknown-linux-gnu.tar.gz,linux-arm64,adf7674086daa4582f598f74ce9caa6b70c1ba8f4a57d2911499b37826b014f9,1))
+$(eval $(call download_targz,delta,https://github.com/dandavison/delta/releases/download/0.18.2/delta-0.18.2-x86_64-unknown-linux-musl.tar.gz,linux-x86_64,b7ea845004762358a00ef9127dd9fd723e333c7e4b9cb1da220c3909372310ee,1))
+
+# nvim (2025.12.07) - .tar.gz
+$(eval $(call download_targz,nvim,https://github.com/whilp/dotfiles/releases/download/2025.12.07-c016a4c/nvim-2025.12.07-darwin-arm64.tar.gz,darwin-arm64,143513b8f91dd29a510beef8c1202a9c623f5ced2f0f379df894d1d3e4b37039,1))
+$(eval $(call download_targz,nvim,https://github.com/whilp/dotfiles/releases/download/2025.12.07-c016a4c/nvim-2025.12.07-linux-arm64.tar.gz,linux-arm64,4a1101efbf237749c0727c356bc3dcf78be6fdbae27d63fc9a5d147b0808a821,1))
+$(eval $(call download_targz,nvim,https://github.com/whilp/dotfiles/releases/download/2025.12.07-c016a4c/nvim-2025.12.07-linux-x64.tar.gz,linux-x86_64,92b09500a845d5c5dd35473b28486c188a836ccc4fa3ab7fe54d2ce0777b4e0d,1))
+
+# ruff (0.8.4) - .tar.gz
+$(eval $(call download_targz,ruff,https://github.com/astral-sh/ruff/releases/download/0.8.4/ruff-aarch64-apple-darwin.tar.gz,darwin-arm64,8893f3ede33a73740f69b10ee9356e5cf2933c0afe146f00176be12ef91bf9d9,1))
+$(eval $(call download_targz,ruff,https://github.com/astral-sh/ruff/releases/download/0.8.4/ruff-aarch64-unknown-linux-gnu.tar.gz,linux-arm64,0dfe36fabb817638863375e0140ce03bf26ccc9a7fd9d2c8e8337b1a21697ed4,1))
+$(eval $(call download_targz,ruff,https://github.com/astral-sh/ruff/releases/download/0.8.4/ruff-x86_64-unknown-linux-gnu.tar.gz,linux-x86_64,c4e6591ae1bb4f15c09c9022b7bfc57e1c3a567acdc9cd76021cd1304b5868c3,1))
+
+# sqruff (v0.21.2) - .tar.gz
+$(eval $(call download_targz,sqruff,https://github.com/quarylabs/sqruff/releases/download/v0.21.2/sqruff-darwin-aarch64.tar.gz,darwin-arm64,cb969b42ebbca8229b4484ae2503530c4eef16e23829b340a0b270e1a007e6b6,0))
+$(eval $(call download_targz,sqruff,https://github.com/quarylabs/sqruff/releases/download/v0.21.2/sqruff-linux-aarch64-musl.tar.gz,linux-arm64,94ef0e55978a960f9cfc717bf5ed2127ae4462cc0a7915d7d38d843e3ca7ddfb,0))
+$(eval $(call download_targz,sqruff,https://github.com/quarylabs/sqruff/releases/download/v0.21.2/sqruff-linux-x86_64-musl.tar.gz,linux-x86_64,ae09dfcb0d275bf5317769d6eff8aa62c05942369f63ea5e747164a7db9225d9,0))
+
+# superhtml (v0.5.3) - .tar.gz
+$(eval $(call download_targz,superhtml,https://github.com/kristoff-it/superhtml/releases/download/v0.5.3/aarch64-macos.tar.gz,darwin-arm64,b8b2327f666ff316422061284e107add5c413ebdfdb91774c0c3702a66e65ec9,1))
+$(eval $(call download_targz,superhtml,https://github.com/kristoff-it/superhtml/releases/download/v0.5.3/aarch64-linux.tar.gz,linux-arm64,54cd2414de6664b85166a0a2e7c208ca3dbcc935274f4a55309cc9dcfa8e605b,1))
+$(eval $(call download_targz,superhtml,https://github.com/kristoff-it/superhtml/releases/download/v0.5.3/x86_64-linux-musl.tar.gz,linux-x86_64,c9fabbbd57851e38a67e6c1eb7942e8bc6189925bfcf437f1e5286932c76d60a,1))
+
+# uv (0.5.7) - .tar.gz
+$(eval $(call download_targz,uv,https://github.com/astral-sh/uv/releases/download/0.5.7/uv-aarch64-apple-darwin.tar.gz,darwin-arm64,b8cab25ab2ec0714dbb34179f948c27aa4ab307be54e0628e9e1eef1d2264f9f,1))
+$(eval $(call download_targz,uv,https://github.com/astral-sh/uv/releases/download/0.5.7/uv-aarch64-unknown-linux-gnu.tar.gz,linux-arm64,d4dd7a72689888c92b5191902fd4ec9d25b7eeba07be41ba4a8f89acbb403e2d,1))
+$(eval $(call download_targz,uv,https://github.com/astral-sh/uv/releases/download/0.5.7/uv-x86_64-unknown-linux-gnu.tar.gz,linux-x86_64,8a0a3e823684dec6e49ae17f31bf6483c778fd579671992d9156875210e5161e,1))
+
+# luajit (2025.10.16-25a61a18) - .tar.gz with multiple executables
+$(eval $(call download_targz,luajit,https://github.com/whilp/dotfiles/releases/download/2025.12.06-06f06e0/luajit-2025.10.16-25a61a18-darwin-arm64.tar.gz,darwin-arm64,20e2f8496582adaec9340471147320b2f536c8da4c28075f3c9949de77860835,1))
+$(eval $(call download_targz,luajit,https://github.com/whilp/dotfiles/releases/download/2025.12.06-06f06e0/luajit-2025.10.16-25a61a18-linux-arm64.tar.gz,linux-arm64,36b2e28e6bb98c62f1f85206753be9cd4a4fab944f1dbd6b41727f12ccdbc3c3,1))
+$(eval $(call download_targz,luajit,https://github.com/whilp/dotfiles/releases/download/2025.12.06-06f06e0/luajit-2025.10.16-25a61a18-linux-x64.tar.gz,linux-x86_64,b235677b901f8ef71bde222506aa632d35c015b01400e73c24b44306ad3fab40,1))
+
+# gh (2.79.0) - mixed format (.zip for darwin, .tar.gz for linux)
+$(eval $(call download_zip,gh,https://github.com/cli/cli/releases/download/v2.79.0/gh_2.79.0_macOS_arm64.zip,darwin-arm64,5454f9509e3dbb8f321310e9e344877d9a01ebb8f8703886b1afb0936d60ffaa,1))
+$(eval $(call download_targz,gh,https://github.com/cli/cli/releases/download/v2.79.0/gh_2.79.0_linux_arm64.tar.gz,linux-arm64,1b91e546b30181a8ee6d8c72bbf59eaadbb0600bab014dfbcc199676c83ea102,1))
+$(eval $(call download_targz,gh,https://github.com/cli/cli/releases/download/v2.79.0/gh_2.79.0_linux_amd64.tar.gz,linux-x86_64,e7af0c72a607c0528fda1989f7c8e3be85e67d321889002af0e2938ad9c8fb68,1))
+
+# duckdb (v1.4.2) - .zip
+$(eval $(call download_zip,duckdb,https://github.com/duckdb/duckdb/releases/download/v1.4.2/duckdb_cli-osx-arm64.zip,darwin-arm64,4dda25dff89b9757dd248f3a48c4d3e215dff64c4c9535a7822b3b7a7f4031c2,0))
+$(eval $(call download_zip,duckdb,https://github.com/duckdb/duckdb/releases/download/v1.4.2/duckdb_cli-linux-arm64.zip,linux-arm64,2b62c2fa4cb2f2e76e937b3b4baf20259cf6a5370e07ff310008ca9d5d6009c4,0))
+$(eval $(call download_zip,duckdb,https://github.com/duckdb/duckdb/releases/download/v1.4.2/duckdb_cli-linux-amd64.zip,linux-x86_64,fae3ba93eedf20b08bca4b23aeac1ba94c446f1c10d029c193e2fc4b4e0bc1bc,0))
+
+# stylua (2.0.1) - .zip
+$(eval $(call download_zip,stylua,https://github.com/JohnnyMorganz/StyLua/releases/download/v2.0.1/stylua-macos-aarch64.zip,darwin-arm64,3d9caaa660da4b3bc092e805d09af59e42b7504f1253c863b682ea3fc80944f2,0))
+$(eval $(call download_zip,stylua,https://github.com/JohnnyMorganz/StyLua/releases/download/v2.0.1/stylua-linux-aarch64.zip,linux-arm64,3db53cd00a685d0b59f4a4ab188bfa6acb804dca489d810a852ed2ea32eb2b1c,0))
+$(eval $(call download_zip,stylua,https://github.com/JohnnyMorganz/StyLua/releases/download/v2.0.1/stylua-linux-x86_64.zip,linux-x86_64,9087e42f599855192cf4f6a7fb0cb7353e23debd7c749c6e3a76fc58abde3c89,0))
+
+# ast-grep (0.28.0) - .zip
+$(eval $(call download_zip,ast-grep,https://github.com/ast-grep/ast-grep/releases/download/0.28.0/app-aarch64-apple-darwin.zip,darwin-arm64,c9a9e690d94cd9696d2552690fe0abdd2c303e48a3ee5cf9d38728eda054f147,0))
+$(eval $(call download_zip,ast-grep,https://github.com/ast-grep/ast-grep/releases/download/0.28.0/app-aarch64-unknown-linux-gnu.zip,linux-arm64,62e9e79148be33d27fde24f4dcda83eab207a297ce50fb4a0becfbb29c8f218b,0))
+$(eval $(call download_zip,ast-grep,https://github.com/ast-grep/ast-grep/releases/download/0.28.0/app-x86_64-unknown-linux-gnu.zip,linux-x86_64,d28be5970afb3e8022210fb9427de0875f1d64f4e4b91ed28b3a3abfebb1d934,0))
+
+# biome (cli/v1.9.4) - direct binary
+$(eval $(call download_binary,biome,https://github.com/biomejs/biome/releases/download/cli%2Fv1.9.4/biome-darwin-arm64,darwin-arm64,c68f2cbe09e9485426a749353a155b1d22c130c6ccdadc7772d603eb247b9a9d))
+$(eval $(call download_binary,biome,https://github.com/biomejs/biome/releases/download/cli%2Fv1.9.4/biome-linux-arm64,linux-arm64,f0f0f3e7cdec78420a600b05bfc364aa9b804811bd3bbae04e7bf090828ae970))
+$(eval $(call download_binary,biome,https://github.com/biomejs/biome/releases/download/cli%2Fv1.9.4/biome-linux-x64,linux-x86_64,ce247fb644999ef52e5111dd6fd6e471019669fc9c4a44b5699721e39b7032c3))
+
+# marksman (2024-12-18) - direct binary
+$(eval $(call download_binary,marksman,https://github.com/artempyanykh/marksman/releases/download/2024-12-18/marksman-macos,darwin-arm64,7e18803966231a33ee107d0d26f69b41f2f0dc1332c52dd9729c2e29fb77be83))
+$(eval $(call download_binary,marksman,https://github.com/artempyanykh/marksman/releases/download/2024-12-18/marksman-linux-arm64,linux-arm64,b8d6972a56f3f9b7bbbf7c77ef8998e3b66fa82fb03c01398e224144486c9e73))
+$(eval $(call download_binary,marksman,https://github.com/artempyanykh/marksman/releases/download/2024-12-18/marksman-linux-x64,linux-x86_64,b9cb666c643dfd9b699811fdfc445ed4c56be65c1d878c21d46847f0d7b0e475))
+
+# shfmt (v3.10.0) - direct binary
+$(eval $(call download_binary,shfmt,https://github.com/mvdan/sh/releases/download/v3.10.0/shfmt_v3.10.0_darwin_arm64,darwin-arm64,86030533a823c0a7cd92dee0f74094e5b901c3277b43def6337d5e19e56fe553))
+$(eval $(call download_binary,shfmt,https://github.com/mvdan/sh/releases/download/v3.10.0/shfmt_v3.10.0_linux_arm64,linux-arm64,9d23013d56640e228732fd2a04a9ede0ab46bc2d764bf22a4a35fb1b14d707a8))
+$(eval $(call download_binary,shfmt,https://github.com/mvdan/sh/releases/download/v3.10.0/shfmt_v3.10.0_linux_amd64,linux-x86_64,1f57a384d59542f8fac5f503da1f3ea44242f46dff969569e80b524d64b71dbc))
+
+# comrak (0.41.0) - direct binary (note: has exec field in config but we ignore it for embedding)
+$(eval $(call download_binary,comrak,https://github.com/kivikakk/comrak/releases/download/v0.41.0/comrak-0.41.0-aarch64-apple-darwin,darwin-arm64,ebff398559a48112e7699ad8ce8a35e1f5f0cf469ed44d55318b1d794abf1090))
+$(eval $(call download_binary,comrak,https://github.com/kivikakk/comrak/releases/download/v0.41.0/comrak-0.41.0-aarch64-unknown-linux-gnu,linux-arm64,b76c1a02cd2b2d2b5f9dbde9d16124aa54d9e5a66fa2bc3f5f4d0ce637b1bb64))
+$(eval $(call download_binary,comrak,https://github.com/kivikakk/comrak/releases/download/v0.41.0/comrak-0.41.0-x86_64-unknown-linux-gnu,linux-x86_64,d3ffc8f04f85a47fa325081affd6b572ad456b542a4d3a1207ef4685afd7e9e2))
+
+# Aggregate all platform extraction markers
+shimlink_binaries := \
+	$(foreach p,$(platforms),$(shimlink_dir)/tree-sitter/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/rg/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/delta/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/nvim/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/ruff/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/sqruff/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/superhtml/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/uv/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/luajit/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/gh/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/duckdb/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/stylua/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/ast-grep/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/biome/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/marksman/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/shfmt/$(p)/.extracted) \
+	$(foreach p,$(platforms),$(shimlink_dir)/comrak/$(p)/.extracted)
+
+.PHONY: shimlink-binaries
+shimlink-binaries: $(shimlink_binaries)

--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,39 @@ results/dotfiles.zip: | results
 	git ls-files -z | grep -zZvE '$(home_exclude_pattern)' | \
 		xargs -0 $(cosmos_zip_bin) -q $@
 
-results/binaries.zip: $(shimlink_binaries) | results
+# Platform-specific binaries zips
+results/binaries-darwin-arm64.zip: $(shimlink_binaries) | results
 	cd $(shimlink_dir) && \
-		find . -type f ! -name '.extracted' | \
+		find . -path '*/darwin-arm64/*' -type f ! -name '.extracted' | \
 		$(cosmos_zip_bin) -q $(CURDIR)/$@ -@
 
-results/bin/home: $(lua_bin) results/dotfiles.zip results/binaries.zip home/main.lua home/.args | results/bin
+results/binaries-linux-arm64.zip: $(shimlink_binaries) | results
+	cd $(shimlink_dir) && \
+		find . -path '*/linux-arm64/*' -type f ! -name '.extracted' | \
+		$(cosmos_zip_bin) -q $(CURDIR)/$@ -@
+
+results/binaries-linux-x86_64.zip: $(shimlink_binaries) | results
+	cd $(shimlink_dir) && \
+		find . -path '*/linux-x86_64/*' -type f ! -name '.extracted' | \
+		$(cosmos_zip_bin) -q $(CURDIR)/$@ -@
+
+# Platform-specific home binaries
+results/bin/home-darwin-arm64: $(lua_bin) results/dotfiles.zip results/binaries-darwin-arm64.zip home/main.lua home/.args | results/bin
 	cp $(lua_bin) $@
 	$(cosmos_zip_bin) -qj $@ results/dotfiles.zip
-	$(cosmos_zip_bin) -qj $@ results/binaries.zip
+	$(cosmos_zip_bin) -qj $@ results/binaries-darwin-arm64.zip
+	cd home && $(cosmos_zip_bin) -qr $(CURDIR)/$@ main.lua .args
+
+results/bin/home-linux-arm64: $(lua_bin) results/dotfiles.zip results/binaries-linux-arm64.zip home/main.lua home/.args | results/bin
+	cp $(lua_bin) $@
+	$(cosmos_zip_bin) -qj $@ results/dotfiles.zip
+	$(cosmos_zip_bin) -qj $@ results/binaries-linux-arm64.zip
+	cd home && $(cosmos_zip_bin) -qr $(CURDIR)/$@ main.lua .args
+
+results/bin/home-linux-x86_64: $(lua_bin) results/dotfiles.zip results/binaries-linux-x86_64.zip home/main.lua home/.args | results/bin
+	cp $(lua_bin) $@
+	$(cosmos_zip_bin) -qj $@ results/dotfiles.zip
+	$(cosmos_zip_bin) -qj $@ results/binaries-linux-x86_64.zip
 	cd home && $(cosmos_zip_bin) -qr $(CURDIR)/$@ main.lua .args
 
 results/bin:
@@ -34,6 +58,6 @@ results/bin:
 results:
 	mkdir -p $@
 
-home: results/bin/home
+home: results/bin/home-darwin-arm64 results/bin/home-linux-arm64 results/bin/home-linux-x86_64
 
 .PHONY: build test clean home

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ include 3p/cook.mk
 include 3p/luaunit/cook.mk
 include 3p/cosmopolitan/cook.mk
 include 3p/lua/cook.mk
+include 3p/shimlink/cook.mk
 
 build: lua
 test: lua
@@ -12,14 +13,26 @@ clean:
 
 home_exclude_pattern = ^(3p/|o/|results/|Makefile|home/|\.git)
 
-results/dotfiles.zip:
+results/dotfiles.zip: | results
 	git ls-files -z | grep -zZvE '$(home_exclude_pattern)' | \
 		xargs -0 $(cosmos_zip_bin) -q $@
 
-results/bin/home: $(lua_bin) results/dotfiles.zip home/main.lua home/.args
+results/binaries.zip: $(shimlink_binaries) | results
+	cd $(shimlink_dir) && \
+		find . -type f ! -name '.extracted' | \
+		$(cosmos_zip_bin) -q $(CURDIR)/$@ -@
+
+results/bin/home: $(lua_bin) results/dotfiles.zip results/binaries.zip home/main.lua home/.args | results/bin
 	cp $(lua_bin) $@
 	$(cosmos_zip_bin) -qj $@ results/dotfiles.zip
+	$(cosmos_zip_bin) -qj $@ results/binaries.zip
 	cd home && $(cosmos_zip_bin) -qr $(CURDIR)/$@ main.lua .args
+
+results/bin:
+	mkdir -p $@
+
+results:
+	mkdir -p $@
 
 home: results/bin/home
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+include 3p/cook.mk
+include 3p/luaunit/cook.mk
+include 3p/cosmopolitan/cook.mk
+include 3p/lua/cook.mk
+
+build: lua
+test: lua
+	$(lua_bin) 3p/lua/test.lua
+
+clean:
+	rm -rf o results
+
+home_exclude_pattern = ^(3p/|o/|results/|Makefile|home/|\.git)
+
+results/dotfiles.zip:
+	git ls-files -z | grep -zZvE '$(home_exclude_pattern)' | \
+		xargs -0 $(cosmos_zip_bin) -q $@
+
+results/bin/home: $(lua_bin) results/dotfiles.zip home/main.lua home/.args
+	cp $(lua_bin) $@
+	$(cosmos_zip_bin) -qj $@ results/dotfiles.zip
+	cd home && $(cosmos_zip_bin) -qr $(CURDIR)/$@ main.lua .args
+
+home: results/bin/home
+
+.PHONY: build test clean home

--- a/home/.args
+++ b/home/.args
@@ -1,0 +1,1 @@
+main.lua

--- a/home/.args
+++ b/home/.args
@@ -1,1 +1,1 @@
-main.lua
+/zip/main.lua

--- a/home/main.lua
+++ b/home/main.lua
@@ -1,5 +1,5 @@
 local function cmd_unpack()
-  local f = io.open("/.zip/dotfiles.zip", "rb")
+  local f = io.open("/zip/dotfiles.zip", "rb")
   if not f then
     io.stderr:write("error: embedded dotfiles not found\n")
     os.exit(1)

--- a/home/main.lua
+++ b/home/main.lua
@@ -1,3 +1,35 @@
+local function detect_platform()
+  local uname_s = io.popen("uname -s"):read("*l")
+  local uname_m = io.popen("uname -m"):read("*l")
+
+  if not uname_s or not uname_m then
+    return nil, "failed to detect platform"
+  end
+
+  local os_name = uname_s:lower()
+  local arch = uname_m:lower()
+
+  local platform_os
+  if os_name:match("darwin") then
+    platform_os = "darwin"
+  elseif os_name:match("linux") then
+    platform_os = "linux"
+  else
+    return nil, "unsupported OS: " .. uname_s
+  end
+
+  local platform_arch
+  if arch == "arm64" or arch == "aarch64" then
+    platform_arch = "arm64"
+  elseif arch == "x86_64" or arch == "amd64" then
+    platform_arch = "x86_64"
+  else
+    return nil, "unsupported architecture: " .. uname_m
+  end
+
+  return platform_os .. "-" .. platform_arch
+end
+
 local function cmd_unpack()
   local f = io.open("/zip/dotfiles.zip", "rb")
   if not f then
@@ -9,6 +41,118 @@ local function cmd_unpack()
   io.stdout:write(content)
 end
 
+local function cmd_install()
+  local dest = os.getenv("HOME")
+  if not dest then
+    io.stderr:write("error: HOME not set\n")
+    os.exit(1)
+  end
+
+  local platform, err = detect_platform()
+  if not platform then
+    io.stderr:write("error: " .. err .. "\n")
+    os.exit(1)
+  end
+
+  io.stderr:write("platform: " .. platform .. "\n")
+
+  io.stderr:write("extracting dotfiles...\n")
+  local dotfiles_tmp = dest .. "/.dotfiles.zip.tmp"
+  local df = io.open("/zip/dotfiles.zip", "rb")
+  if not df then
+    io.stderr:write("error: embedded dotfiles not found\n")
+    os.exit(1)
+  end
+  local dtf = io.open(dotfiles_tmp, "wb")
+  if not dtf then
+    io.stderr:write("error: failed to write dotfiles\n")
+    os.exit(1)
+  end
+  dtf:write(df:read("*a"))
+  df:close()
+  dtf:close()
+
+  os.execute(string.format("unzip -q -o '%s' -d '%s'", dotfiles_tmp, dest))
+  os.remove(dotfiles_tmp)
+
+  io.stderr:write("extracting binaries for " .. platform .. "...\n")
+  local binaries_tmp = dest .. "/.binaries.zip.tmp"
+  local bf = io.open("/zip/binaries.zip", "rb")
+  if not bf then
+    io.stderr:write("warning: no binaries embedded\n")
+  else
+    local btf = io.open(binaries_tmp, "wb")
+    if not btf then
+      io.stderr:write("error: failed to write binaries\n")
+      os.exit(1)
+    end
+    btf:write(bf:read("*a"))
+    bf:close()
+    btf:close()
+
+    local extract_dir = dest .. "/.local/share/home-binaries"
+    os.execute("mkdir -p " .. extract_dir)
+
+    local cmd = string.format(
+      "unzip -q -o '%s' -d '%s' '*/%s/*' 2>/dev/null || true",
+      binaries_tmp,
+      extract_dir,
+      platform
+    )
+    os.execute(cmd)
+    os.remove(binaries_tmp)
+
+    io.stderr:write("creating symlinks...\n")
+    local bin_dir = dest .. "/.local/bin"
+    os.execute("mkdir -p " .. bin_dir)
+
+    local binaries = {
+      "nvim", "gh", "delta", "rg", "duckdb", "tree-sitter",
+      "ast-grep", "biome", "comrak", "marksman", "ruff",
+      "shfmt", "sqruff", "stylua", "superhtml", "uv",
+      "luajit", "luarocks", "luarocks-admin", "djot", "lunamark"
+    }
+
+    for _, name in ipairs(binaries) do
+      local cmd = string.format(
+        "find '%s' -path '*/%s/%s' -o -path '*/%s/bin/%s' | head -1",
+        extract_dir, platform, name, platform, name
+      )
+      local binary_path = io.popen(cmd):read("*l")
+      if binary_path and binary_path ~= "" then
+        local target = bin_dir .. "/" .. name
+        os.execute(string.format("ln -sf '%s' '%s'", binary_path, target))
+        os.execute("chmod +x '" .. binary_path .. "'")
+      end
+    end
+  end
+
+  io.stderr:write("installation complete\n")
+  io.stderr:write("add ~/.local/bin to PATH if needed\n")
+end
+
+local function cmd_list()
+  local platform, err = detect_platform()
+  if not platform then
+    io.stderr:write("error: " .. err .. "\n")
+    os.exit(1)
+  end
+
+  io.stdout:write("platform: " .. platform .. "\n")
+  io.stdout:write("\nembedded binaries:\n")
+
+  local binaries = {
+    "tree-sitter", "rg", "delta", "nvim", "ruff", "sqruff",
+    "superhtml", "uv", "gh", "duckdb", "stylua", "ast-grep",
+    "biome", "marksman", "shfmt", "comrak",
+    "luajit (+ luarocks, luarocks-admin, djot, lunamark)"
+  }
+
+  for _, name in ipairs(binaries) do
+    io.stdout:write("  - " .. name .. "\n")
+  end
+end
+
 local function cmd_version()
   io.stdout:write("home built COMMIT_PLACEHOLDER\n")
 end
@@ -18,12 +162,19 @@ local function main(args)
 
   if cmd == "unpack" then
     cmd_unpack()
+  elseif cmd == "install" then
+    cmd_install()
+  elseif cmd == "list" then
+    cmd_list()
   elseif cmd == "version" then
     cmd_version()
   else
-    io.stderr:write("usage: home unpack > dotfiles.zip\n")
-    io.stderr:write("       unzip dotfiles.zip -d ~/\n")
-    io.stderr:write("       home version\n")
+    io.stderr:write("usage: home <command>\n")
+    io.stderr:write("\ncommands:\n")
+    io.stderr:write("  install  - install dotfiles and binaries to $HOME\n")
+    io.stderr:write("  unpack   - output dotfiles.zip to stdout\n")
+    io.stderr:write("  list     - list embedded binaries for current platform\n")
+    io.stderr:write("  version  - show build version\n")
     os.exit(cmd == "help" and 0 or 1)
   end
 end

--- a/home/main.lua
+++ b/home/main.lua
@@ -93,13 +93,7 @@ local function cmd_install()
     local extract_dir = dest .. "/.local/share/home-binaries"
     os.execute("mkdir -p " .. extract_dir)
 
-    local cmd = string.format(
-      "unzip -q -o '%s' -d '%s' '*/%s/*' 2>/dev/null || true",
-      binaries_tmp,
-      extract_dir,
-      platform
-    )
-    os.execute(cmd)
+    os.execute(string.format("unzip -q -o '%s' -d '%s'", binaries_tmp, extract_dir))
     os.remove(binaries_tmp)
 
     io.stderr:write("creating symlinks...\n")

--- a/home/main.lua
+++ b/home/main.lua
@@ -1,0 +1,31 @@
+local function cmd_unpack()
+  local f = io.open("/.zip/dotfiles.zip", "rb")
+  if not f then
+    io.stderr:write("error: embedded dotfiles not found\n")
+    os.exit(1)
+  end
+  local content = f:read("*a")
+  f:close()
+  io.stdout:write(content)
+end
+
+local function cmd_version()
+  io.stdout:write("home built COMMIT_PLACEHOLDER\n")
+end
+
+local function main(args)
+  local cmd = args[1] or "help"
+
+  if cmd == "unpack" then
+    cmd_unpack()
+  elseif cmd == "version" then
+    cmd_version()
+  else
+    io.stderr:write("usage: home unpack > dotfiles.zip\n")
+    io.stderr:write("       home unpack | unzip -d ~/\n")
+    io.stderr:write("       home version\n")
+    os.exit(cmd == "help" and 0 or 1)
+  end
+end
+
+main({...})

--- a/home/main.lua
+++ b/home/main.lua
@@ -22,7 +22,7 @@ local function main(args)
     cmd_version()
   else
     io.stderr:write("usage: home unpack > dotfiles.zip\n")
-    io.stderr:write("       home unpack | unzip -d ~/\n")
+    io.stderr:write("       unzip dotfiles.zip -d ~/\n")
     io.stderr:write("       home version\n")
     os.exit(cmd == "help" and 0 or 1)
   end

--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,10 @@
 
 SETUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.config/setup" && pwd)"
 
+if command -v home &>/dev/null; then
+  home unpack | unzip -o -d ~/
+fi
+
 main() {
   "$SETUP_DIR/backup"
   "$SETUP_DIR/git"


### PR DESCRIPTION
Fixes build issues in the fat binary build system:

- Fix lua_build_dir to use $(o) variable for absolute path
- Update .args to specify /zip/main.lua entry point  
- Fix dotfiles.zip path from /.zip to /zip mount point

Verification:
- Binary builds successfully (5.4M)
- `home unpack` outputs 373KB dotfiles.zip
- `home version` shows build info
- Successfully extracts all dotfiles