### PR TITLE
nvim: pin actions to full SHA

### DIFF
--- a/.github/workflows/nvim.yml
+++ b/.github/workflows/nvim.yml
@@ -44,7 +44,7 @@ jobs:
         run: mv nvim-upstream.tar.gz nvim-${{ matrix.platform }}.tar.gz
 
       - name: upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: nvim-${{ matrix.platform }}
           path: |
@@ -57,10 +57,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
 
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
 


### PR DESCRIPTION
## Summary

Pin GitHub Actions to full SHA as required by repo policy.

## Test plan

- [ ] Merge and trigger nvim workflow