### PR TITLE
claude: fix package.path calculation for module loading

### DIFF
--- a/.local/bin/claude
+++ b/.local/bin/claude
@@ -3,7 +3,7 @@
 local cosmo = require("cosmo")
 local unix = cosmo.unix
 
-local script_dir = cosmo.path.dirname(cosmo.path.dirname(debug.getinfo(1, "S").source:sub(2)))
+local script_dir = cosmo.path.dirname(cosmo.path.dirname(cosmo.path.dirname(debug.getinfo(1, "S").source:sub(2))))
 package.path = script_dir .. "/src/?.lua;" .. package.path
 
 local claude = require("claude.main")


### PR DESCRIPTION
Add one more dirname call to correctly resolve script directory. The script is at ~/.local/bin/claude, so we need to go up three levels to reach ~/ where src/ is located.