### PR TITLE
spawn: consolidate spawn functions into lib/spawn module

### DIFF
--- a/.config/setup/env.lua
+++ b/.config/setup/env.lua
@@ -1,6 +1,7 @@
 local cosmo = require("cosmo")
 local unix = cosmo.unix
 local path = cosmo.path
+local spawn = require("spawn").spawn
 
 local function get()
 	local env = {}
@@ -35,11 +36,9 @@ local function get()
 
 	env.SHELLINIT = path.join(env.DST, ".config", "shellinit")
 
-	local handle = io.popen("git config --get remote.origin.url 2>/dev/null", "r")
-	if handle then
-		local remote = handle:read("*l")
-		handle:close()
-		env.REMOTE = remote or ""
+	local ok, output = spawn({"git", "config", "--get", "remote.origin.url"}):read()
+	if ok and output then
+		env.REMOTE = output:gsub("%s+$", "")
 	else
 		env.REMOTE = ""
 	end

--- a/.config/setup/shell.lua
+++ b/.config/setup/shell.lua
@@ -1,19 +1,18 @@
 local cosmo = require("cosmo")
 local unix = cosmo.unix
 local path = cosmo.path
-local util = require("util")
+local spawn = require("spawn").spawn
 
 local function run(env)
-	local handle = io.popen("id -un", "r")
-	if not handle then
+	local ok, output = spawn({"id", "-un"}):read()
+	if not ok then
 		return 1
 	end
-	local username = handle:read("*l")
-	handle:close()
+	local username = output:gsub("%s+$", "")
 
 	local zsh_path = unix.commandv("zsh")
 	if zsh_path then
-		util.spawn({"sudo", "chsh", username, "--shell", zsh_path})
+		spawn({"sudo", "chsh", username, "--shell", zsh_path}):wait()
 	end
 
 	local bashrc = path.join(env.DST, ".bashrc")

--- a/.config/setup/util.lua
+++ b/.config/setup/util.lua
@@ -1,58 +1,10 @@
-local cosmo = require("cosmo")
-local unix = cosmo.unix
-
-local function spawn(argv, opts)
-	opts = opts or {}
-	local cmd = unix.commandv(argv[1])
-	if not cmd then
-		return nil, "command not found: " .. argv[1]
-	end
-
-	local pid = unix.fork()
-	if pid == 0 then
-		if opts.silent then
-			local devnull = unix.open("/dev/null", unix.O_WRONLY)
-			if devnull then
-				unix.dup2(devnull, 1)
-				unix.dup2(devnull, 2)
-				unix.close(devnull)
-			end
-		end
-		local full_argv = {cmd}
-		for i = 2, #argv do
-			table.insert(full_argv, argv[i])
-		end
-		unix.execve(cmd, full_argv, unix.environ())
-		os.exit(127)
-	else
-		local wpid, status = unix.wait(pid)
-		if unix.WIFEXITED(status) then
-			return unix.WEXITSTATUS(status)
-		end
-		return nil, "process terminated abnormally"
-	end
-end
+local spawn = require("spawn").spawn
 
 local function copy_tree(src, dst)
-	local cp = unix.commandv("cp")
-	if not cp then
-		return nil, "cp command not found"
-	end
-
-	local pid = unix.fork()
-	if pid == 0 then
-		unix.execve(cp, {cp, "-ra", src, dst}, unix.environ())
-		os.exit(127)
-	else
-		local wpid, status = unix.wait(pid)
-		if unix.WIFEXITED(status) then
-			return unix.WEXITSTATUS(status) == 0
-		end
-		return nil, "cp process terminated abnormally"
-	end
+	local status = spawn({"cp", "-ra", src, dst}):wait()
+	return status == 0
 end
 
 return {
-	spawn = spawn,
 	copy_tree = copy_tree,
 }

--- a/3p/cook.mk
+++ b/3p/cook.mk
@@ -28,6 +28,7 @@ TOOLS := nvim gh delta rg duckdb tree-sitter ast-grep biome comrak \
 
 # download-tool needs our custom lua binary with cosmo built-in
 lua_bin := results/bin/lua
+lib_lua = LUA_PATH="$(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;;" $(CURDIR)/$(lua_bin)
 
 # download-tool target
 download_tool := lib/build/download-tool.lua
@@ -39,7 +40,7 @@ $(download_tool): lua
 define tool_download_rule
 $(3p)/$(1)/%/.extracted: 3p/$(1)/version.lua $(download_tool)
 	@mkdir -p $$(dir $$@)
-	$(lua_bin) $(download_tool) $(1) $$* $$(dir $$@)
+	$(lib_lua) $(download_tool) $(1) $$* $$(dir $$@)
 	touch $$@
 endef
 

--- a/lib/home/gen-platforms.lua
+++ b/lib/home/gen-platforms.lua
@@ -18,7 +18,7 @@ local function extract_manifest(asset_path)
     return nil, "unzip not found"
   end
 
-  local ok, output = home.spawn(unzip, { "unzip", "-p", asset_path, "manifest.lua" })
+  local ok, output = home.spawn({ "unzip", "-p", asset_path, "manifest.lua" }):read()
   if not ok or not output or output == "" then
     return nil, "no manifest.lua found in " .. asset_path
   end

--- a/lib/spawn/init.lua
+++ b/lib/spawn/init.lua
@@ -1,0 +1,158 @@
+local cosmo = require("cosmo")
+local unix = cosmo.unix
+
+local function make_pipe(fd)
+	if not fd then
+		return nil
+	end
+	local pipe = {fd = fd}
+
+	function pipe:write(data)
+		return unix.write(self.fd, data)
+	end
+
+	function pipe:read(size)
+		if size then
+			return unix.read(self.fd, size)
+		end
+		local chunks = {}
+		while true do
+			local chunk = unix.read(self.fd, 65536)
+			if not chunk or chunk == "" then
+				break
+			end
+			table.insert(chunks, chunk)
+		end
+		return table.concat(chunks)
+	end
+
+	function pipe:close()
+		if self.fd then
+			unix.close(self.fd)
+			self.fd = nil
+		end
+	end
+
+	return pipe
+end
+
+local function spawn(argv, opts)
+	opts = opts or {}
+	local cmd
+	if argv[1]:find("/") then
+		cmd = argv[1]
+	else
+		cmd = unix.commandv(argv[1])
+		if not cmd then
+			return nil, "command not found: " .. argv[1]
+		end
+	end
+
+	local stdin_r, stdin_w
+	local stdin_is_fd = type(opts.stdin) == "number"
+	if not stdin_is_fd then
+		stdin_r, stdin_w = unix.pipe()
+	end
+
+	local stdout_r, stdout_w
+	local stdout_is_fd = type(opts.stdout) == "number"
+	if not stdout_is_fd then
+		stdout_r, stdout_w = unix.pipe()
+	end
+
+	local stderr_r, stderr_w
+	local stderr_is_fd = type(opts.stderr) == "number"
+	if not stderr_is_fd then
+		stderr_r, stderr_w = unix.pipe()
+	end
+
+	local pid = unix.fork()
+	if pid == 0 then
+		unix.close(0)
+		if stdin_is_fd then
+			unix.dup(opts.stdin)
+		else
+			unix.close(stdin_w)
+			unix.dup(stdin_r)
+			unix.close(stdin_r)
+		end
+
+		unix.close(1)
+		if stdout_is_fd then
+			unix.dup(opts.stdout)
+		else
+			unix.close(stdout_r)
+			unix.dup(stdout_w)
+			unix.close(stdout_w)
+		end
+
+		unix.close(2)
+		if stderr_is_fd then
+			unix.dup(opts.stderr)
+		else
+			unix.close(stderr_r)
+			unix.dup(stderr_w)
+			unix.close(stderr_w)
+		end
+
+		local full_argv = {cmd}
+		for i = 2, #argv do
+			table.insert(full_argv, argv[i])
+		end
+		local env = opts.env or unix.environ()
+		unix.execve(cmd, full_argv, env)
+		os.exit(127)
+	end
+
+	if not stdin_is_fd then
+		unix.close(stdin_r)
+	end
+	if not stdout_is_fd then
+		unix.close(stdout_w)
+	end
+	if not stderr_is_fd then
+		unix.close(stderr_w)
+	end
+
+	local handle = {
+		pid = pid,
+		stdin = make_pipe(stdin_w),
+		stdout = make_pipe(stdout_r),
+		stderr = make_pipe(stderr_r),
+	}
+
+	function handle:wait()
+		if self.stdin then self.stdin:close() end
+		if self.stdout then self.stdout:close() end
+		if self.stderr then self.stderr:close() end
+		local _, status = unix.wait(self.pid)
+		if unix.WIFEXITED(status) then
+			return unix.WEXITSTATUS(status)
+		end
+		return nil, "process terminated abnormally"
+	end
+
+	function handle:read(size)
+		if not self.stdout then
+			return nil, "stdout not captured"
+		end
+		if self.stdin then self.stdin:close() end
+		local out = self.stdout:read(size)
+		if size then
+			return out
+		end
+		local exit_code = self:wait()
+		return exit_code == 0, out, exit_code
+	end
+
+	if type(opts.stdin) == "string" then
+		handle.stdin:write(opts.stdin)
+		handle.stdin:close()
+	end
+
+	return handle
+end
+
+return {
+	spawn = spawn,
+}

--- a/lib/test.mk
+++ b/lib/test.mk
@@ -40,8 +40,7 @@ test-home: private .UNVEIL = \
 	rwc:lib/home/o \
 	rw:/dev/null
 test-home: lua
-	cd lib/home && LUA_PATH="$(CURDIR)/lib/?.lua;;" \
-		$(CURDIR)/$(lua_bin) $(CURDIR)/$(test_runner) test_main.lua
+	cd lib/home && $(home_lua) $(CURDIR)/$(test_runner) test_main.lua
 
 test-lib-daemonize: private .UNVEIL = \
 	r:lib \

--- a/lib/test.mk
+++ b/lib/test.mk
@@ -75,9 +75,7 @@ test-nvim: private .UNVEIL = \
 	rwc:/tmp \
 	rw:/dev/null
 test-nvim: lua
-	cd lib/nvim && HOME=$(CURDIR) \
-		LUA_PATH="$(CURDIR)/lib/?.lua;;" \
-		$(CURDIR)/$(lua_bin) $(CURDIR)/$(test_runner) test.lua
+	cd lib/nvim && HOME=$(CURDIR) $(home_lua) $(CURDIR)/$(test_runner) test.lua
 
 test-claude-skills: private .UNVEIL = \
 	r:lib/claude \
@@ -100,9 +98,7 @@ test-environ: private .UNVEIL = \
 	r:$(CURDIR) \
 	rw:/dev/null
 test-environ: lua
-	cd lib/environ && HOME=$(CURDIR) \
-		LUA_PATH="$(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;;" \
-		$(CURDIR)/$(lua_bin) $(CURDIR)/$(test_runner) test.lua
+	cd lib/environ && HOME=$(CURDIR) $(home_lua) $(CURDIR)/$(test_runner) test.lua
 
 test-build-download-tool: private .UNVEIL = \
 	r:lib/build \
@@ -114,9 +110,7 @@ test-build-download-tool: private .UNVEIL = \
 	rwc:/tmp \
 	rw:/dev/null
 test-build-download-tool: lua
-	cd lib/build && HOME=$(CURDIR) \
-		LUA_PATH="$(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;;" \
-		$(CURDIR)/$(lua_bin) $(CURDIR)/$(test_runner) test.lua
+	cd lib/build && HOME=$(CURDIR) $(home_lua) $(CURDIR)/$(test_runner) test.lua
 
 # skip test-work until work.lua module is available in CI
 test-all: test-3p-lua test-lib-whereami test-home test-lib-daemonize test-claude test-nvim test-claude-skills test-environ test-build-download-tool


### PR DESCRIPTION
- Create lib/spawn/init.lua with spawn() and spawn_detach() functions
- spawn() supports capture option for stdout, stdin option for input
- spawn_detach() for fire-and-forget processes (no wait)
- Handle both PATH commands and paths containing /
- Update lib/home/main.lua to use lib/spawn
- Update setup scripts (util.lua, git.lua, shell.lua, claude.lua) to use
  the enhanced spawn interface
- Replace io.popen() calls with spawn({capture=true}) for consistency