### PR TITLE
nvim: fix environment loading and cross-platform compatibility

### DIFF
--- a/.local/lib/lua/whereami.lua
+++ b/.local/lib/lua/whereami.lua
@@ -1,8 +1,8 @@
 -- Module to get hostname or box-name/host_env identifier
 local M = {}
 
-local cosmo = require('cosmo')
-local unix = cosmo.unix
+local ok, cosmo = pcall(require, 'cosmo')
+local unix = ok and cosmo.unix or nil
 
 -- Function to trim whitespace
 local function trim(s)
@@ -22,6 +22,14 @@ end
 
 -- Function to check if file exists
 local function file_exists(path)
+  if not unix then
+    local f = io.open(path, 'r')
+    if f then
+      f:close()
+      return true
+    end
+    return false
+  end
   return unix.access(path, unix.F_OK)
 end
 
@@ -32,6 +40,11 @@ local cached_conf_dir = nil
 local function find_conf_dir()
   if cached_conf_dir ~= nil then
     return cached_conf_dir
+  end
+
+  if not unix then
+    cached_conf_dir = false
+    return nil
   end
 
   local dir = unix.opendir('/')

--- a/src/nvim/main.lua
+++ b/src/nvim/main.lua
@@ -151,6 +151,12 @@ end
 
 local function load_zsh_environment()
   local env = {}
+
+  local zsh_path = unix.commandv("zsh")
+  if not zsh_path then
+    return env
+  end
+
   local read_fd, write_fd = unix.pipe()
   if not read_fd then
     return env
@@ -167,7 +173,7 @@ local function load_zsh_environment()
     unix.close(read_fd)
     unix.dup(write_fd, 1)
     unix.close(write_fd)
-    unix.execve("/usr/bin/zsh", {"zsh", "-l", "-c", "env -0"}, unix.environ())
+    unix.execve(zsh_path, {"zsh", "-l", "-c", "env -0"}, unix.environ())
     unix.exit(1)
   else
     unix.close(write_fd)
@@ -320,7 +326,7 @@ end
 
 local function cmd_restart(paths)
   cmd_stop(paths)
-  unix.sleep(1)
+  unix.nanosleep(1, 0)
   return cmd_start(paths)
 end
 


### PR DESCRIPTION
## Summary
- Use `unix.commandv` to dynamically find zsh instead of hardcoded path
- Fix `whereami.lua` to work in neovim without cosmo module
- Fix `unix.sleep` → `unix.nanosleep` in restart command

## Details

### nvim daemon environment loading
The nvim daemon was failing to load environment variables because it tried to execute `/usr/bin/zsh`, which doesn't exist on all systems (zsh is at `/bin/zsh` on macOS). This caused HOME and PATH to be empty, breaking plugins that depend on git and other tools.

Changed to use `unix.commandv("zsh")` to dynamically find zsh in PATH.

### whereami module compatibility
The `whereami.lua` module was failing when loaded in neovim because it assumed `cosmo.unix` would always be available. Added fallbacks for environments without cosmo:
- Use `pcall` to gracefully handle missing cosmo
- Fallback to `io.open` for file existence checks
- Skip directory scanning when unix bindings unavailable

### Minor fix
Fixed `unix.sleep(1)` → `unix.nanosleep(1, 0)` in cmd_restart (sleep doesn't exist in cosmo.unix).

## Test plan
- [x] Verified nvim daemon starts and loads full environment
- [x] Verified HOME and PATH are set correctly
- [x] Verified git is found by plugins
- [x] Verified whereami module works in neovim