### PR TITLE
claude: switch model to opus

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,10 +26,10 @@
       "Bash(npm test:*)"
     ]
   },
+  "model": "opus",
   "alwaysThinkingEnabled": true,
   "feedbackSurveyState": {
     "lastShownTime": 1754368507584
   },
-  "installMethod": "unknown",
-  "model": "opusplan"
+  "installMethod": "unknown"
 }


### PR DESCRIPTION
## Summary
- Switch Claude model from `opusplan` to `opus`

## Test plan
- Verify model setting takes effect