### PR TITLE
setup: use universal home binary with setup subcommand

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,37 +2,12 @@
 
 SETUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.config/setup" && pwd)"
 
-get_platform() {
-  local os arch
-  case "$(uname -s)" in
-  Darwin) os="darwin" ;;
-  Linux) os="linux" ;;
-  *)
-    echo "unsupported OS: $(uname -s)" >&2
-    return 1
-    ;;
-  esac
-
-  case "$(uname -m)" in
-  arm64 | aarch64) arch="arm64" ;;
-  x86_64 | amd64) arch="x86_64" ;;
-  *)
-    echo "unsupported architecture: $(uname -m)" >&2
-    return 1
-    ;;
-  esac
-
-  echo "${os}-${arch}"
-}
-
 install_home() {
-  local platform binary_name url tmpdir
-  platform=$(get_platform) || return 1
-  binary_name="home-${platform}"
-  url="https://github.com/whilp/dotfiles/releases/latest/download/${binary_name}"
+  local url tmpdir
+  url="https://github.com/whilp/dotfiles/releases/latest/download/home"
   tmpdir=$(mktemp -d)
 
-  echo "downloading ${binary_name}..." >&2
+  echo "downloading home..." >&2
   if ! curl -fsSL -o "${tmpdir}/home" "${url}"; then
     echo "failed to download home binary" >&2
     rm -rf "${tmpdir}"
@@ -45,7 +20,7 @@ install_home() {
 
 main() {
   home_bin=$(install_home) || return 1
-  "${home_bin}" unpack --force "$HOME"
+  "${home_bin}" unpack --force --with-platform "$HOME"
   rm -rf "$(dirname "${home_bin}")"
 
   export LUA_PATH="$SETUP_DIR/?.lua;$HOME/.local/bootstrap/lib/lua/?.lua;$HOME/.local/bootstrap/lib/lua/?/init.lua;;"

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-SETUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.config/setup" && pwd)"
-
 install_home() {
   local url tmpdir
   url="https://github.com/whilp/dotfiles/releases/latest/download/home"
@@ -21,10 +19,8 @@ install_home() {
 main() {
   home_bin=$(install_home) || return 1
   "${home_bin}" unpack --force --with-platform "$HOME"
+  "${home_bin}" setup "$HOME"
   rm -rf "$(dirname "${home_bin}")"
-
-  export LUA_PATH="$SETUP_DIR/?.lua;$HOME/.local/bootstrap/lib/lua/?.lua;$HOME/.local/bootstrap/lib/lua/?/init.lua;;"
-  lua -e "require('setup').main()"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- Download the universal `home` binary instead of platform-specific `home-${platform}`
- Add `--with-platform` flag to fetch 3p binaries during unpack
- Add `setup` subcommand to run setup scripts using home's built-in cosmo-enabled lua
- Remove dependency on system lua and bootstrap directory

## Test plan
- [ ] Run `./setup.sh` on a fresh environment and verify 3p binaries are installed
- [ ] Verify setup scripts run correctly via `home setup`