### PR TITLE
lua: fix LUA_PATH to include init.lua patterns

### DIFF
--- a/.config/setup/env.lua
+++ b/.config/setup/env.lua
@@ -23,10 +23,12 @@ local function get()
 	env.PATH = table.concat(path_parts, ":")
 
 	local lua_path_parts = {
-		path.join(env.DST, ".local", "bootstrap", "lib", "lua", "?.lua"),
-		path.join(env.DST, ".local", "bootstrap", "lib", "lua", "?", "init.lua"),
-		path.join(env.DST, ".local", "lib", "lua", "?.lua"),
-		path.join(env.DST, ".local", "lib", "lua", "?", "init.lua"),
+		path.join(env.DST, "extras", "lua", "?.lua"),
+		path.join(env.DST, "extras", "lua", "?", "init.lua"),
+		path.join(env.DST, "extras", "lua", "3p", "?.lua"),
+		path.join(env.DST, "lib", "?.lua"),
+		path.join(env.DST, "lib", "?", "init.lua"),
+		path.join(env.DST, "lib", "3p", "?.lua"),
 		"",
 	}
 	env.LUA_PATH = table.concat(lua_path_parts, ";")

--- a/.local/bin/gh
+++ b/.local/bin/gh
@@ -4,9 +4,6 @@ local cosmo = require("cosmo")
 local unix = cosmo.unix
 local path = cosmo.path
 
-local script_dir = path.dirname(path.dirname(path.dirname(debug.getinfo(1, "S").source:sub(2))))
-package.path = script_dir .. "/src/?.lua;" .. script_dir .. "/src/?/init.lua;" .. package.path
-
 local environ = require("environ")
 
 local invoked_as = path.basename(arg[0])

--- a/.zshenv
+++ b/.zshenv
@@ -16,8 +16,10 @@ typeset -aU lua_path
 
 lua_path=(
   "$HOME/extras/lua/?.lua"
+  "$HOME/extras/lua/?/init.lua"
   "$HOME/extras/lua/3p/?.lua"
   "$HOME/lib/?.lua"
+  "$HOME/lib/?/init.lua"
   "$HOME/lib/3p/?.lua"
 )
 

--- a/lib/test/work/run.lua
+++ b/lib/test/work/run.lua
@@ -2,8 +2,7 @@
 
 local lu = require("luaunit")
 
-package.path = os.getenv("HOME") .. "/lib/?.lua;"
-  .. os.getenv("HOME") .. "/lib/test/work/?.lua;" .. package.path
+package.path = os.getenv("HOME") .. "/lib/test/work/?.lua;" .. package.path
 
 require("command-blocked")
 require("blockers")


### PR DESCRIPTION
## Summary
- Remove `package.path` manipulation from `gh` wrapper (now relies on `LUA_PATH`)
- Add `?/init.lua` patterns to `.zshenv` for `extras/lua` and `lib` directories
- Update `.config/setup/env.lua` to match consolidated `lib/` paths from PR #40
- Remove redundant path entry from test runner

Fixes gh wrapper failing with "module 'environ' not found" after PR #40 consolidated lua libraries.

## Test plan
- Start new shell session to pick up updated `LUA_PATH`
- Run `gh --version` to verify wrapper works