### PR TITLE
nvim-bundle: fix git clone hanging with cosmos git

### DIFF
--- a/3p/nvim/cook.mk
+++ b/3p/nvim/cook.mk
@@ -1,8 +1,21 @@
 nvim_pack_lock := .config/nvim/nvim-pack-lock.json
-nvim_bundle := lib/build/nvim-bundle.lua
+nvim_plugins_dir := $(3p)/nvim/plugins
 
-$(3p)/nvim/%/.bundled: $(3p)/nvim/%/.extracted $(nvim_bundle) $(nvim_pack_lock)
-	$(lib_lua) $(nvim_bundle) $* $(dir $@)
+# Get plugin list from pack-lock
+nvim_plugins := $(shell $(lib_lua) lib/build/list-plugins.lua)
+
+# Fetch each plugin to shared cache
+fetch_plugin := lib/build/fetch-plugin.lua
+$(nvim_plugins_dir)/%/.fetched: $(nvim_pack_lock) $(fetch_plugin)
+	$(lib_lua) $(fetch_plugin) $* $(dir $@)
+	touch $@
+
+nvim_plugin_targets := $(foreach p,$(nvim_plugins),$(nvim_plugins_dir)/$(p)/.fetched)
+
+# Bundle plugins into nvim directory
+nvim_bundle := lib/build/nvim-bundle.lua
+$(3p)/nvim/%/.bundled: $(3p)/nvim/%/.extracted $(nvim_bundle) $(nvim_plugin_targets)
+	$(lib_lua) $(nvim_bundle) $* $(dir $@) $(nvim_plugins_dir)
 	touch $@
 
 nvim_bundled := $(foreach p,$(PLATFORMS),$(3p)/nvim/$(p)/.bundled)

--- a/lib/build/fetch-plugin.lua
+++ b/lib/build/fetch-plugin.lua
@@ -1,0 +1,150 @@
+#!/usr/bin/env lua
+-- Fetches a single nvim plugin from GitHub archive
+-- Usage: lua lib/build/fetch-plugin.lua <plugin-name> <output-dir>
+-- Reads plugin info from .config/nvim/nvim-pack-lock.json
+
+local cosmo = require("cosmo")
+local path = cosmo.path
+local unix = cosmo.unix
+local spawn = require("spawn").spawn
+
+local PACK_LOCK = ".config/nvim/nvim-pack-lock.json"
+
+local function execute(program, args)
+  local handle, err = spawn(args)
+  if not handle then
+    return nil, string.format("command failed to start: %s (%s)", program, err or "unknown error")
+  end
+  local exit_code, wait_err = handle:wait()
+  if not exit_code then
+    return nil, string.format("command failed: %s (%s)", program, wait_err or "abnormal termination")
+  end
+  if exit_code ~= 0 then
+    return nil, string.format("command failed: %s (exit: %d)", program, exit_code)
+  end
+  return true
+end
+
+local function read_file(filepath)
+  local fd = unix.open(filepath, unix.O_RDONLY)
+  if not fd then
+    return nil, "failed to open " .. filepath
+  end
+  local chunks = {}
+  while true do
+    local chunk = unix.read(fd, 65536)
+    if not chunk or chunk == "" then break end
+    table.insert(chunks, chunk)
+  end
+  unix.close(fd)
+  return table.concat(chunks)
+end
+
+local function parse_plugin_info(content, plugin_name)
+  local in_plugin = false
+  local info = {}
+
+  for line in content:gmatch("[^\n]+") do
+    local name = line:match('^%s*"([^"]+)":%s*{%s*$')
+    if name == plugin_name then
+      in_plugin = true
+    elseif in_plugin then
+      local key, value = line:match('^%s*"([^"]+)":%s*"([^"]*)"')
+      if key then
+        info[key] = value
+      end
+      if line:match("^%s*}") then
+        break
+      end
+    end
+  end
+
+  if not info.src or not info.rev then
+    return nil, "plugin not found or missing src/rev: " .. plugin_name
+  end
+  return info
+end
+
+local function fetch_plugin(plugin_name, output_dir)
+  if not plugin_name or plugin_name == "" then
+    return nil, "plugin name is required"
+  end
+  if not output_dir or output_dir == "" then
+    return nil, "output directory is required"
+  end
+
+  output_dir = output_dir:gsub("/$", "")
+
+  local content, err = read_file(PACK_LOCK)
+  if not content then
+    return nil, err
+  end
+
+  local info
+  info, err = parse_plugin_info(content, plugin_name)
+  if not info then
+    return nil, err
+  end
+
+  io.write(string.format("fetching %s at %s\n", plugin_name, info.rev))
+
+  local owner, repo = info.src:match("github%.com/([^/]+)/([^/]+)$")
+  if not owner or not repo then
+    return nil, "invalid GitHub URL: " .. info.src
+  end
+
+  local url = string.format("https://github.com/%s/%s/archive/%s.tar.gz", owner, repo, info.rev)
+  local tarball = output_dir .. ".tar.gz"
+
+  -- Ensure parent directory exists
+  local parent = output_dir:match("(.+)/[^/]+$")
+  if parent then
+    local parent_ok, parent_err = execute("mkdir", {"mkdir", "-p", parent})
+    if not parent_ok then
+      return nil, parent_err
+    end
+  end
+
+  -- Download
+  local curl_ok, curl_err = execute("curl", {"curl", "-fsSL", "-o", tarball, url})
+  if not curl_ok then
+    return nil, curl_err
+  end
+
+  -- Extract
+  local mkdir_ok, mkdir_err = execute("mkdir", {"mkdir", "-p", output_dir})
+  if not mkdir_ok then
+    execute("rm", {"rm", "-f", tarball})
+    return nil, mkdir_err
+  end
+
+  local tar_ok, tar_err = execute("tar", {"tar", "-xzf", tarball, "-C", output_dir, "--strip-components=1"})
+  if not tar_ok then
+    execute("rm", {"rm", "-f", tarball})
+    execute("rm", {"rm", "-rf", output_dir})
+    return nil, tar_err
+  end
+
+  -- Cleanup tarball
+  execute("rm", {"rm", "-f", tarball})
+
+  if plugin_name == "nui-components.nvim" then
+    execute("rm", {"rm", "-rf", path.join(output_dir, "docs/public")}, { allow_failure = true })
+  end
+
+  return true
+end
+
+if not pcall(debug.getlocal, 4, 1) then
+  local plugin_name = arg[1]
+  local output_dir = arg[2]
+
+  local ok, err = fetch_plugin(plugin_name, output_dir)
+  if not ok then
+    io.stderr:write("error: " .. tostring(err) .. "\n")
+    os.exit(1)
+  end
+  os.exit(0)
+end
+
+return { fetch_plugin = fetch_plugin }

--- a/lib/build/list-plugins.lua
+++ b/lib/build/list-plugins.lua
@@ -1,0 +1,50 @@
+#!/usr/bin/env lua
+-- Lists plugin names from nvim-pack-lock.json
+-- Usage: lua lib/build/list-plugins.lua
+-- Outputs space-separated plugin names for make
+
+local cosmo = require("cosmo")
+local unix = cosmo.unix
+
+local PACK_LOCK = ".config/nvim/nvim-pack-lock.json"
+
+local function read_file(filepath)
+  local fd = unix.open(filepath, unix.O_RDONLY)
+  if not fd then
+    return nil, "failed to open " .. filepath
+  end
+  local chunks = {}
+  while true do
+    local chunk = unix.read(fd, 65536)
+    if not chunk or chunk == "" then break end
+    table.insert(chunks, chunk)
+  end
+  unix.close(fd)
+  return table.concat(chunks)
+end
+
+local function list_plugins()
+  local content, err = read_file(PACK_LOCK)
+  if not content then
+    io.stderr:write("error: " .. err .. "\n")
+    os.exit(1)
+  end
+
+  local plugins = {}
+  local in_plugins = false
+
+  for line in content:gmatch("[^\n]+") do
+    if line:match('^%s*"plugins":%s*{%s*$') then
+      in_plugins = true
+    elseif in_plugins then
+      local name = line:match('^%s*"([^"]+)":%s*{%s*$')
+      if name then
+        table.insert(plugins, name)
+      end
+    end
+  end
+
+  io.write(table.concat(plugins, " "))
+end
+
+list_plugins()

--- a/lib/build/nvim-bundle.lua
+++ b/lib/build/nvim-bundle.lua
@@ -1,7 +1,6 @@
 #!/usr/bin/env lua
--- Bundles plugins into an extracted nvim directory
--- Usage: lua lib/build/nvim-bundle.lua <platform> <nvim_dir>
--- Reads plugin list from .config/nvim/nvim-pack-lock.json
+-- Bundles pre-fetched plugins into an nvim directory
+-- Usage: lua lib/build/nvim-bundle.lua <platform> <nvim_dir> <plugins_dir>
 
 local cosmo = require("cosmo")
 local path = cosmo.path
@@ -44,93 +43,25 @@ local function read_file(filepath)
   return table.concat(chunks)
 end
 
-local function parse_pack_lock(content)
+local function list_plugins(content)
   local plugins = {}
-  local current_plugin = nil
-  local current_info = {}
   local in_plugins = false
 
   for line in content:gmatch("[^\n]+") do
     if line:match('^%s*"plugins":%s*{%s*$') then
       in_plugins = true
     elseif in_plugins then
-      local plugin_name = line:match('^%s*"([^"]+)":%s*{%s*$')
-      if plugin_name then
-        if current_plugin then
-          plugins[current_plugin] = current_info
-        end
-        current_plugin = plugin_name
-        current_info = {}
-      end
-
-      local key, value = line:match('^%s*"([^"]+)":%s*"([^"]*)"')
-      if key and current_plugin then
-        current_info[key] = value
-      end
-
-      if line:match("^%s*}") and current_plugin then
-        plugins[current_plugin] = current_info
-        current_plugin = nil
-        current_info = {}
+      local name = line:match('^%s*"([^"]+)":%s*{%s*$')
+      if name then
+        table.insert(plugins, name)
       end
     end
   end
 
-  return { plugins = plugins }
+  return plugins
 end
 
-local function load_pack_lock(lock_file)
-  local content, err = read_file(lock_file)
-  if not content then
-    return nil, err
-  end
-
-  return parse_pack_lock(content)
-end
-
-local S_IFDIR = 16384
-
-local function dir_exists(dir_path)
-  local stat = unix.stat(dir_path)
-  if not stat then return false end
-  local mode = stat:mode()
-  return (mode - (mode % S_IFDIR)) / S_IFDIR % 2 == 1
-end
-
-local function clone_plugin(name, info, pack_dir)
-  local plugin_dir = path.join(pack_dir, name)
-
-  if dir_exists(plugin_dir) then
-    io.write(string.format("  %s already exists, skipping\n", name))
-    return true
-  end
-
-  io.write(string.format("  cloning %s at %s\n", name, info.rev))
-
-  -- Clone and checkout the specific rev
-  -- Using --branch with a commit SHA or --filter=blob:none hangs with cosmos git
-  local clone_ok, clone_err = execute("git", {"git", "clone", info.src, plugin_dir})
-  if not clone_ok then
-    return nil, clone_err
-  end
-  local checkout_ok, checkout_err = execute("git", {"git", "-C", plugin_dir, "checkout", info.rev})
-  if not checkout_ok then
-    return nil, checkout_err
-  end
-
-  local rm_ok, rm_err = execute("rm", {"rm", "-rf", path.join(plugin_dir, ".git")})
-  if not rm_ok then
-    return nil, rm_err
-  end
-
-  if name == "nui-components.nvim" then
-    execute("rm", {"rm", "-rf", path.join(plugin_dir, "docs/public")}, { allow_failure = true })
-  end
-
-  return true
-end
-
-local function bundle_plugins(nvim_dir, pack_lock)
+local function bundle_plugins(nvim_dir, plugins_dir, plugins)
   io.write("bundling plugins\n")
 
   local pack_dir = path.join(nvim_dir, "share/nvim/site/pack/core/opt")
@@ -139,11 +70,14 @@ local function bundle_plugins(nvim_dir, pack_lock)
     return nil, err
   end
 
-  local plugins = pack_lock.plugins
-  for name, info in pairs(plugins) do
-    local clone_ok, clone_err = clone_plugin(name, info, pack_dir)
-    if not clone_ok then
-      return nil, string.format("failed to clone %s: %s", name, clone_err)
+  for _, name in ipairs(plugins) do
+    local src = path.join(plugins_dir, name)
+    local dst = path.join(pack_dir, name)
+
+    io.write(string.format("  copying %s\n", name))
+    local cp_ok, cp_err = execute("cp", {"cp", "-r", src, dst})
+    if not cp_ok then
+      return nil, string.format("failed to copy %s: %s", name, cp_err)
     end
   end
 
@@ -157,7 +91,7 @@ local function bundle_plugins(nvim_dir, pack_lock)
   return true
 end
 
-local function verify_plugins(nvim_dir, pack_lock)
+local function verify_plugins(nvim_dir, plugins)
   io.write("verifying plugins\n")
   local nvim_bin = path.join(nvim_dir, "bin/nvim")
 
@@ -167,7 +101,7 @@ local function verify_plugins(nvim_dir, pack_lock)
     return true
   end
 
-  for name, _ in pairs(pack_lock.plugins) do
+  for _, name in ipairs(plugins) do
     local cmd = string.format("+packadd %s", name)
     local ok, err = execute(nvim_bin, {nvim_bin, "--headless", cmd, "+qa"})
     if not ok then
@@ -178,28 +112,37 @@ local function verify_plugins(nvim_dir, pack_lock)
   return true
 end
 
-local function bundle(platform, nvim_dir)
+local function bundle(platform, nvim_dir, plugins_dir)
   if not platform or platform == "" then
     return nil, "platform is required"
   end
   if not nvim_dir or nvim_dir == "" then
     return nil, "nvim_dir is required"
   end
+  if not plugins_dir or plugins_dir == "" then
+    return nil, "plugins_dir is required"
+  end
 
   nvim_dir = nvim_dir:gsub("/$", "")
+  plugins_dir = plugins_dir:gsub("/$", "")
 
-  local pack_lock, err = load_pack_lock(PACK_LOCK)
-  if not pack_lock then
+  local content, err = read_file(PACK_LOCK)
+  if not content then
     return nil, err
   end
 
+  local plugins = list_plugins(content)
+  if #plugins == 0 then
+    return nil, "no plugins found in pack-lock"
+  end
+
   local ok
-  ok, err = bundle_plugins(nvim_dir, pack_lock)
+  ok, err = bundle_plugins(nvim_dir, plugins_dir, plugins)
   if not ok then
     return nil, err
   end
 
-  ok, err = verify_plugins(nvim_dir, pack_lock)
+  ok, err = verify_plugins(nvim_dir, plugins)
   if not ok then
     return nil, err
   end
@@ -208,16 +151,12 @@ local function bundle(platform, nvim_dir)
   return true
 end
 
-local M = {
-  bundle = bundle,
-  load_pack_lock = load_pack_lock,
-}
-
 if not pcall(debug.getlocal, 4, 1) then
   local platform = arg[1]
   local nvim_dir = arg[2]
+  local plugins_dir = arg[3]
 
-  local ok, err = bundle(platform, nvim_dir)
+  local ok, err = bundle(platform, nvim_dir, plugins_dir)
   if not ok then
     io.stderr:write("error: " .. tostring(err) .. "\n")
     os.exit(1)
@@ -225,4 +164,4 @@ if not pcall(debug.getlocal, 4, 1) then
   os.exit(0)
 end
 
-return M
+return { bundle = bundle }


### PR DESCRIPTION
## Summary
Download plugins via GitHub archive tarballs with make-level caching.

## Changes
- `lib/build/fetch-plugin.lua` - downloads single plugin via `curl | tar`
- `lib/build/list-plugins.lua` - outputs plugin names for make
- `3p/nvim/cook.mk` - pattern rule with `.fetched` markers per plugin
- `lib/build/nvim-bundle.lua` - copies pre-fetched plugins into nvim

## Benefits
- Parallel downloads with `make -j`
- Per-plugin caching (only re-fetch changed plugins)
- No git dependency
- ~6s for all 8 plugins (vs minutes with cosmos git)

## Root cause of cosmos git slowdown
nvim-treesitter has 5556 `refs/pull/*` refs that cosmos git processes slowly.