### PR TITLE
path: remove shimlink/bin directory from PATH

### DIFF
--- a/.claude/skills/nvim/SKILL.md
+++ b/.claude/skills/nvim/SKILL.md
@@ -10,7 +10,8 @@ This skill provides comprehensive knowledge for interacting with Neovim in this 
 ## Architecture
 
 ### Binary management
-- Actual nvim binary managed by shimlink at `~/.local/share/shimlink/bin/nvim`
+- Nvim binary installed to `~/.local/share/nvim/<version>-<sha>/bin/nvim`
+- Symlinked from `~/.local/bin/nvim` (managed by `home 3p`)
 - Custom nvim builds with bundled plugins available via `.github/workflows/build-nvim.yml`
 
 ### Configuration structure

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -427,6 +427,6 @@ bin/work show {id}
   - `render.lua` - Formatting and display
 - ULID library is global (`~/.local/lib/lua/ulid.lua`)
 - Each work item is a separate file for version control friendliness
-- Uses `Work{}` callback pattern like shimlink's `Version{}`
+- Uses `Work{}` callback pattern for data definition
 - Commands follow Load → Process → Render pattern
 - Enrichment pattern computes derived fields once, renders many times

--- a/.config/setup/env.lua
+++ b/.config/setup/env.lua
@@ -16,7 +16,6 @@ local function get()
 
 	local path_parts = {
 		path.join(env.DST, ".local", "bootstrap", "bin"),
-		path.join(env.DST, ".local", "share", "shimlink", "bin"),
 		path.join(env.DST, ".local", "bin"),
 		path.join(env.DST, "extras", "bin"),
 		os.getenv("PATH") or "",

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ paste.*
 .lesshst
 .local/bin/claude
 .local/bin/debugpy
-.local/bin/lua-shimlink
 .local/bin/debugpy-adapter
 .local/bin/f2py
 .local/bin/fonttools

--- a/.zshenv
+++ b/.zshenv
@@ -3,7 +3,6 @@ typeset -aU path
 path=(
   "$HOME/.local/bin"
   "$HOME/.local/bootstrap/bin"
-  "$HOME/.local/share/shimlink/bin"
   "/Applications/Ghostty.app/Contents/MacOS"
   "/Applications/Hammerspoon.app/Contents/Frameworks/hs"
   "/Library/Application Support/org.pqrs/Karabiner-Elements/bin"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A reproducible and complete environment for computering since 2005.
 - Everything works on (Mac) laptop, GitHub codespaces, and internal devboxes (and three architectures)
 - `claude` works
 - `scpaste` (and `CMD-Shift-v` in `Ghostty`) copies rich clipboard contents to any active SSH connection
-- `shimlink` fetches utility executables and verifies checksums
+- `home 3p` manages versioned third-party binaries with checksum verification
 
 ## License
 


### PR DESCRIPTION
## Summary

Remove `~/.local/share/shimlink/bin/` from PATH since the new `home 3p` system creates symlinks directly in `~/.local/bin/`.

## Changes

- Remove shimlink/bin from `.zshenv` path array
- Remove shimlink/bin from `.config/setup/env.lua` PATH construction  
- Remove lua-shimlink binary entry from `.gitignore`
- Update README.md feature list to reference 'home 3p' instead of shimlink
- Update nvim and work skill documentation to reflect new binary management

## Context

After PR #31 introduced the `home 3p` command for versioned 3p binary management, the old shimlink directory is no longer needed in PATH. The new system installs binaries to `~/.local/share/<tool>/<version>-<sha>/` and creates symlinks in `~/.local/bin/`, which is already in PATH.

The `3p/shimlink/cook.mk` build system remains unchanged as it's still used to download binaries during the build process.