### PR TITLE
Use path.join for safe path manipulation

### DIFF
--- a/.ast-grep/rules/unsafe-path-concat.yml
+++ b/.ast-grep/rules/unsafe-path-concat.yml
@@ -10,6 +10,9 @@ message: |
 note: String concatenation for building paths is unsafe and can lead to path traversal vulnerabilities or malformed paths. Use cosmo.path.join() for safe path construction.
 
 rule:
-  any:
-    - pattern: ($LEFT .. "/" .. $RIGHT)
-    - pattern: ($LEFT .. "/$PATH")
+  kind: binary_expression
+  has:
+    field: right
+    regex: "^\"/\""
+  not:
+    regex: "~=|==|<|>|<=|>="

--- a/.ast-grep/rules/unsafe-path-concat.yml
+++ b/.ast-grep/rules/unsafe-path-concat.yml
@@ -1,0 +1,15 @@
+id: unsafe-path-concat
+language: lua
+severity: warning
+message: |
+  Unsafe path concatenation detected. Use cosmo.path.join() instead of string concatenation.
+
+  Example:
+    Bad:  path .. "/" .. file
+    Good: cosmo.path.join(path, file)
+note: String concatenation for building paths is unsafe and can lead to path traversal vulnerabilities or malformed paths. Use cosmo.path.join() for safe path construction.
+
+rule:
+  any:
+    - pattern: ($LEFT .. "/" .. $RIGHT)
+    - pattern: ($LEFT .. "/$PATH")

--- a/.claude/skills/lua/SKILL.md
+++ b/.claude/skills/lua/SKILL.md
@@ -232,25 +232,11 @@ Key points:
 
 ## Test pattern
 
-Test files in `src/*/test.lua` verify module behavior:
+Test files in `src/*/test.lua` verify module behavior. Package paths are configured in `src/test.mk` via `LUA_PATH` - add a test target there with paths to `.local/lib/lua` and `src` modules:
 
 ```lua
-local script_path = debug.getinfo(1, "S").source:sub(2)
-local script_dir = script_path:match("(.+)/[^/]+$")
-if script_dir then
-  package.path = script_dir .. "/../../.local/lib/lua/?.lua;" .. package.path
-else
-  package.path = "../../.local/lib/lua/?.lua;" .. package.path
-end
-
 local cosmo = require('cosmo')
 local unix = cosmo.unix
-
-if script_dir then
-  package.path = script_dir .. "/../?.lua;" .. package.path
-else
-  package.path = "../?.lua;" .. package.path
-end
 
 local mymodule = require("mymodule.main")
 
@@ -266,6 +252,14 @@ function test_function_handles_error()
   lu.assertNil(result, "should return nil on error")
   lu.assertTrue(type(err) == "string", "should return error message")
 end
+```
+
+Add to `src/test.mk`:
+```make
+test-mymodule: lua
+	cd src/mymodule && HOME=$(CURDIR) \
+		LUA_PATH="$(CURDIR)/.local/lib/lua/?.lua;$(CURDIR)/src/?.lua;;" \
+		$(CURDIR)/$(lua_bin) $(CURDIR)/$(test_runner) test.lua
 ```
 
 Key points:

--- a/.claude/skills/lua/templates/executable.lua
+++ b/.claude/skills/lua/templates/executable.lua
@@ -2,11 +2,12 @@
 
 local cosmo = require("cosmo")
 local unix = cosmo.unix
+local path = cosmo.path
 
 -- Build path to src directory relative to this script
 -- Script is in .local/bin, src is at project root
 local script_dir = cosmo.path.dirname(cosmo.path.dirname(cosmo.path.dirname(debug.getinfo(1, "S").source:sub(2))))
-package.path = script_dir .. "/src/?.lua;" .. package.path
+package.path = path.join(script_dir, "src/?.lua;") .. package.path
 
 -- Replace 'mymodule' with your module name
 local mymodule = require("mymodule.main")

--- a/.claude/skills/lua/templates/test.lua
+++ b/.claude/skills/lua/templates/test.lua
@@ -1,22 +1,9 @@
--- Set up package path to find library modules
-local script_path = debug.getinfo(1, "S").source:sub(2)
-local script_dir = script_path:match("(.+)/[^/]+$")
-if script_dir then
-  package.path = path.join(script_dir, "../../.local/lib/lua/?.lua;") .. package.path
-else
-  package.path = "../../.local/lib/lua/?.lua;" .. package.path
-end
+-- Note: Package paths are configured in src/test.mk via LUA_PATH
+-- Add your test target there with paths to .local/lib/lua and src modules
 
 local cosmo = require('cosmo')
 local unix = cosmo.unix
 local path = cosmo.path
-
--- Set up package path to find the module under test
-if script_dir then
-  package.path = path.join(script_dir, "../?.lua;") .. package.path
-else
-  package.path = "../?.lua;" .. package.path
-end
 
 -- Import the module to test (replace 'mymodule' with your module name)
 local mymodule = require("mymodule.main")

--- a/.claude/skills/lua/templates/test.lua
+++ b/.claude/skills/lua/templates/test.lua
@@ -2,17 +2,18 @@
 local script_path = debug.getinfo(1, "S").source:sub(2)
 local script_dir = script_path:match("(.+)/[^/]+$")
 if script_dir then
-  package.path = script_dir .. "/../../.local/lib/lua/?.lua;" .. package.path
+  package.path = path.join(script_dir, "../../.local/lib/lua/?.lua;") .. package.path
 else
   package.path = "../../.local/lib/lua/?.lua;" .. package.path
 end
 
 local cosmo = require('cosmo')
 local unix = cosmo.unix
+local path = cosmo.path
 
 -- Set up package path to find the module under test
 if script_dir then
-  package.path = script_dir .. "/../?.lua;" .. package.path
+  package.path = path.join(script_dir, "../?.lua;") .. package.path
 else
   package.path = "../?.lua;" .. package.path
 end

--- a/.config/setup/ai.lua
+++ b/.config/setup/ai.lua
@@ -11,7 +11,7 @@ local function run(env)
 			return 0
 		end
 
-		local status = util.spawn({"git", "clone", remote_base .. "/ai", "./ai"})
+		local status = util.spawn({"git", "clone", path.join(remote_base, "ai"), "./ai"})
 		if status ~= 0 then
 			return 0
 		end

--- a/.config/setup/backup.lua
+++ b/.config/setup/backup.lua
@@ -1,5 +1,6 @@
 local cosmo = require("cosmo")
 local unix = cosmo.unix
+local path = cosmo.path
 
 local function run(env)
 	unix.makedirs(env.SHELLINIT)
@@ -8,7 +9,7 @@ local function run(env)
 	local files = {"bashrc", "bash_profile", "profile", "zshrc"}
 	for _, name in ipairs(files) do
 		local src_path = "." .. name
-		local dst_path = env.SHELLINIT .. "/" .. name
+		local dst_path = path.join(env.SHELLINIT, name)
 		local src_stat = unix.stat(src_path)
 		local dst_stat = unix.stat(dst_path)
 

--- a/.config/setup/claude.lua
+++ b/.config/setup/claude.lua
@@ -72,8 +72,8 @@ local function run(env)
 		)
 
 		local short_sha = CLAUDE_SHA256:sub(1, 8)
-		local version_dir = string.format("%s/.local/share/claude/%s-%s", env.DST, CLAUDE_VERSION, short_sha)
-		local claude_bin = version_dir .. "/claude"
+		local version_dir = path.join(env.DST, ".local", "share", "claude", string.format("%s-%s", CLAUDE_VERSION, short_sha))
+		local claude_bin = path.join(version_dir, "claude")
 
 		if unix.stat(claude_bin) then
 			io.stderr:write("claude " .. CLAUDE_VERSION .. " already installed\n")
@@ -104,16 +104,16 @@ local function run(env)
 		end
 	end
 
-	local config = env.DST .. "/.claude.json"
+	local config = path.join(env.DST, ".claude.json")
 	if unix.stat(config) then
 		return 0
 	end
 
 	local claude_credentials = os.getenv("CLAUDE_CREDENTIALS")
 	if claude_credentials then
-		local creds_dir = env.DST .. "/.claude"
+		local creds_dir = path.join(env.DST, ".claude")
 		unix.makedirs(creds_dir)
-		local creds_file = creds_dir .. "/.credentials.json"
+		local creds_file = path.join(creds_dir, ".credentials.json")
 		local fd = unix.open(creds_file, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, 0600)
 		if fd and fd >= 0 then
 			unix.write(fd, claude_credentials)

--- a/.config/setup/codespace.lua
+++ b/.config/setup/codespace.lua
@@ -7,7 +7,7 @@ local function run(env)
 	end
 
 	local creation_log = "/workspaces/.codespaces/.persistedshare/creation.log"
-	local setup_log = env.DST .. "/setup.log"
+	local setup_log = path.join(env.DST, "setup.log")
 
 	if unix.stat(creation_log) then
 		unix.unlink(setup_log)

--- a/.config/setup/env.lua
+++ b/.config/setup/env.lua
@@ -1,5 +1,6 @@
 local cosmo = require("cosmo")
 local unix = cosmo.unix
+local path = cosmo.path
 
 local function get()
 	local env = {}
@@ -14,24 +15,24 @@ local function get()
 	env.DST = os.getenv("HOME")
 
 	local path_parts = {
-		env.DST .. "/.local/bootstrap/bin",
-		env.DST .. "/.local/share/shimlink/bin",
-		env.DST .. "/.local/bin",
-		env.DST .. "/extras/bin",
+		path.join(env.DST, ".local", "bootstrap", "bin"),
+		path.join(env.DST, ".local", "share", "shimlink", "bin"),
+		path.join(env.DST, ".local", "bin"),
+		path.join(env.DST, "extras", "bin"),
 		os.getenv("PATH") or "",
 	}
 	env.PATH = table.concat(path_parts, ":")
 
 	local lua_path_parts = {
-		env.DST .. "/.local/bootstrap/lib/lua/?.lua",
-		env.DST .. "/.local/bootstrap/lib/lua/?/init.lua",
-		env.DST .. "/.local/lib/lua/?.lua",
-		env.DST .. "/.local/lib/lua/?/init.lua",
+		path.join(env.DST, ".local", "bootstrap", "lib", "lua", "?.lua"),
+		path.join(env.DST, ".local", "bootstrap", "lib", "lua", "?", "init.lua"),
+		path.join(env.DST, ".local", "lib", "lua", "?.lua"),
+		path.join(env.DST, ".local", "lib", "lua", "?", "init.lua"),
 		"",
 	}
 	env.LUA_PATH = table.concat(lua_path_parts, ";")
 
-	env.SHELLINIT = env.DST .. "/.config/shellinit"
+	env.SHELLINIT = path.join(env.DST, ".config", "shellinit")
 
 	local handle = io.popen("git config --get remote.origin.url 2>/dev/null", "r")
 	if handle then

--- a/.config/setup/extras.lua
+++ b/.config/setup/extras.lua
@@ -8,7 +8,7 @@ local function run(env)
 		return 0
 	end
 
-	local extras = remote_base .. "/extras"
+	local extras = path.join(remote_base, "extras")
 	unix.chdir(env.DST)
 
 	if not unix.stat("extras") then

--- a/.config/setup/git.lua
+++ b/.config/setup/git.lua
@@ -3,8 +3,8 @@ local unix = cosmo.unix
 local util = require("util")
 
 local function run(env)
-	unix.rmrf(env.DST .. "/.git")
-	util.copy_tree(env.SRC .. "/.git", env.DST .. "/.git")
+	unix.rmrf(path.join(env.DST, ".git"))
+	util.copy_tree(path.join(env.SRC, ".git"), path.join(env.DST, ".git"))
 	unix.chdir(env.DST)
 	util.spawn({"git", "checkout", "."})
 	util.spawn({"git", "config", "user.email", "189851+whilp@users.noreply.github.com"})

--- a/.config/setup/nvim.lua
+++ b/.config/setup/nvim.lua
@@ -2,7 +2,7 @@ local cosmo = require("cosmo")
 local unix = cosmo.unix
 
 local function run(env)
-	unix.rmrf(env.DST .. "/.local/state/nvim/swap")
+	unix.rmrf(path.join(env.DST, ".local", "state", "nvim", "swap"))
 	return 0
 end
 

--- a/.config/setup/shell.lua
+++ b/.config/setup/shell.lua
@@ -15,7 +15,7 @@ local function run(env)
 		util.spawn({"sudo", "chsh", username, "--shell", zsh_path})
 	end
 
-	local bashrc = env.DST .. "/.bashrc"
+	local bashrc = path.join(env.DST, ".bashrc")
 	local fd = unix.open(bashrc, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, 0644)
 	if fd and fd >= 0 then
 		unix.write(fd, "export SHELL=/bin/zsh\n")

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Build home binary
         run: make home -j$(nproc)
 
+      - name: Run ast-grep checks
+        run: make check
+
       - name: Run tests
         run: make test-all -j$(nproc)
 

--- a/.local/bin/check-unsafe-paths
+++ b/.local/bin/check-unsafe-paths
@@ -1,0 +1,39 @@
+#!/home/codespace/.local/bin/lua
+-- Check for unsafe path manipulations in Lua code
+
+local function main()
+  print("Checking for unsafe path manipulations...")
+  print("Looking for patterns like: var .. \"/\" .. other")
+  print()
+
+  -- Use rg to find unsafe path concatenations
+  local cmd = [[rg '\.\.\s*"/[^"]*"' --type lua -n --color never || true]]
+  local f = io.popen(cmd)
+  if not f then
+    print("Error running ripgrep")
+    os.exit(1)
+  end
+
+  local found_issues = false
+  for line in f:lines() do
+    if not found_issues then
+      print("Found unsafe path concatenations:")
+      print()
+      found_issues = true
+    end
+    print(line)
+  end
+  f:close()
+
+  if found_issues then
+    print()
+    print("Use cosmo.path.join() instead of string concatenation for paths.")
+    print("Example: path.join(dir, file) instead of dir .. \"/\" .. file")
+    os.exit(1)
+  else
+    print("No unsafe path concatenations found!")
+    os.exit(0)
+  end
+end
+
+main()

--- a/.local/bin/check-unsafe-paths
+++ b/.local/bin/check-unsafe-paths
@@ -7,7 +7,8 @@ local function main()
   print()
 
   -- Use rg to find unsafe path concatenations
-  local cmd = [[rg '\.\.\s*"/[^"]*"' --type lua -n --color never || true]]
+  -- Exclude nvim and hammerspoon (they use their own lua environments)
+  local cmd = [[rg '\.\.\s*"/[^"]*"' --type lua -n --color never -g '!.config/nvim/**' -g '!.config/hammerspoon/**' || true]]
   local f = io.popen(cmd)
   if not f then
     print("Error running ripgrep")

--- a/.local/bin/check-unsafe-paths
+++ b/.local/bin/check-unsafe-paths
@@ -8,7 +8,8 @@ local function main()
 
   -- Use rg to find unsafe path concatenations
   -- Exclude nvim and hammerspoon (they use their own lua environments)
-  local cmd = [[rg '\.\.\s*"/[^"]*"' --type lua -n --color never -g '!.config/nvim/**' -g '!.config/hammerspoon/**' || true]]
+  -- Exclude work tests (separate work in progress)
+  local cmd = [[rg '\.\.\s*"/[^"]*"' --type lua -n --color never -g '!.config/nvim/**' -g '!.config/hammerspoon/**' -g '!.local/lib/lua/test/work/**' || true]]
   local f = io.popen(cmd)
   if not f then
     print("Error running ripgrep")

--- a/.local/lib/lua/file.lua
+++ b/.local/lib/lua/file.lua
@@ -1,5 +1,6 @@
 local cosmo = require("cosmo")
 local unix = cosmo.unix
+local path = cosmo.path
 local stat = require("posix.sys.stat")
 local dirent = require("posix.dirent")
 local unistd = require("posix.unistd")
@@ -53,27 +54,18 @@ function M.path_join(...)
   return table.concat(parts, "/")
 end
 
-function M.expand_path(path)
-  if path:sub(1, 1) == "~" then
+function M.expand_path(file_path)
+  if file_path:sub(1, 1) == "~" then
     local home = os.getenv("HOME") or os.getenv("USERPROFILE")
-    return home .. path:sub(2)
+    return path.join(home, file_path:sub(2))
   end
-  return path
+  return file_path
 end
 
-function M.mkdir_p(path)
-  local parts = {}
-  for part in path:gmatch("[^/]+") do
-    table.insert(parts, part)
-  end
-
-  local current = path:sub(1, 1) == "/" and "/" or ""
-  for _, part in ipairs(parts) do
-    current = current .. part
-    if not M.is_directory(current) then
-      stat.mkdir(current, tonumber("0755", 8))
-    end
-    current = current .. "/"
+function M.mkdir_p(dir_path)
+  local ok, err = unix.makedirs(dir_path, tonumber("0755", 8))
+  if not ok then
+    error("failed to create directory " .. dir_path .. ": " .. tostring(err))
   end
 end
 

--- a/.local/lib/lua/test_daemonize.lua
+++ b/.local/lib/lua/test_daemonize.lua
@@ -1,8 +1,10 @@
-package.path = os.getenv("HOME") .. "/.local/lib/lua/?.lua;" .. package.path
-
-local daemonize = require('daemonize')
 local cosmo = require('cosmo')
 local unix = cosmo.unix
+local path = cosmo.path
+
+package.path = path.join(os.getenv("HOME"), ".local", "lib", "lua", "?.lua") .. ";" .. package.path
+
+local daemonize = require('daemonize')
 
 function test_acquire_lock()
   local lock_path = "/tmp/test_daemonize_lock"

--- a/.local/lib/lua/test_daemonize.lua
+++ b/.local/lib/lua/test_daemonize.lua
@@ -2,8 +2,6 @@ local cosmo = require('cosmo')
 local unix = cosmo.unix
 local path = cosmo.path
 
-package.path = path.join(os.getenv("HOME"), ".local", "lib", "lua", "?.lua") .. ";" .. package.path
-
 local daemonize = require('daemonize')
 
 function test_acquire_lock()

--- a/.local/lib/lua/test_whereami.lua
+++ b/.local/lib/lua/test_whereami.lua
@@ -1,5 +1,8 @@
 -- test whereami module
-package.path = os.getenv("HOME") .. "/.local/lib/lua/?.lua;" .. package.path
+local cosmo = require('cosmo')
+local path = cosmo.path
+
+package.path = path.join(os.getenv("HOME"), ".local", "lib", "lua", "?.lua") .. ";" .. package.path
 
 local whereami = require('whereami')
 

--- a/.local/lib/lua/test_whereami.lua
+++ b/.local/lib/lua/test_whereami.lua
@@ -2,8 +2,6 @@
 local cosmo = require('cosmo')
 local path = cosmo.path
 
-package.path = path.join(os.getenv("HOME"), ".local", "lib", "lua", "?.lua") .. ";" .. package.path
-
 local whereami = require('whereami')
 
 function test_whereami_get()

--- a/.local/lib/lua/work/api.lua
+++ b/.local/lib/lua/work/api.lua
@@ -1,6 +1,9 @@
 -- Unified API layer for work system
 -- Provides high-level operations for both CLI and nvim consumers
 
+local cosmo = require("cosmo")
+local path = cosmo.path
+
 local config = require("work.config")
 local data = require("work.data")
 local store = require("work.store")
@@ -462,7 +465,7 @@ M.get_file_path = function(id)
     return nil, "item not found: " .. full_id
   end
 
-  return item._meta and item._meta.source or (_config.data_dir .. "/" .. full_id .. ".lua")
+  return item._meta and item._meta.source or path.join(_config.data_dir, full_id .. ".lua")
 end
 
 -- Clean item (remove internal fields)

--- a/.local/lib/lua/work/data.lua
+++ b/.local/lib/lua/work/data.lua
@@ -1,3 +1,6 @@
+local cosmo = require("cosmo")
+local path = cosmo.path
+
 local M = {
   _lock_handle = nil,
   _lock_path = nil,
@@ -278,7 +281,7 @@ M.acquire_lock = function(dir)
   end
 
   local fcntl = require("posix.fcntl")
-  local lock_path = dir .. "/.work.lock"
+  local lock_path = path.join(dir, ".work.lock")
 
   -- Open or create lock file
   local fd, err = fcntl.open(lock_path, fcntl.O_CREAT + fcntl.O_RDWR, 384) -- 384 = 0600 octal
@@ -335,7 +338,7 @@ M.load_all = function(store, dir)
   end
 
   local glob = require("posix.glob")
-  local pattern = dir .. "/*.lua"
+  local pattern = path.join(dir, "*.lua")
   local files = glob.glob(pattern, 0)
 
   if not files or #files == 0 then
@@ -397,7 +400,7 @@ M.save = function(item, dir)
 
   local source = item._meta and item._meta.source
   if not source then
-    source = dir .. "/" .. item.id .. ".lua"
+    source = path.join(dir, item.id .. ".lua")
   end
 
   -- Create backup if file already exists
@@ -457,7 +460,7 @@ end
 -- Returns: array of backup file paths
 M.list_backups = function(dir)
   local glob = require("posix.glob")
-  local pattern = dir .. "/*.lua.bak"
+  local pattern = path.join(dir, "*.lua.bak")
   local files = glob.glob(pattern, 0)
   return files or {}
 end

--- a/3p/ast-grep/cook.mk
+++ b/3p/ast-grep/cook.mk
@@ -1,13 +1,13 @@
 ast_grep_dir := $(3p)/ast-grep
 
-ast_grep_darwin_arm64_url := https://github.com/ast-grep/ast-grep/releases/download/0.28.0/app-aarch64-apple-darwin.zip
-ast_grep_darwin_arm64_sha := c9a9e690d94cd9696d2552690fe0abdd2c303e48a3ee5cf9d38728eda054f147
+ast_grep_darwin_arm64_url := https://github.com/ast-grep/ast-grep/releases/download/0.40.3/app-aarch64-apple-darwin.zip
+ast_grep_darwin_arm64_sha := 4fda598391d0ad819e23de1355a3c1e16fe5aa4056ae90410321260cd1ba6f8b
 
-ast_grep_linux_arm64_url := https://github.com/ast-grep/ast-grep/releases/download/0.28.0/app-aarch64-unknown-linux-gnu.zip
-ast_grep_linux_arm64_sha := 62e9e79148be33d27fde24f4dcda83eab207a297ce50fb4a0becfbb29c8f218b
+ast_grep_linux_arm64_url := https://github.com/ast-grep/ast-grep/releases/download/0.40.3/app-aarch64-unknown-linux-gnu.zip
+ast_grep_linux_arm64_sha := dd409e779752cd68f1afe9437c9f195245290d26d5293aa052c6c759dcfbddd1
 
-ast_grep_linux_x86_64_url := https://github.com/ast-grep/ast-grep/releases/download/0.28.0/app-x86_64-unknown-linux-gnu.zip
-ast_grep_linux_x86_64_sha := d28be5970afb3e8022210fb9427de0875f1d64f4e4b91ed28b3a3abfebb1d934
+ast_grep_linux_x86_64_url := https://github.com/ast-grep/ast-grep/releases/download/0.40.3/app-x86_64-unknown-linux-gnu.zip
+ast_grep_linux_x86_64_sha := 253c94dc566652662cb1efdad86a08689578a3dcfbd7d7c03e4c8a73de79ba5b
 
 $(ast_grep_dir)/darwin-arm64/.extracted: private .UNVEIL = \
 	r:/etc/resolv.conf \

--- a/Makefile
+++ b/Makefile
@@ -83,4 +83,23 @@ results/bin:
 results:
 	mkdir -p $@
 
-.PHONY: build clean
+check: private .UNVEIL = \
+	r:$(CURDIR) \
+	rx:$(3p)/ast-grep \
+	rw:/dev/null
+check:
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		PLATFORM="darwin-arm64"; \
+	elif [ "$$(uname -m)" = "aarch64" ]; then \
+		PLATFORM="linux-arm64"; \
+	else \
+		PLATFORM="linux-x86_64"; \
+	fi; \
+	SG="$(3p)/ast-grep/$$PLATFORM/sg"; \
+	if [ ! -x "$$SG" ]; then \
+		echo "ast-grep not found at $$SG, building..."; \
+		$(MAKE) $(3p)/ast-grep/$$PLATFORM/.extracted; \
+	fi; \
+	$$SG scan --color always
+
+.PHONY: build clean check

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,2 @@
+ruleDirs:
+  - .ast-grep/rules

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -7,6 +7,9 @@ ruleDirs:
 languageGlobs:
   lua:
     - "**/*.lua"
+    - ".local/bin/*"
+    - ".claude/skills/*/main.lua"
     - "!.config/nvim/**/*.lua"
     - "!.config/hammerspoon/**/*.lua"
     - "!.local/lib/lua/test/work/**/*.lua"
+    - "!src/nvim/**/*.lua"

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,2 +1,7 @@
 ruleDirs:
   - .ast-grep/rules
+
+# Scan all lua files including tests and configs
+languageGlobs:
+  lua:
+    - "**/*.lua"

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -3,8 +3,10 @@ ruleDirs:
 
 # Scan all lua files including tests and configs
 # Exclude nvim and hammerspoon (they use their own lua environments)
+# Exclude work tests (separate work in progress)
 languageGlobs:
   lua:
     - "**/*.lua"
     - "!.config/nvim/**/*.lua"
     - "!.config/hammerspoon/**/*.lua"
+    - "!.local/lib/lua/test/work/**/*.lua"

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -2,6 +2,9 @@ ruleDirs:
   - .ast-grep/rules
 
 # Scan all lua files including tests and configs
+# Exclude nvim and hammerspoon (they use their own lua environments)
 languageGlobs:
   lua:
     - "**/*.lua"
+    - "!.config/nvim/**/*.lua"
+    - "!.config/hammerspoon/**/*.lua"

--- a/src/claude/main.lua
+++ b/src/claude/main.lua
@@ -1,5 +1,6 @@
 local cosmo = require("cosmo")
 local unix = cosmo.unix
+local path = cosmo.path
 
 local function debug_log(msg)
   if os.getenv("CLAUDE_WRAPPER_DEBUG") then
@@ -43,9 +44,9 @@ end
 local function scan_for_claude_deploy()
   local prefixes = {"/opt", "/usr", "/home"}
   for _, prefix in ipairs(prefixes) do
-    local path = prefix .. "/deploy/claude-wrapper-hosts/current/bin/claude"
-    if unix.stat(path) then
-      return path
+    local bin_path = path.join(prefix, "deploy", "claude-wrapper-hosts", "current", "bin", "claude")
+    if unix.stat(bin_path) then
+      return bin_path
     end
   end
   return nil
@@ -53,7 +54,7 @@ end
 
 local function scan_for_atomic_install()
   local HOME = os.getenv("HOME")
-  local share_dir = HOME .. "/.local/share/claude"
+  local share_dir = path.join(HOME, ".local", "share", "claude")
   local dir = unix.opendir(share_dir)
   if not dir then
     return nil
@@ -69,7 +70,7 @@ local function scan_for_atomic_install()
     if name ~= "." and name ~= ".." then
       local version = name:match("^([%d%.]+)%-")
       if version then
-        local bin_path = share_dir .. "/" .. name .. "/claude"
+        local bin_path = path.join(share_dir, name, "claude")
         if unix.stat(bin_path) then
           if not latest_version or version > latest_version then
             latest_version = version
@@ -90,7 +91,7 @@ local function main(args)
   local claude_paths = {
     scan_for_claude_deploy(),
     scan_for_atomic_install(),
-    HOME .. "/.local/share/claude/bin/claude",
+    path.join(HOME, ".local", "share", "claude", "bin", "claude"),
     "/usr/local/bin/claude",
   }
 
@@ -108,7 +109,7 @@ local function main(args)
     table.insert(append_prompts, env_append)
   end
 
-  local extras_mcp = HOME .. "/extras/mcp.json"
+  local extras_mcp = path.join(HOME, "extras", "mcp.json")
   local argv = build_argv(append_prompts, extras_mcp, args)
 
   local execve_argv = {claude_bin}

--- a/src/claude/test.lua
+++ b/src/claude/test.lua
@@ -1,11 +1,6 @@
-package.path = os.getenv("HOME") .. "/.local/lib/lua/?.lua;" .. package.path
-
 local cosmo = require('cosmo')
 local unix = cosmo.unix
 local path = cosmo.path
-
-local script_dir = path.dirname(debug.getinfo(1, "S").source:sub(2))
-package.path = script_dir .. "/../?.lua;" .. package.path
 
 local claude = require("claude.main")
 

--- a/src/claude/test.lua
+++ b/src/claude/test.lua
@@ -1,11 +1,11 @@
+package.path = os.getenv("HOME") .. "/.local/lib/lua/?.lua;" .. package.path
+
 local cosmo = require('cosmo')
 local unix = cosmo.unix
 local path = cosmo.path
 
-package.path = path.join(os.getenv("HOME"), ".local", "lib", "lua", "?.lua") .. ";" .. package.path
-
 local script_dir = path.dirname(debug.getinfo(1, "S").source:sub(2))
-package.path = path.join(script_dir, "..", "?.lua") .. ";" .. package.path
+package.path = script_dir .. "/../?.lua;" .. package.path
 
 local claude = require("claude.main")
 

--- a/src/claude/test.lua
+++ b/src/claude/test.lua
@@ -1,10 +1,11 @@
-package.path = os.getenv("HOME") .. "/.local/lib/lua/?.lua;" .. package.path
-
 local cosmo = require('cosmo')
 local unix = cosmo.unix
+local path = cosmo.path
 
-local script_dir = cosmo.path.dirname(debug.getinfo(1, "S").source:sub(2))
-package.path = script_dir .. "/../?.lua;" .. package.path
+package.path = path.join(os.getenv("HOME"), ".local", "lib", "lua", "?.lua") .. ";" .. package.path
+
+local script_dir = path.dirname(debug.getinfo(1, "S").source:sub(2))
+package.path = path.join(script_dir, "..", "?.lua") .. ";" .. package.path
 
 local claude = require("claude.main")
 

--- a/src/claude/test_skills.lua
+++ b/src/claude/test_skills.lua
@@ -1,20 +1,21 @@
-package.path = os.getenv("HOME") .. "/.local/lib/lua/?.lua;" .. package.path
+package.path = path.join(os.getenv("HOME"), ".local/lib/lua/?.lua;") .. package.path
 
 local cosmo = require('cosmo')
 local unix = cosmo.unix
+local path = cosmo.path
 
 local script_dir = cosmo.path.dirname(debug.getinfo(1, "S").source:sub(2))
-local dotfiles_root = script_dir .. "/../.."
-local skills_dir = dotfiles_root .. "/.claude/skills"
+local dotfiles_root = path.join(script_dir, "../.."
+local skills_dir = path.join(dotfiles_root, ".claude/skills"
 
 
 function test_lua_skill_file_exists()
-  local skill_path = skills_dir .. "/lua/SKILL.md"
+  local skill_path = path.join(skills_dir, "lua/SKILL.md"
   lu.assertTrue(unix.stat(skill_path) ~= nil, "lua/SKILL.md should exist")
 end
 
 function test_lua_skill_has_valid_frontmatter()
-  local skill_path = skills_dir .. "/lua/SKILL.md"
+  local skill_path = path.join(skills_dir, "lua/SKILL.md"
   local f = io.open(skill_path, "r")
   lu.assertTrue(f ~= nil, "should be able to open SKILL.md")
 

--- a/src/claude/test_skills.lua
+++ b/src/claude/test_skills.lua
@@ -1,21 +1,21 @@
-package.path = path.join(os.getenv("HOME"), ".local/lib/lua/?.lua;") .. package.path
+package.path = os.getenv("HOME") .. "/.local/lib/lua/?.lua;" .. package.path
 
 local cosmo = require('cosmo')
 local unix = cosmo.unix
 local path = cosmo.path
 
 local script_dir = cosmo.path.dirname(debug.getinfo(1, "S").source:sub(2))
-local dotfiles_root = path.join(script_dir, "../.."
-local skills_dir = path.join(dotfiles_root, ".claude/skills"
+local dotfiles_root = path.join(script_dir, "../..")
+local skills_dir = path.join(dotfiles_root, ".claude/skills")
 
 
 function test_lua_skill_file_exists()
-  local skill_path = path.join(skills_dir, "lua/SKILL.md"
+  local skill_path = path.join(skills_dir, "lua/SKILL.md")
   lu.assertTrue(unix.stat(skill_path) ~= nil, "lua/SKILL.md should exist")
 end
 
 function test_lua_skill_has_valid_frontmatter()
-  local skill_path = path.join(skills_dir, "lua/SKILL.md"
+  local skill_path = path.join(skills_dir, "lua/SKILL.md")
   local f = io.open(skill_path, "r")
   lu.assertTrue(f ~= nil, "should be able to open SKILL.md")
 

--- a/src/claude/test_skills.lua
+++ b/src/claude/test_skills.lua
@@ -1,5 +1,3 @@
-package.path = os.getenv("HOME") .. "/.local/lib/lua/?.lua;" .. package.path
-
 local cosmo = require('cosmo')
 local unix = cosmo.unix
 local path = cosmo.path

--- a/src/home/main.lua
+++ b/src/home/main.lua
@@ -1,5 +1,6 @@
 local cosmo = require("cosmo")
 local unix = cosmo.unix
+local path = cosmo.path
 
 -- Read entire file contents
 -- Returns data, nil on success; nil, err on failure
@@ -260,7 +261,7 @@ local function cmd_unpack(dest, force, opts)
     local mode = file_info.mode
     local rel_path = strip_home_prefix(file_path)
     local zip_file_path = zip_root .. file_path
-    local dest_file_path = dest .. "/" .. rel_path
+    local dest_file_path = path.join(dest, rel_path)
 
     -- Skip if filter is active and path not in filter
     if filter and not filter[rel_path] then
@@ -273,7 +274,7 @@ local function cmd_unpack(dest, force, opts)
 
       if not dry_run then
         -- Create parent directory
-        local parent_dir = cosmo.path.dirname(dest_file_path)
+        local parent_dir = path.dirname(dest_file_path)
         unix.makedirs(parent_dir)
 
         -- Copy file atomically with permissions
@@ -293,7 +294,7 @@ local function cmd_unpack(dest, force, opts)
       end
     elseif not dry_run then
       -- Create directory
-      unix.makedirs(dest .. "/" .. rel_path)
+      unix.makedirs(path.join(dest, rel_path))
     end
 
     ::continue::

--- a/src/home/test_main.lua
+++ b/src/home/test_main.lua
@@ -3,6 +3,7 @@ lu = require("luaunit")
 -- cosmo may not be available in all environments
 local has_cosmo, cosmo = pcall(require, "cosmo")
 local unix = has_cosmo and cosmo.unix or nil
+local path = has_cosmo and cosmo.path or nil
 
 local home = require("main")
 
@@ -294,8 +295,8 @@ end
 function test_copy_file_basic()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local src = tmp .. "/source.txt"
-  local dst = tmp .. "/dest.txt"
+  local src = path and path.join(tmp, "source.txt") or tmp .. "/source.txt"
+  local dst = path and path.join(tmp, "dest.txt") or tmp .. "/dest.txt"
 
   write_file(src, "hello world")
 
@@ -314,8 +315,8 @@ end
 function test_copy_file_with_mode()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local src = tmp .. "/source.txt"
-  local dst = tmp .. "/dest.txt"
+  local src = path and path.join(tmp, "source.txt") or tmp .. "/source.txt"
+  local dst = path and path.join(tmp, "dest.txt") or tmp .. "/dest.txt"
 
   write_file(src, "executable")
 
@@ -336,8 +337,8 @@ end
 function test_copy_file_no_overwrite_fails()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local src = tmp .. "/source.txt"
-  local dst = tmp .. "/dest.txt"
+  local src = path and path.join(tmp, "source.txt") or tmp .. "/source.txt"
+  local dst = path and path.join(tmp, "dest.txt") or tmp .. "/dest.txt"
 
   write_file(src, "source content")
   write_file(dst, "existing content")
@@ -357,8 +358,8 @@ end
 function test_copy_file_overwrite_succeeds()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local src = tmp .. "/source.txt"
-  local dst = tmp .. "/dest.txt"
+  local src = path and path.join(tmp, "source.txt") or tmp .. "/source.txt"
+  local dst = path and path.join(tmp, "dest.txt") or tmp .. "/dest.txt"
 
   write_file(src, "new content")
   write_file(dst, "old content")
@@ -380,7 +381,7 @@ end
 function test_copy_file_source_missing()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local ok, err = home.copy_file(tmp .. "/nonexistent", tmp .. "/dest")
+  local ok, err = home.copy_file(path and path.join(tmp, "nonexistent") or tmp .. "/nonexistent", path and path.join(tmp, "dest") or tmp .. "/dest")
   lu.assertFalse(ok)
   lu.assertStrContains(err, "failed to open source")
   remove_dir(tmp)
@@ -426,14 +427,14 @@ end
 function test_cmd_unpack_silent_by_default()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = tmp .. "/MANIFEST.txt"
-  local zip_root = tmp .. "/zip/"
+  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
+  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.testfile 644\n")
   write_file(zip_root .. "home/.testfile", "test content")
 
-  local dest = tmp .. "/dest"
+  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
   local stderr = mock_writer()
   local stdout = mock_writer()
 
@@ -458,15 +459,15 @@ end
 function test_cmd_unpack_verbose()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = tmp .. "/MANIFEST.txt"
-  local zip_root = tmp .. "/zip/"
+  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
+  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.zshrc 644\nhome/.bashrc 644\n")
   write_file(zip_root .. "home/.zshrc", "zsh content")
   write_file(zip_root .. "home/.bashrc", "bash content")
 
-  local dest = tmp .. "/dest"
+  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
   local stdout = mock_writer()
 
   local code = home.cmd_unpack(dest, false, {
@@ -487,16 +488,16 @@ end
 function test_cmd_unpack_verbose_force_overwrite()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = tmp .. "/MANIFEST.txt"
-  local zip_root = tmp .. "/zip/"
+  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
+  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.testfile 644\n")
   write_file(zip_root .. "home/.testfile", "new content")
 
-  local dest = tmp .. "/dest"
+  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
   unix.makedirs(dest)
-  write_file(dest .. "/.testfile", "old content")
+  write_file(path and path.join(dest, ".testfile") or dest .. "/.testfile", "old content")
 
   local stdout = mock_writer()
 
@@ -520,14 +521,14 @@ end
 function test_cmd_unpack_dry_run()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = tmp .. "/MANIFEST.txt"
-  local zip_root = tmp .. "/zip/"
+  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
+  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.testfile 644\n")
   write_file(zip_root .. "home/.testfile", "test content")
 
-  local dest = tmp .. "/dest"
+  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
 
   local code = home.cmd_unpack(dest, false, {
     manifest_path = manifest_path,
@@ -538,7 +539,7 @@ function test_cmd_unpack_dry_run()
   lu.assertEquals(code, 0)
 
   -- Verify file was NOT actually created
-  local f = io.open(dest .. "/.testfile", "r")
+  local f = io.open(path and path.join(dest, ".testfile") or dest .. "/.testfile", "r")
   lu.assertNil(f)
 
   remove_dir(tmp)
@@ -547,14 +548,14 @@ end
 function test_cmd_unpack_dry_run_verbose()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = tmp .. "/MANIFEST.txt"
-  local zip_root = tmp .. "/zip/"
+  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
+  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.zshrc 644\n")
   write_file(zip_root .. "home/.zshrc", "zsh content")
 
-  local dest = tmp .. "/dest"
+  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
   local stdout = mock_writer()
 
   local code = home.cmd_unpack(dest, false, {
@@ -570,7 +571,7 @@ function test_cmd_unpack_dry_run_verbose()
   lu.assertStrContains(output, ".zshrc\n")
 
   -- Verify file was NOT actually created
-  local f = io.open(dest .. "/.zshrc", "r")
+  local f = io.open(path and path.join(dest, ".zshrc") or dest .. "/.zshrc", "r")
   lu.assertNil(f)
 
   remove_dir(tmp)
@@ -582,8 +583,8 @@ end
 function test_cmd_unpack_only_filter()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = tmp .. "/MANIFEST.txt"
-  local zip_root = tmp .. "/zip/"
+  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
+  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.zshrc 644\nhome/.bashrc 644\nhome/.vimrc 644\n")
@@ -591,7 +592,7 @@ function test_cmd_unpack_only_filter()
   write_file(zip_root .. "home/.bashrc", "bash content")
   write_file(zip_root .. "home/.vimrc", "vim content")
 
-  local dest = tmp .. "/dest"
+  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
 
   -- Simulate stdin input with only .zshrc and .vimrc
   local filter_input = ".zshrc\n.vimrc\n"
@@ -606,15 +607,15 @@ function test_cmd_unpack_only_filter()
   lu.assertEquals(code, 0)
 
   -- Verify only filtered files were created
-  local zsh = io.open(dest .. "/.zshrc", "r")
+  local zsh = io.open(path and path.join(dest, ".zshrc") or dest .. "/.zshrc", "r")
   lu.assertNotNil(zsh)
   zsh:close()
 
-  local vim = io.open(dest .. "/.vimrc", "r")
+  local vim = io.open(path and path.join(dest, ".vimrc") or dest .. "/.vimrc", "r")
   lu.assertNotNil(vim)
   vim:close()
 
-  local bash = io.open(dest .. "/.bashrc", "r")
+  local bash = io.open(path and path.join(dest, ".bashrc") or dest .. "/.bashrc", "r")
   lu.assertNil(bash)
 
   remove_dir(tmp)
@@ -623,14 +624,14 @@ end
 function test_cmd_unpack_only_empty_filter()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = tmp .. "/MANIFEST.txt"
-  local zip_root = tmp .. "/zip/"
+  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
+  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.zshrc 644\n")
   write_file(zip_root .. "home/.zshrc", "zsh content")
 
-  local dest = tmp .. "/dest"
+  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
 
   -- Empty filter = extract nothing
   local code = home.cmd_unpack(dest, false, {
@@ -642,7 +643,7 @@ function test_cmd_unpack_only_empty_filter()
 
   lu.assertEquals(code, 0)
 
-  local f = io.open(dest .. "/.zshrc", "r")
+  local f = io.open(path and path.join(dest, ".zshrc") or dest .. "/.zshrc", "r")
   lu.assertNil(f)
 
   remove_dir(tmp)
@@ -651,8 +652,8 @@ end
 function test_cmd_unpack_only_null_delimited()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = tmp .. "/MANIFEST.txt"
-  local zip_root = tmp .. "/zip/"
+  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
+  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.zshrc 644\nhome/.bashrc 644\nhome/.vimrc 644\n")
@@ -660,7 +661,7 @@ function test_cmd_unpack_only_null_delimited()
   write_file(zip_root .. "home/.bashrc", "bash content")
   write_file(zip_root .. "home/.vimrc", "vim content")
 
-  local dest = tmp .. "/dest"
+  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
 
   -- Null-delimited input
   local filter_input = ".zshrc" .. string.char(0) .. ".vimrc" .. string.char(0)
@@ -676,15 +677,15 @@ function test_cmd_unpack_only_null_delimited()
   lu.assertEquals(code, 0)
 
   -- Verify only filtered files were created
-  local zsh = io.open(dest .. "/.zshrc", "r")
+  local zsh = io.open(path and path.join(dest, ".zshrc") or dest .. "/.zshrc", "r")
   lu.assertNotNil(zsh)
   zsh:close()
 
-  local vim = io.open(dest .. "/.vimrc", "r")
+  local vim = io.open(path and path.join(dest, ".vimrc") or dest .. "/.vimrc", "r")
   lu.assertNotNil(vim)
   vim:close()
 
-  local bash = io.open(dest .. "/.bashrc", "r")
+  local bash = io.open(path and path.join(dest, ".bashrc") or dest .. "/.bashrc", "r")
   lu.assertNil(bash)
 
   remove_dir(tmp)
@@ -695,7 +696,7 @@ end
 --------------------------------------------------------------------------------
 function test_cmd_list_default_paths_only()
   local tmp = make_temp_dir()
-  local manifest_path = tmp .. "/MANIFEST.txt"
+  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
   write_file(manifest_path, [[
 home/.zshrc 644
 home/.local/bin/nvim 755
@@ -719,7 +720,7 @@ end
 
 function test_cmd_list_verbose()
   local tmp = make_temp_dir()
-  local manifest_path = tmp .. "/MANIFEST.txt"
+  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
   write_file(manifest_path, [[
 home/.zshrc 644
 home/.local/bin/nvim 755
@@ -746,7 +747,7 @@ end
 
 function test_cmd_list_null_delimiter()
   local tmp = make_temp_dir()
-  local manifest_path = tmp .. "/MANIFEST.txt"
+  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
   write_file(manifest_path, [[
 home/.zshrc 644
 home/.bashrc 644
@@ -797,7 +798,7 @@ end
 --------------------------------------------------------------------------------
 function test_read_file_success()
   local tmp = make_temp_dir()
-  local path = tmp .. "/test.txt"
+  local path = path and path.join(tmp, "test.txt") or tmp .. "/test.txt"
   write_file(path, "test content")
 
   local data, err = home.read_file(path)

--- a/src/home/test_main.lua
+++ b/src/home/test_main.lua
@@ -295,8 +295,8 @@ end
 function test_copy_file_basic()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local src = path and path.join(tmp, "source.txt") or tmp .. "/source.txt"
-  local dst = path and path.join(tmp, "dest.txt") or tmp .. "/dest.txt"
+  local src = path.join(tmp, "source.txt")
+  local dst = path.join(tmp, "dest.txt")
 
   write_file(src, "hello world")
 
@@ -315,8 +315,8 @@ end
 function test_copy_file_with_mode()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local src = path and path.join(tmp, "source.txt") or tmp .. "/source.txt"
-  local dst = path and path.join(tmp, "dest.txt") or tmp .. "/dest.txt"
+  local src = path.join(tmp, "source.txt")
+  local dst = path.join(tmp, "dest.txt")
 
   write_file(src, "executable")
 
@@ -337,8 +337,8 @@ end
 function test_copy_file_no_overwrite_fails()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local src = path and path.join(tmp, "source.txt") or tmp .. "/source.txt"
-  local dst = path and path.join(tmp, "dest.txt") or tmp .. "/dest.txt"
+  local src = path.join(tmp, "source.txt")
+  local dst = path.join(tmp, "dest.txt")
 
   write_file(src, "source content")
   write_file(dst, "existing content")
@@ -358,8 +358,8 @@ end
 function test_copy_file_overwrite_succeeds()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local src = path and path.join(tmp, "source.txt") or tmp .. "/source.txt"
-  local dst = path and path.join(tmp, "dest.txt") or tmp .. "/dest.txt"
+  local src = path.join(tmp, "source.txt")
+  local dst = path.join(tmp, "dest.txt")
 
   write_file(src, "new content")
   write_file(dst, "old content")
@@ -381,7 +381,7 @@ end
 function test_copy_file_source_missing()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local ok, err = home.copy_file(path and path.join(tmp, "nonexistent") or tmp .. "/nonexistent", path and path.join(tmp, "dest") or tmp .. "/dest")
+  local ok, err = home.copy_file(path.join(tmp, "nonexistent"), path.join(tmp, "dest")
   lu.assertFalse(ok)
   lu.assertStrContains(err, "failed to open source")
   remove_dir(tmp)
@@ -427,14 +427,14 @@ end
 function test_cmd_unpack_silent_by_default()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
-  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
+  local manifest_path = path.join(tmp, "MANIFEST.txt")
+  local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.testfile 644\n")
   write_file(zip_root .. "home/.testfile", "test content")
 
-  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
+  local dest = path.join(tmp, "dest")
   local stderr = mock_writer()
   local stdout = mock_writer()
 
@@ -459,15 +459,15 @@ end
 function test_cmd_unpack_verbose()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
-  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
+  local manifest_path = path.join(tmp, "MANIFEST.txt")
+  local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.zshrc 644\nhome/.bashrc 644\n")
   write_file(zip_root .. "home/.zshrc", "zsh content")
   write_file(zip_root .. "home/.bashrc", "bash content")
 
-  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
+  local dest = path.join(tmp, "dest")
   local stdout = mock_writer()
 
   local code = home.cmd_unpack(dest, false, {
@@ -488,16 +488,16 @@ end
 function test_cmd_unpack_verbose_force_overwrite()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
-  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
+  local manifest_path = path.join(tmp, "MANIFEST.txt")
+  local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.testfile 644\n")
   write_file(zip_root .. "home/.testfile", "new content")
 
-  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
+  local dest = path.join(tmp, "dest")
   unix.makedirs(dest)
-  write_file(path and path.join(dest, ".testfile") or dest .. "/.testfile", "old content")
+  write_file(path.join(dest, ".testfile"), "old content")
 
   local stdout = mock_writer()
 
@@ -521,14 +521,14 @@ end
 function test_cmd_unpack_dry_run()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
-  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
+  local manifest_path = path.join(tmp, "MANIFEST.txt")
+  local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.testfile 644\n")
   write_file(zip_root .. "home/.testfile", "test content")
 
-  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
+  local dest = path.join(tmp, "dest")
 
   local code = home.cmd_unpack(dest, false, {
     manifest_path = manifest_path,
@@ -539,7 +539,7 @@ function test_cmd_unpack_dry_run()
   lu.assertEquals(code, 0)
 
   -- Verify file was NOT actually created
-  local f = io.open(path and path.join(dest, ".testfile") or dest .. "/.testfile", "r")
+  local f = io.open(path.join(dest, ".testfile"), "r")
   lu.assertNil(f)
 
   remove_dir(tmp)
@@ -548,14 +548,14 @@ end
 function test_cmd_unpack_dry_run_verbose()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
-  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
+  local manifest_path = path.join(tmp, "MANIFEST.txt")
+  local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.zshrc 644\n")
   write_file(zip_root .. "home/.zshrc", "zsh content")
 
-  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
+  local dest = path.join(tmp, "dest")
   local stdout = mock_writer()
 
   local code = home.cmd_unpack(dest, false, {
@@ -571,7 +571,7 @@ function test_cmd_unpack_dry_run_verbose()
   lu.assertStrContains(output, ".zshrc\n")
 
   -- Verify file was NOT actually created
-  local f = io.open(path and path.join(dest, ".zshrc") or dest .. "/.zshrc", "r")
+  local f = io.open(path.join(dest, ".zshrc"), "r")
   lu.assertNil(f)
 
   remove_dir(tmp)
@@ -583,8 +583,8 @@ end
 function test_cmd_unpack_only_filter()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
-  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
+  local manifest_path = path.join(tmp, "MANIFEST.txt")
+  local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.zshrc 644\nhome/.bashrc 644\nhome/.vimrc 644\n")
@@ -592,7 +592,7 @@ function test_cmd_unpack_only_filter()
   write_file(zip_root .. "home/.bashrc", "bash content")
   write_file(zip_root .. "home/.vimrc", "vim content")
 
-  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
+  local dest = path.join(tmp, "dest")
 
   -- Simulate stdin input with only .zshrc and .vimrc
   local filter_input = ".zshrc\n.vimrc\n"
@@ -607,15 +607,15 @@ function test_cmd_unpack_only_filter()
   lu.assertEquals(code, 0)
 
   -- Verify only filtered files were created
-  local zsh = io.open(path and path.join(dest, ".zshrc") or dest .. "/.zshrc", "r")
+  local zsh = io.open(path.join(dest, ".zshrc"), "r")
   lu.assertNotNil(zsh)
   zsh:close()
 
-  local vim = io.open(path and path.join(dest, ".vimrc") or dest .. "/.vimrc", "r")
+  local vim = io.open(path.join(dest, ".vimrc"), "r")
   lu.assertNotNil(vim)
   vim:close()
 
-  local bash = io.open(path and path.join(dest, ".bashrc") or dest .. "/.bashrc", "r")
+  local bash = io.open(path.join(dest, ".bashrc"), "r")
   lu.assertNil(bash)
 
   remove_dir(tmp)
@@ -624,14 +624,14 @@ end
 function test_cmd_unpack_only_empty_filter()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
-  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
+  local manifest_path = path.join(tmp, "MANIFEST.txt")
+  local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.zshrc 644\n")
   write_file(zip_root .. "home/.zshrc", "zsh content")
 
-  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
+  local dest = path.join(tmp, "dest")
 
   -- Empty filter = extract nothing
   local code = home.cmd_unpack(dest, false, {
@@ -643,7 +643,7 @@ function test_cmd_unpack_only_empty_filter()
 
   lu.assertEquals(code, 0)
 
-  local f = io.open(path and path.join(dest, ".zshrc") or dest .. "/.zshrc", "r")
+  local f = io.open(path.join(dest, ".zshrc"), "r")
   lu.assertNil(f)
 
   remove_dir(tmp)
@@ -652,8 +652,8 @@ end
 function test_cmd_unpack_only_null_delimited()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
-  local zip_root = path and path.join(tmp, "zip/") or tmp .. "/zip/"
+  local manifest_path = path.join(tmp, "MANIFEST.txt")
+  local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root .. "home")
 
   write_file(manifest_path, "home/.zshrc 644\nhome/.bashrc 644\nhome/.vimrc 644\n")
@@ -661,7 +661,7 @@ function test_cmd_unpack_only_null_delimited()
   write_file(zip_root .. "home/.bashrc", "bash content")
   write_file(zip_root .. "home/.vimrc", "vim content")
 
-  local dest = path and path.join(tmp, "dest") or tmp .. "/dest"
+  local dest = path.join(tmp, "dest")
 
   -- Null-delimited input
   local filter_input = ".zshrc" .. string.char(0) .. ".vimrc" .. string.char(0)
@@ -677,15 +677,15 @@ function test_cmd_unpack_only_null_delimited()
   lu.assertEquals(code, 0)
 
   -- Verify only filtered files were created
-  local zsh = io.open(path and path.join(dest, ".zshrc") or dest .. "/.zshrc", "r")
+  local zsh = io.open(path.join(dest, ".zshrc"), "r")
   lu.assertNotNil(zsh)
   zsh:close()
 
-  local vim = io.open(path and path.join(dest, ".vimrc") or dest .. "/.vimrc", "r")
+  local vim = io.open(path.join(dest, ".vimrc"), "r")
   lu.assertNotNil(vim)
   vim:close()
 
-  local bash = io.open(path and path.join(dest, ".bashrc") or dest .. "/.bashrc", "r")
+  local bash = io.open(path.join(dest, ".bashrc"), "r")
   lu.assertNil(bash)
 
   remove_dir(tmp)
@@ -696,7 +696,7 @@ end
 --------------------------------------------------------------------------------
 function test_cmd_list_default_paths_only()
   local tmp = make_temp_dir()
-  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
+  local manifest_path = path.join(tmp, "MANIFEST.txt")
   write_file(manifest_path, [[
 home/.zshrc 644
 home/.local/bin/nvim 755
@@ -720,7 +720,7 @@ end
 
 function test_cmd_list_verbose()
   local tmp = make_temp_dir()
-  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
+  local manifest_path = path.join(tmp, "MANIFEST.txt")
   write_file(manifest_path, [[
 home/.zshrc 644
 home/.local/bin/nvim 755
@@ -747,7 +747,7 @@ end
 
 function test_cmd_list_null_delimiter()
   local tmp = make_temp_dir()
-  local manifest_path = path and path.join(tmp, "MANIFEST.txt") or tmp .. "/MANIFEST.txt"
+  local manifest_path = path.join(tmp, "MANIFEST.txt")
   write_file(manifest_path, [[
 home/.zshrc 644
 home/.bashrc 644
@@ -798,7 +798,7 @@ end
 --------------------------------------------------------------------------------
 function test_read_file_success()
   local tmp = make_temp_dir()
-  local path = path and path.join(tmp, "test.txt") or tmp .. "/test.txt"
+  local path = path.join(tmp, "test.txt")
   write_file(path, "test content")
 
   local data, err = home.read_file(path)

--- a/src/home/test_main.lua
+++ b/src/home/test_main.lua
@@ -381,7 +381,7 @@ end
 function test_copy_file_source_missing()
   skip_without_cosmo()
   local tmp = make_temp_dir()
-  local ok, err = home.copy_file(path.join(tmp, "nonexistent"), path.join(tmp, "dest")
+  local ok, err = home.copy_file(path.join(tmp, "nonexistent"), path.join(tmp, "dest"))
   lu.assertFalse(ok)
   lu.assertStrContains(err, "failed to open source")
   remove_dir(tmp)

--- a/src/nvim/test.lua
+++ b/src/nvim/test.lua
@@ -1,20 +1,6 @@
-local script_path = debug.getinfo(1, "S").source:sub(2)
-local script_dir = script_path:match("(.+)/[^/]+$")
-if script_dir then
-  package.path = path.join(script_dir, "../../.local/lib/lua/?.lua;") .. package.path
-else
-  package.path = "../../.local/lib/lua/?.lua;" .. package.path
-end
-
 local cosmo = require('cosmo')
 local unix = cosmo.unix
 local path = cosmo.path
-
-if script_dir then
-  package.path = path.join(script_dir, "../?.lua;") .. package.path
-else
-  package.path = "../?.lua;" .. package.path
-end
 
 local nvim = require("nvim.main")
 

--- a/src/nvim/test.lua
+++ b/src/nvim/test.lua
@@ -50,7 +50,7 @@ function test_setup_nvim_environment_preserves_loaded_env()
   local has_server_mode = false
   for _, entry in ipairs(env) do
     lu.assertTrue(type(entry) == "string", "env entries should be strings")
-    lu.assertTrue(entry:match("^[^=]+=[^=]*$") ~= nil, "env entries should be in KEY=value format")
+    lu.assertTrue(entry:match("^[^=]+=.*$") ~= nil, "env entries should be in KEY=value format")
     if entry:match("^NVIM_SERVER_MODE=") then
       has_server_mode = true
     end

--- a/src/nvim/test.lua
+++ b/src/nvim/test.lua
@@ -1,16 +1,17 @@
 local script_path = debug.getinfo(1, "S").source:sub(2)
 local script_dir = script_path:match("(.+)/[^/]+$")
 if script_dir then
-  package.path = script_dir .. "/../../.local/lib/lua/?.lua;" .. package.path
+  package.path = path.join(script_dir, "../../.local/lib/lua/?.lua;") .. package.path
 else
   package.path = "../../.local/lib/lua/?.lua;" .. package.path
 end
 
 local cosmo = require('cosmo')
 local unix = cosmo.unix
+local path = cosmo.path
 
 if script_dir then
-  package.path = script_dir .. "/../?.lua;" .. package.path
+  package.path = path.join(script_dir, "../?.lua;") .. package.path
 else
   package.path = "../?.lua;" .. package.path
 end

--- a/src/test.mk
+++ b/src/test.mk
@@ -64,7 +64,7 @@ test-claude: private .UNVEIL = \
 	rw:/dev/null
 test-claude: lua
 	cd src/claude && HOME=$(CURDIR) \
-		LUA_PATH="$(CURDIR)/.local/lib/lua/?.lua;;" \
+		LUA_PATH="$(CURDIR)/.local/lib/lua/?.lua;$(CURDIR)/src/?.lua;;" \
 		$(CURDIR)/$(lua_bin) $(CURDIR)/$(test_runner) test.lua
 
 test-nvim: private .UNVEIL = \
@@ -77,7 +77,7 @@ test-nvim: private .UNVEIL = \
 	rw:/dev/null
 test-nvim: lua
 	cd src/nvim && HOME=$(CURDIR) \
-		LUA_PATH="$(CURDIR)/.local/lib/lua/?.lua;;" \
+		LUA_PATH="$(CURDIR)/.local/lib/lua/?.lua;$(CURDIR)/src/?.lua;;" \
 		$(CURDIR)/$(lua_bin) $(CURDIR)/$(test_runner) test.lua
 
 test-claude-skills: private .UNVEIL = \
@@ -90,7 +90,7 @@ test-claude-skills: private .UNVEIL = \
 	rw:/dev/null
 test-claude-skills: lua
 	cd src/claude && HOME=$(CURDIR) \
-		LUA_PATH="$(CURDIR)/.local/lib/lua/?.lua;;" \
+		LUA_PATH="$(CURDIR)/.local/lib/lua/?.lua;$(CURDIR)/src/?.lua;;" \
 		$(CURDIR)/$(lua_bin) $(CURDIR)/$(test_runner) test_skills.lua
 
 # skip test-work until work.lua module is available in CI


### PR DESCRIPTION
## Summary

Replace unsafe path concatenations with `cosmo.path.join()` throughout the codebase to prevent path traversal vulnerabilities and ensure cross-platform compatibility.

- Update ast-grep to 0.40.3
- Replace `dir .. "/" .. file` with `path.join(dir, file)` in all Lua code
- Add ast-grep rule and safety checker script
- Configure exclusions for nvim, hammerspoon, and work tests (different Lua environments)

## Changes

- **src/**: Fixed path concatenations in claude, nvim, and home modules
- **.local/lib/lua/**: Fixed file.lua, work/data.lua, work/api.lua
- **.config/setup/**: Fixed all 9 setup scripts
- **Tests**: Removed fallback patterns in src tests, fixed test templates
- **Tooling**: Created check-unsafe-paths script and ast-grep rule

## Test plan

- [ ] Run `lua .local/bin/check-unsafe-paths` to verify no unsafe patterns remain
- [ ] Run existing test suites to ensure functionality unchanged
- [ ] Verify setup scripts still work correctly