### PR TITLE
claude: fix opendir usage to use iterator pattern

### DIFF
--- a/src/claude/main.lua
+++ b/src/claude/main.lua
@@ -125,6 +125,7 @@ local claude = {
   find_claude_binary = find_claude_binary,
   build_argv = build_argv,
   scan_for_claude_deploy = scan_for_claude_deploy,
+  scan_for_atomic_install = scan_for_atomic_install,
   main = main,
 }
 

--- a/src/claude/main.lua
+++ b/src/claude/main.lua
@@ -54,18 +54,15 @@ end
 local function scan_for_atomic_install()
   local HOME = os.getenv("HOME")
   local share_dir = HOME .. "/.local/share/claude"
-  local dir = unix.opendir(share_dir)
-  if not dir then
+
+  if not unix.stat(share_dir) then
     return nil
   end
 
   local latest_path = nil
   local latest_version = nil
 
-  while true do
-    local entry = unix.readdir(dir)
-    if not entry then break end
-    local name = entry.name
+  for name, _ in unix.opendir(share_dir) do
     if name ~= "." and name ~= ".." then
       local version = name:match("^([%d%.]+)%-")
       if version then
@@ -80,7 +77,6 @@ local function scan_for_atomic_install()
     end
   end
 
-  unix.closedir(dir)
   return latest_path
 end
 

--- a/src/claude/test.lua
+++ b/src/claude/test.lua
@@ -86,6 +86,10 @@ end
 
 function test_scan_for_claude_deploy()
   local result = claude.scan_for_claude_deploy()
-  -- Should return nil or a valid path, but not crash
+  lu.assertTrue(result == nil or type(result) == "string", "should return nil or string")
+end
+
+function test_scan_for_atomic_install()
+  local result = claude.scan_for_atomic_install()
   lu.assertTrue(result == nil or type(result) == "string", "should return nil or string")
 end


### PR DESCRIPTION
## Summary
- Fix `scan_for_atomic_install()` to use the correct cosmo.unix.opendir() iterator pattern
- `unix.opendir()` returns an iterator for use in a `for` loop, not a directory handle
- Removes calls to non-existent `unix.readdir()` and `unix.closedir()` functions

## Test plan
- [x] Verified `claude --version` works after the fix