### PR TITLE
check: fix make target dependencies and add luacheck config

### DIFF
--- a/.config/setup/claude.lua
+++ b/.config/setup/claude.lua
@@ -3,6 +3,9 @@ local unix = cosmo.unix
 local path = cosmo.path
 local util = require("util")
 
+local CLAUDE_BASE_URL = "https://storage.googleapis.com/" ..
+	"claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819"
+
 local function get_latest_version()
 	local handle = io.popen("gh api repos/anthropics/claude-code/releases/latest --jq '.tag_name'", "r")
 	if not handle then
@@ -45,10 +48,7 @@ local function print_latest()
 		return 1
 	end
 
-	local url = string.format(
-		"https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/%s/linux-x64/claude",
-		version
-	)
+	local url = string.format("%s/claude-code-releases/%s/linux-x64/claude", CLAUDE_BASE_URL, version)
 
 	io.write("Fetching SHA256 for version " .. version .. "...\n")
 	local sha256 = get_sha256(url)
@@ -68,9 +68,7 @@ local function run(env)
 		local CLAUDE_VERSION = "2.0.74"
 		local CLAUDE_SHA256 = "43065ff86a1b952225e42042bf4dfe9f6b72ff8ed91686a23add5396b1a11e80"
 		local CLAUDE_URL = string.format(
-			"https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/%s/linux-x64/claude",
-			CLAUDE_VERSION
-		)
+			"%s/claude-code-releases/%s/linux-x64/claude", CLAUDE_BASE_URL, CLAUDE_VERSION)
 
 		local short_sha = CLAUDE_SHA256:sub(1, 8)
 		local version_dir = path.join(env.DST, ".local", "share", "claude", string.format("%s-%s", CLAUDE_VERSION, short_sha))

--- a/.config/setup/validate.lua
+++ b/.config/setup/validate.lua
@@ -1,6 +1,8 @@
-package.path = "/workspaces/dotfiles/.config/setup/?.lua;/home/codespace/.local/bootstrap/lib/lua/?.lua;/home/codespace/.local/bootstrap/lib/lua/?/init.lua;;"
+package.path = "/workspaces/dotfiles/.config/setup/?.lua;" ..
+	"/home/codespace/.local/bootstrap/lib/lua/?.lua;" ..
+	"/home/codespace/.local/bootstrap/lib/lua/?/init.lua;;"
 
-local cosmo = require("cosmo")
+local cosmo = require("cosmo") -- luacheck: ignore
 
 print("validating setup scripts...")
 print()

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,68 @@
+std = "lua54"
+max_line_length = 120
+allow_defined_top = true
+
+ignore = {
+  "131/test_.*",
+  "131/Test.*",
+  "212/self",
+}
+
+read_globals = {
+  "jit",
+  "setfenv",
+}
+
+globals = {
+  "lu",
+}
+
+-- Baseline suppressions - tighten over time
+-- 211: unused variable
+-- 212: unused argument
+-- 213: unused loop variable
+-- 311: value assigned is unused
+-- 411: variable was previously defined
+-- 412: variable previously defined on line N
+-- 421: shadowing definition of variable
+-- 431: shadowing upvalue
+
+files[".config/setup/test.lua"] = { ignore = { "211" } }
+files[".config/setup/util.lua"] = { ignore = { "211" } }
+
+files["lib/claude/main.lua"] = { ignore = { "211", "431" } }
+files["lib/claude/test.lua"] = { ignore = { "211" } }
+
+files["lib/daemonize.lua"] = { ignore = { "211", "411" } }
+
+files["lib/file.lua"] = { ignore = { "211", "431" } }
+
+files["lib/home/main.lua"] = { ignore = { "211", "431" } }
+files["lib/home/test_main.lua"] = { ignore = { "211", "431" } }
+
+files["lib/nvim/main.lua"] = {
+  ignore = { "211", "431" },
+  globals = { "pid" },
+}
+files["lib/nvim/test.lua"] = { ignore = { "211" } }
+
+files["lib/run-test.lua"] = { ignore = { "122" } }
+
+files["lib/symbols/dump.lua"] = { ignore = { "411" } }
+
+files["lib/test_daemonize.lua"] = { ignore = { "211" } }
+files["lib/test_whereami.lua"] = { ignore = { "211" } }
+
+files["lib/version.lua"] = { ignore = { "411", "421" } }
+
+files["lib/work/api.lua"] = { ignore = { "411", "421" } }
+files["lib/work/data.lua"] = { ignore = { "211", "411", "421", "431" } }
+files["lib/work/process.lua"] = { ignore = { "211" } }
+files["lib/work/render.lua"] = { ignore = { "212", "311" } }
+files["lib/work/validate.lua"] = { ignore = { "212" } }
+
+files["lib/work/test_backup.lua"] = { ignore = { "411" } }
+files["lib/work/test_command_blocked.lua"] = { ignore = { "211" } }
+files["lib/work/test_file_locking.lua"] = { ignore = { "211", "411" } }
+files["lib/work/test_orphaned_blocks.lua"] = { ignore = { "211" } }
+files["lib/work/test_validate_blocks.lua"] = { ignore = { "211" } }

--- a/lib/home/main.lua
+++ b/lib/home/main.lua
@@ -135,7 +135,7 @@ local function extract_tools(files)
 end
 
 -- Parse command-line arguments
--- Returns {cmd=string, subcmd=string|nil, force=bool, verbose=bool, dry_run=bool, only=bool, null=bool, dest=string|nil}
+-- Returns {cmd, subcmd, force, verbose, dry_run, only, null, dest}
 local function parse_args(args)
   local result = {
     cmd = args[1] or "help",

--- a/lib/test_whereami.lua
+++ b/lib/test_whereami.lua
@@ -18,5 +18,6 @@ function test_whereami_get_with_emoji()
   lu.assertIsString(identifier, "whereami.get_with_emoji() should return a string")
   lu.assertTrue(#identifier > 0, "whereami.get_with_emoji() should return a non-empty string")
   -- Should contain a space (separating identifier and emoji)
-  lu.assertNotNil(identifier:find(" "), "whereami.get_with_emoji() should contain identifier and emoji separated by space")
+  lu.assertNotNil(identifier:find(" "),
+    "whereami.get_with_emoji() should contain identifier and emoji separated by space")
 end

--- a/lib/version.lua
+++ b/lib/version.lua
@@ -40,7 +40,9 @@ local function validate_config(config)
     end
 
     if #platform_data.sha256 ~= 64 then
-      return nil, string.format("platform '%s' field 'sha256' must be 64 characters (SHA-256 hex), got %d", plat, #platform_data.sha256)
+      return nil, string.format(
+        "platform '%s' field 'sha256' must be 64 characters (SHA-256 hex), got %d",
+        plat, #platform_data.sha256)
     end
 
     if platform_data.arch and type(platform_data.arch) ~= "string" then
@@ -77,7 +79,9 @@ local function validate_config(config)
       return nil, string.format("field 'strip_components' must be number, got %s", type(config.strip_components))
     end
     if config.strip_components < 0 or config.strip_components ~= math.floor(config.strip_components) then
-      return nil, string.format("field 'strip_components' must be non-negative integer, got %s", tostring(config.strip_components))
+      return nil, string.format(
+        "field 'strip_components' must be non-negative integer, got %s",
+        tostring(config.strip_components))
     end
   end
 


### PR DESCRIPTION
## Summary
- Fix `make check` to have proper dependencies so `make clean check` works
- Add platform detection for ast-grep binary selection
- Create `.luacheckrc` with baseline suppressions as a ratchet to tighten over time
- Fix line-too-long issues in a few files

## Test plan
- [x] `make clean check` passes with 0 warnings/0 errors