### PR TITLE
home: use {tag} interpolation syntax to avoid shell escaping

### DIFF
--- a/.claude/skills/lua/SKILL.md
+++ b/.claude/skills/lua/SKILL.md
@@ -531,7 +531,7 @@ M.interpolate = function(template, context)
   if type(template) ~= "string" then
     return template
   end
-  return template:gsub("%${([%w_]+)}", function(key)
+  return template:gsub("{([%w_]+)}", function(key)
     return tostring(context[key] or "")
   end)
 end
@@ -572,7 +572,7 @@ return {
 }
 ```
 
-Template variables use `${variable}` syntax and are interpolated at runtime.
+Template variables use `{variable}` syntax and are interpolated at runtime.
 
 ## Common dependencies
 

--- a/3p/ast-grep/version.lua
+++ b/3p/ast-grep/version.lua
@@ -2,7 +2,7 @@ return {
   version = "0.28.0",
   format = "zip",
   strip_components = 0,
-  url = "https://github.com/ast-grep/ast-grep/releases/download/${version}/app-${arch}.zip",
+  url = "https://github.com/ast-grep/ast-grep/releases/download/{version}/app-{arch}.zip",
   platforms = {
     ["darwin-arm64"] = {
       arch = "aarch64-apple-darwin",

--- a/3p/biome/version.lua
+++ b/3p/biome/version.lua
@@ -1,7 +1,7 @@
 return {
   version = "1.9.4",
   format = "binary",
-  url = "https://github.com/biomejs/biome/releases/download/cli%2Fv${version}/biome-${platform}",
+  url = "https://github.com/biomejs/biome/releases/download/cli%2Fv{version}/biome-{platform}",
   platforms = {
     ["darwin-arm64"] = {
       sha = "c68f2cbe09e9485426a749353a155b1d22c130c6ccdadc7772d603eb247b9a9d",

--- a/3p/comrak/version.lua
+++ b/3p/comrak/version.lua
@@ -1,7 +1,7 @@
 return {
   version = "0.41.0",
   format = "binary",
-  url = "https://github.com/kivikakk/comrak/releases/download/v${version}/comrak-${version}-${arch}",
+  url = "https://github.com/kivikakk/comrak/releases/download/v{version}/comrak-{version}-{arch}",
   platforms = {
     ["darwin-arm64"] = {
       arch = "aarch64-apple-darwin",

--- a/3p/delta/version.lua
+++ b/3p/delta/version.lua
@@ -2,7 +2,7 @@ return {
   version = "0.18.2",
   format = "tar.gz",
   strip_components = 1,
-  url = "https://github.com/dandavison/delta/releases/download/${version}/delta-${version}-${arch}.tar.gz",
+  url = "https://github.com/dandavison/delta/releases/download/{version}/delta-{version}-{arch}.tar.gz",
   platforms = {
     ["darwin-arm64"] = {
       arch = "aarch64-apple-darwin",

--- a/3p/duckdb/version.lua
+++ b/3p/duckdb/version.lua
@@ -2,7 +2,7 @@ return {
   version = "1.4.2",
   format = "zip",
   strip_components = 0,
-  url = "https://github.com/duckdb/duckdb/releases/download/v${version}/duckdb_cli-${os}-${arch}.zip",
+  url = "https://github.com/duckdb/duckdb/releases/download/v{version}/duckdb_cli-{os}-{arch}.zip",
   platforms = {
     ["darwin-arm64"] = {
       os = "osx",

--- a/3p/gh/version.lua
+++ b/3p/gh/version.lua
@@ -1,7 +1,7 @@
 return {
   version = "2.79.0",
   strip_components = 1,
-  url = "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_${os}_${arch}.${ext}",
+  url = "https://github.com/cli/cli/releases/download/v{version}/gh_{version}_{os}_{arch}.{ext}",
   platforms = {
     ["darwin-arm64"] = {
       os = "macOS",

--- a/3p/marksman/version.lua
+++ b/3p/marksman/version.lua
@@ -1,7 +1,7 @@
 return {
   version = "2024-12-18",
   format = "binary",
-  url = "https://github.com/artempyanykh/marksman/releases/download/${version}/marksman-${platform}",
+  url = "https://github.com/artempyanykh/marksman/releases/download/{version}/marksman-{platform}",
   platforms = {
     ["darwin-arm64"] = {
       platform = "macos",

--- a/3p/nvim/version.lua
+++ b/3p/nvim/version.lua
@@ -3,7 +3,7 @@ return {
   release_sha = "c016a4c",
   format = "tar.gz",
   strip_components = 1,
-  url = "https://github.com/whilp/dotfiles/releases/download/${version}-${release_sha}/nvim-${version}-${platform}.tar.gz",
+  url = "https://github.com/whilp/dotfiles/releases/download/{version}-{release_sha}/nvim-{version}-{platform}.tar.gz",
   platforms = {
     ["darwin-arm64"] = {
       sha = "143513b8f91dd29a510beef8c1202a9c623f5ced2f0f379df894d1d3e4b37039",

--- a/3p/rg/version.lua
+++ b/3p/rg/version.lua
@@ -2,7 +2,7 @@ return {
   version = "14.1.1",
   format = "tar.gz",
   strip_components = 1,
-  url = "https://github.com/BurntSushi/ripgrep/releases/download/${version}/ripgrep-${version}-${arch}.tar.gz",
+  url = "https://github.com/BurntSushi/ripgrep/releases/download/{version}/ripgrep-{version}-{arch}.tar.gz",
   platforms = {
     ["darwin-arm64"] = {
       arch = "aarch64-apple-darwin",

--- a/3p/ruff/version.lua
+++ b/3p/ruff/version.lua
@@ -2,7 +2,7 @@ return {
   version = "0.8.4",
   format = "tar.gz",
   strip_components = 1,
-  url = "https://github.com/astral-sh/ruff/releases/download/${version}/ruff-${arch}.tar.gz",
+  url = "https://github.com/astral-sh/ruff/releases/download/{version}/ruff-{arch}.tar.gz",
   platforms = {
     ["darwin-arm64"] = {
       arch = "aarch64-apple-darwin",

--- a/3p/shfmt/version.lua
+++ b/3p/shfmt/version.lua
@@ -1,7 +1,7 @@
 return {
   version = "3.10.0",
   format = "binary",
-  url = "https://github.com/mvdan/sh/releases/download/v${version}/shfmt_v${version}_${os}_${arch}",
+  url = "https://github.com/mvdan/sh/releases/download/v{version}/shfmt_v{version}_{os}_{arch}",
   platforms = {
     ["darwin-arm64"] = {
       os = "darwin",

--- a/3p/sqruff/version.lua
+++ b/3p/sqruff/version.lua
@@ -2,7 +2,7 @@ return {
   version = "0.21.2",
   format = "tar.gz",
   strip_components = 0,
-  url = "https://github.com/quarylabs/sqruff/releases/download/v${version}/sqruff-${platform}.tar.gz",
+  url = "https://github.com/quarylabs/sqruff/releases/download/v{version}/sqruff-{platform}.tar.gz",
   platforms = {
     ["darwin-arm64"] = {
       platform = "darwin-aarch64",

--- a/3p/stylua/version.lua
+++ b/3p/stylua/version.lua
@@ -2,7 +2,7 @@ return {
   version = "2.0.1",
   format = "zip",
   strip_components = 0,
-  url = "https://github.com/JohnnyMorganz/StyLua/releases/download/v${version}/stylua-${os}-${arch}.zip",
+  url = "https://github.com/JohnnyMorganz/StyLua/releases/download/v{version}/stylua-{os}-{arch}.zip",
   platforms = {
     ["darwin-arm64"] = {
       os = "macos",

--- a/3p/superhtml/version.lua
+++ b/3p/superhtml/version.lua
@@ -2,7 +2,7 @@ return {
   version = "0.5.3",
   format = "tar.gz",
   strip_components = 1,
-  url = "https://github.com/kristoff-it/superhtml/releases/download/v${version}/${arch}-${os}.tar.gz",
+  url = "https://github.com/kristoff-it/superhtml/releases/download/v{version}/{arch}-{os}.tar.gz",
   platforms = {
     ["darwin-arm64"] = {
       arch = "aarch64",

--- a/3p/tree-sitter/version.lua
+++ b/3p/tree-sitter/version.lua
@@ -1,7 +1,7 @@
 return {
   version = "0.25.8",
   format = "gz",
-  url = "https://github.com/tree-sitter/tree-sitter/releases/download/v${version}/tree-sitter-${os}-${arch}.gz",
+  url = "https://github.com/tree-sitter/tree-sitter/releases/download/v{version}/tree-sitter-{os}-{arch}.gz",
   platforms = {
     ["darwin-arm64"] = {
       os = "macos",

--- a/3p/uv/version.lua
+++ b/3p/uv/version.lua
@@ -2,7 +2,7 @@ return {
   version = "0.5.7",
   format = "tar.gz",
   strip_components = 1,
-  url = "https://github.com/astral-sh/uv/releases/download/${version}/uv-${arch}.tar.gz",
+  url = "https://github.com/astral-sh/uv/releases/download/{version}/uv-{arch}.tar.gz",
   platforms = {
     ["darwin-arm64"] = {
       arch = "aarch64-apple-darwin",

--- a/lib/build/download-tool.lua
+++ b/lib/build/download-tool.lua
@@ -12,7 +12,7 @@ local function interpolate(template, vars)
   if type(template) ~= "string" then
     return template
   end
-  return template:gsub("%${([%w_]+)}", function(key)
+  return template:gsub("{([%w_]+)}", function(key)
     return tostring(vars[key] or "")
   end)
 end

--- a/lib/build/test.lua
+++ b/lib/build/test.lua
@@ -5,7 +5,7 @@ local download_tool = require("build.download-tool")
 
 -- Test template interpolation
 function test_interpolate_replaces_variables()
-  local template = "https://example.com/${version}/file-${release_sha}.tar.gz"
+  local template = "https://example.com/{version}/file-{release_sha}.tar.gz"
   local vars = { version = "1.0.0", release_sha = "abc123" }
 
   local result = download_tool.interpolate(template, vars)
@@ -14,7 +14,7 @@ function test_interpolate_replaces_variables()
 end
 
 function test_interpolate_handles_missing_variables()
-  local template = "https://example.com/${version}/file-${missing}.tar.gz"
+  local template = "https://example.com/{version}/file-{missing}.tar.gz"
   local vars = { version = "1.0.0" }
 
   local result = download_tool.interpolate(template, vars)
@@ -38,7 +38,7 @@ function test_interpolate_handles_empty_vars()
 end
 
 function test_interpolate_handles_custom_variables()
-  local template = "https://example.com/${version}/file-${arch}.tar.gz"
+  local template = "https://example.com/{version}/file-{arch}.tar.gz"
   local vars = { version = "1.0.0", arch = "x86_64-unknown-linux-musl" }
 
   local result = download_tool.interpolate(template, vars)
@@ -47,7 +47,7 @@ function test_interpolate_handles_custom_variables()
 end
 
 function test_interpolate_handles_platform_variable()
-  local template = "https://example.com/${version}/file-${platform}.tar.gz"
+  local template = "https://example.com/{version}/file-{platform}.tar.gz"
   local vars = { version = "1.0.0", platform = "darwin-arm64" }
 
   local result = download_tool.interpolate(template, vars)

--- a/lib/home/cook.mk
+++ b/lib/home/cook.mk
@@ -70,7 +70,7 @@ platform-assets: results/bin/home-darwin-arm64 results/bin/home-linux-arm64 resu
 
 # Universal home binary with dotfiles + platform metadata
 HOME_VERSION ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-HOME_BASE_URL ?= https://github.com/whilp/dotfiles/releases/download/$${tag}
+HOME_BASE_URL ?= https://github.com/whilp/dotfiles/releases/download/{tag}
 HOME_TAG ?= home-$(shell date -u +%Y-%m-%d)-$(HOME_VERSION)
 
 results/bin/home: $(lua_bin) results/dotfiles.zip results/bin/home-darwin-arm64 results/bin/home-linux-arm64 results/bin/home-linux-x86_64 lib/home/main.lua lib/home/.args lib/home/gen-manifest.lua lib/home/gen-platforms.lua | results/bin

--- a/lib/home/main.lua
+++ b/lib/home/main.lua
@@ -179,7 +179,7 @@ local function interpolate(template, context)
   if type(template) ~= "string" then
     return template
   end
-  return template:gsub("%${([%w_]+)}", function(key)
+  return template:gsub("{([%w_]+)}", function(key)
     return tostring(context[key] or "")
   end)
 end

--- a/lib/version.lua
+++ b/lib/version.lua
@@ -206,7 +206,7 @@ function M.interpolate(template, context)
   if type(template) ~= "string" then
     return template
   end
-  return template:gsub("%${([%w_]+)}", function(key)
+  return template:gsub("{([%w_]+)}", function(key)
     return tostring(context[key] or "")
   end)
 end


### PR DESCRIPTION
## Summary
- Fix platform asset download failing with `curl failed with status 22`
- The `${tag}` syntax was being expanded by the shell to empty string
- Switch to Python-style `{tag}` which has no special meaning to bash

## Test plan
- [ ] Build home binary and verify `platforms.lua` contains `{tag}` in base_url
- [ ] Run `setup.sh` and verify platform binaries download successfully