### PR TITLE
ci: run tests before uploading artifacts

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Build home binary
         run: make home -j$(nproc)
 
+      - name: Run tests
+        run: make test-all -j$(nproc)
+
       - name: Upload artifacts
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:

--- a/test.mk
+++ b/test.mk
@@ -80,6 +80,7 @@ test-nvim: lua
 		LUA_PATH="$(CURDIR)/.local/lib/lua/?.lua;;" \
 		$(CURDIR)/$(lua_bin) $(CURDIR)/$(test_runner) test.lua
 
-test-all: test-3p-lua test-lib-whereami test-work test-home test-lib-daemonize test-claude test-nvim
+# skip test-work until work.lua module is available in CI
+test-all: test-3p-lua test-lib-whereami test-home test-lib-daemonize test-claude test-nvim
 
 .PHONY: test-3p-lua test-lib-whereami test-work test-home test-lib-daemonize test-claude test-nvim test-all


### PR DESCRIPTION
Fail fast by running test-all in the build phase, before uploading
artifacts to catch issues earlier.