### PR TITLE
claude: fix ipairs bug when nil in paths array

### DIFF
--- a/src/claude/main.lua
+++ b/src/claude/main.lua
@@ -2,8 +2,9 @@ local cosmo = require("cosmo")
 local unix = cosmo.unix
 
 local function find_claude_binary(paths)
-  for _, path in ipairs(paths) do
-    if unix.stat(path) then
+  for i = 1, #paths do
+    local path = paths[i]
+    if path and unix.stat(path) then
       return path
     end
   end

--- a/src/claude/test.lua
+++ b/src/claude/test.lua
@@ -28,6 +28,19 @@ function test_find_claude_binary_returns_nil_when_none_exist()
   lu.assertNil(result, "should return nil when no files exist")
 end
 
+function test_find_claude_binary_handles_nil_in_paths()
+  local tmpfile = os.tmpname()
+  local f = io.open(tmpfile, "w")
+  f:write("test")
+  f:close()
+
+  local paths = {nil, tmpfile, "/also/nonexistent"}
+  local result = claude.find_claude_binary(paths)
+
+  lu.assertEquals(result, tmpfile, "should find existing file even when nil is first element")
+  os.remove(tmpfile)
+end
+
 function test_build_argv_basic()
   local argv = claude.build_argv({}, nil, {})
 


### PR DESCRIPTION
## Summary

- Fixed `find_claude_binary` to handle nil values in the paths array
- Changed from `ipairs()` to numeric for loop to properly iterate over all elements
- Added test case to validate the fix

## Details

The bug occurred because `scan_for_claude_deploy()` returns `nil` when no deploy paths exist, and this `nil` gets inserted as the first element in the `claude_paths` array. The original code used `ipairs(paths)` which stops iteration at the first `nil` value, causing the valid path at index 2 (`~/.local/share/claude/bin/claude`) to never be checked.

## Changes

**src/claude/main.lua:4-12** - Changed `find_claude_binary` to use numeric loop instead of ipairs
**src/claude/test.lua:31-42** - Added test case `test_find_claude_binary_handles_nil_in_paths()`

## Test plan

- [x] All existing tests pass
- [x] New test validates nil handling in paths array
- [x] Verified claude wrapper successfully finds and executes the binary