### PR TITLE
Fix bootstrap errors

### DIFF
--- a/.config/setup/ai.lua
+++ b/.config/setup/ai.lua
@@ -12,7 +12,7 @@ local function run(env)
 			return 0
 		end
 
-		local status = util.spawn({"git", "clone", path.join(remote_base, "ai"), "./ai"})
+		local status = util.spawn({"git", "clone", path.join(remote_base, "ai"), "./ai"}, {silent = true})
 		if status ~= 0 then
 			return 0
 		end

--- a/.config/setup/extras.lua
+++ b/.config/setup/extras.lua
@@ -13,7 +13,7 @@ local function run(env)
 	unix.chdir(env.DST)
 
 	if not unix.stat("extras") then
-		local status = util.spawn({"git", "clone", extras, "extras"})
+		local status = util.spawn({"git", "clone", extras, "extras"}, {silent = true})
 		if status == 0 then
 			unix.chdir("extras")
 			if unix.stat("./setup.sh") and unix.access("./setup.sh", unix.X_OK) then

--- a/.config/setup/util.lua
+++ b/.config/setup/util.lua
@@ -1,7 +1,8 @@
 local cosmo = require("cosmo")
 local unix = cosmo.unix
 
-local function spawn(argv)
+local function spawn(argv, opts)
+	opts = opts or {}
 	local cmd = unix.commandv(argv[1])
 	if not cmd then
 		return nil, "command not found: " .. argv[1]
@@ -9,6 +10,14 @@ local function spawn(argv)
 
 	local pid = unix.fork()
 	if pid == 0 then
+		if opts.silent then
+			local devnull = unix.open("/dev/null", unix.O_WRONLY)
+			if devnull then
+				unix.dup2(devnull, 1)
+				unix.dup2(devnull, 2)
+				unix.close(devnull)
+			end
+		end
 		local full_argv = {cmd}
 		for i = 2, #argv do
 			table.insert(full_argv, argv[i])

--- a/lib/home/cook.mk
+++ b/lib/home/cook.mk
@@ -81,7 +81,8 @@ results/bin/home: $(lua_bin) results/dotfiles.zip results/bin/home-darwin-arm64 
 	@echo "Generating manifest..."
 	@LUA_PATH="lib/home/?.lua;;" $(lua_bin) lib/home/gen-manifest.lua results/home-universal/home $(HOME_VERSION) > results/home-universal/manifest.lua
 	@echo "Generating platforms metadata..."
-	@LUA_PATH="lib/home/?.lua;;" $(lua_bin) lib/home/gen-platforms.lua results/home-universal "$(HOME_BASE_URL)" "$(HOME_TAG)" \
+	# Single quotes preserve ${tag} literally; double quotes would expand it as empty shell variable
+	@LUA_PATH="lib/home/?.lua;;" $(lua_bin) lib/home/gen-platforms.lua results/home-universal '$(HOME_BASE_URL)' "$(HOME_TAG)" \
 		results/bin/home-darwin-arm64 \
 		results/bin/home-linux-arm64 \
 		results/bin/home-linux-x86_64


### PR DESCRIPTION
## Summary

- Fix platform download URL by using single quotes to preserve `${tag}` literal (was being expanded as empty shell variable)
- Silence optional repo clone errors for `extras` and `ai` repos that may not exist

## Test plan

- [ ] Merge and wait for new release
- [ ] Run `bash -x setup.sh` in fresh codespace
- [ ] Verify platform binary downloads successfully
- [ ] Verify no error output for missing extras/ai repos