### PR TITLE
nvim: remove scheduled trigger

### DIFF
--- a/.github/workflows/nvim.yml
+++ b/.github/workflows/nvim.yml
@@ -2,8 +2,6 @@ name: nvim nightly
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 6 * * *'
 
 permissions:
   contents: write

--- a/.github/workflows/nvim.yml
+++ b/.github/workflows/nvim.yml
@@ -51,9 +51,6 @@ jobs:
             nvim-${{ matrix.platform }}.tar.gz
             nvim-${{ matrix.platform }}.tar.gz.sha256
 
-    outputs:
-      sha: ${{ steps.sha.outputs.sha }}
-
   release:
     needs: fetch
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Remove the daily scheduled trigger from the nvim workflow. The workflow should only be triggered manually via workflow_dispatch.

## Test plan

- [x] Workflow still has workflow_dispatch trigger