### PR TITLE
version: add runtime binary scanning to version module

### DIFF
--- a/.github/workflows/nvim.yml
+++ b/.github/workflows/nvim.yml
@@ -29,6 +29,15 @@ jobs:
           curl -fsSL -o nvim-upstream.tar.gz \
             "https://github.com/neovim/neovim/releases/download/nightly/${{ matrix.upstream }}"
 
+      - name: extract version from binary
+        id: version
+        run: |
+          mkdir -p nvim-temp
+          tar -xzf nvim-upstream.tar.gz -C nvim-temp --strip-components=1
+          VERSION=$(nvim-temp/bin/nvim --version | head -1 | sed 's/^NVIM v//' | sed 's/+.*//')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          rm -rf nvim-temp
+
       - name: calculate sha256
         id: sha
         run: |
@@ -43,6 +52,9 @@ jobs:
       - name: rename for release
         run: mv nvim-upstream.tar.gz nvim-${{ matrix.platform }}.tar.gz
 
+      - name: write version file
+        run: echo "${{ steps.version.outputs.version }}" > nvim-${{ matrix.platform }}.version
+
       - name: upload artifact
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
@@ -50,6 +62,7 @@ jobs:
           path: |
             nvim-${{ matrix.platform }}.tar.gz
             nvim-${{ matrix.platform }}.tar.gz.sha256
+            nvim-${{ matrix.platform }}.version
 
   release:
     needs: fetch
@@ -68,16 +81,18 @@ jobs:
         id: date
         run: echo "date=$(date -u +%Y.%m.%d)" >> $GITHUB_OUTPUT
 
-      - name: collect shas
+      - name: collect shas and version
         id: shas
         run: |
           cd artifacts
           DARWIN_ARM64_SHA=$(cat nvim-darwin-arm64/nvim-darwin-arm64.tar.gz.sha256 | cut -d' ' -f1)
           LINUX_ARM64_SHA=$(cat nvim-linux-arm64/nvim-linux-arm64.tar.gz.sha256 | cut -d' ' -f1)
           LINUX_X64_SHA=$(cat nvim-linux-x64/nvim-linux-x64.tar.gz.sha256 | cut -d' ' -f1)
+          VERSION=$(cat nvim-linux-x64/nvim-linux-x64.version | tr -d '\n')
           echo "darwin_arm64=${DARWIN_ARM64_SHA}" >> $GITHUB_OUTPUT
           echo "linux_arm64=${LINUX_ARM64_SHA}" >> $GITHUB_OUTPUT
           echo "linux_x64=${LINUX_X64_SHA}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: create release
         env:
@@ -101,7 +116,7 @@ jobs:
         run: |
           cat > 3p/nvim/version.lua << EOF
           return {
-            version = "nightly",
+            version = "${{ steps.shas.outputs.version }}",
             date = "${{ steps.date.outputs.date }}",
             format = "tar.gz",
             strip_components = 1,

--- a/3p/nvim/version.lua
+++ b/3p/nvim/version.lua
@@ -1,5 +1,5 @@
 return {
-  version = "nightly",
+  version = "0.12.0-dev-1892",
   date = "2025.12.24",
   format = "tar.gz",
   strip_components = 1,

--- a/lib/home/cook.mk
+++ b/lib/home/cook.mk
@@ -1,5 +1,6 @@
 include lib/spawn/cook.mk
 
+version_file = lib/version.lua
 home_exclude_pattern = ^(3p/|o/|results/|Makefile|lib/home/|\.git)
 home_lua = LUA_PATH="$(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;$(CURDIR)/lib/home/?.lua;;" $(CURDIR)/$(lua_bin)
 home_setup_dir = lib/home/setup
@@ -56,20 +57,20 @@ define build_platform_asset
 	@cp $(lua_bin) $(1)
 	@cd results/platform-$(2) && find . -type f -o -type l | $(cosmos_zip_bin) -q $(CURDIR)/$(1) -@
 	@$(cosmos_zip_bin) -qj $(1) lib/home/main.lua
-	@mkdir -p results/platform-$(2)/.lua && cp -r $(spawn_dir) results/platform-$(2)/.lua/
+	@mkdir -p results/platform-$(2)/.lua && cp -r $(spawn_dir) results/platform-$(2)/.lua/ && cp $(version_file) results/platform-$(2)/.lua/
 	@cd results/platform-$(2) && $(cosmos_zip_bin) -qr $(CURDIR)/$(1) .lua
 	@echo -n '/zip/main.lua' > results/platform-$(2)/.args
 	@$(cosmos_zip_bin) -qj $(1) results/platform-$(2)/.args
 	@rm -rf results/platform-$(2)
 endef
 
-results/bin/home-darwin-arm64: $(lua_bin) results/binaries-darwin-arm64.zip lib/home/main.lua lib/home/gen-manifest.lua $(spawn_sources) | results/bin
+results/bin/home-darwin-arm64: $(lua_bin) results/binaries-darwin-arm64.zip lib/home/main.lua lib/home/gen-manifest.lua $(spawn_sources) $(version_file) | results/bin
 	$(call build_platform_asset,$@,darwin-arm64)
 
-results/bin/home-linux-arm64: $(lua_bin) results/binaries-linux-arm64.zip lib/home/main.lua lib/home/gen-manifest.lua $(spawn_sources) | results/bin
+results/bin/home-linux-arm64: $(lua_bin) results/binaries-linux-arm64.zip lib/home/main.lua lib/home/gen-manifest.lua $(spawn_sources) $(version_file) | results/bin
 	$(call build_platform_asset,$@,linux-arm64)
 
-results/bin/home-linux-x86_64: $(lua_bin) results/binaries-linux-x86_64.zip lib/home/main.lua lib/home/gen-manifest.lua $(spawn_sources) | results/bin
+results/bin/home-linux-x86_64: $(lua_bin) results/binaries-linux-x86_64.zip lib/home/main.lua lib/home/gen-manifest.lua $(spawn_sources) $(version_file) | results/bin
 	$(call build_platform_asset,$@,linux-x86_64)
 
 platform-assets: results/bin/home-darwin-arm64 results/bin/home-linux-arm64 results/bin/home-linux-x86_64
@@ -79,7 +80,7 @@ HOME_VERSION ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown"
 HOME_BASE_URL ?= https://github.com/whilp/dotfiles/releases/download/{tag}
 HOME_TAG ?= home-$(shell date -u +%Y-%m-%d)-$(HOME_VERSION)
 
-results/bin/home: $(lua_bin) results/dotfiles.zip results/bin/home-darwin-arm64 results/bin/home-linux-arm64 results/bin/home-linux-x86_64 lib/home/main.lua lib/home/.args lib/home/gen-manifest.lua lib/home/gen-platforms.lua $(spawn_sources) $(home_setup_sources) $(home_mac_sources) | results/bin
+results/bin/home: $(lua_bin) results/dotfiles.zip results/bin/home-darwin-arm64 results/bin/home-linux-arm64 results/bin/home-linux-x86_64 lib/home/main.lua lib/home/.args lib/home/gen-manifest.lua lib/home/gen-platforms.lua $(spawn_sources) $(version_file) $(home_setup_sources) $(home_mac_sources) | results/bin
 	@echo "Building universal home binary..."
 	@rm -rf results/home-universal
 	@mkdir -p results/home-universal/home/.local/bin
@@ -98,7 +99,7 @@ results/bin/home: $(lua_bin) results/dotfiles.zip results/bin/home-darwin-arm64 
 	@cp $(lua_bin) $@
 	@cd results/home-universal && find . -type f -o -type l | $(cosmos_zip_bin) -q $(CURDIR)/$@ -@
 	@cd lib/home && $(cosmos_zip_bin) -qr $(CURDIR)/$@ main.lua .args
-	@mkdir -p results/home-universal/.lua && cp -r $(spawn_dir) $(home_setup_dir) $(home_mac_dir) results/home-universal/.lua/
+	@mkdir -p results/home-universal/.lua && cp -r $(spawn_dir) $(home_setup_dir) $(home_mac_dir) results/home-universal/.lua/ && cp $(version_file) results/home-universal/.lua/
 	@cd results/home-universal && $(cosmos_zip_bin) -qr $(CURDIR)/$@ .lua
 	@rm -rf results/home-universal
 

--- a/lib/nvim/test.lua
+++ b/lib/nvim/test.lua
@@ -50,12 +50,6 @@ function test_setup_nvim_environment_returns_table()
   lu.assertTrue(type(env) == "table", "should return a table")
 end
 
-function test_get_script_dir_returns_string()
-  local dir = nvim.get_script_dir()
-
-  lu.assertTrue(type(dir) == "string" or dir == nil, "should return a string or nil")
-end
-
 function test_resolve_nvim_bin_returns_path()
   local bin = nvim.resolve_nvim_bin()
 
@@ -63,8 +57,8 @@ function test_resolve_nvim_bin_returns_path()
   lu.assertTrue(bin:match("nvim$") ~= nil, "should end with 'nvim'")
 end
 
-function test_resolve_nvim_bin_uses_relative_path()
+function test_resolve_nvim_bin_uses_share_path()
   local bin = nvim.resolve_nvim_bin()
 
-  lu.assertTrue(bin:match("share/nvim/bin/nvim") ~= nil, "should contain share/nvim/bin/nvim")
+  lu.assertTrue(bin:match("share/nvim/") ~= nil, "should contain share/nvim/")
 end


### PR DESCRIPTION
## Summary

- Add version scanning functions to `lib/version.lua` for finding installed binaries
- Update `lib/nvim/main.lua` to use the version module instead of broken `find_latest_version()` that only matched versions starting with a digit
- Update `lib/home/main.lua` to delegate to the version module
- Update nvim workflow to extract actual version from binary (e.g., `0.12.0-dev-1892` instead of `nightly`)

This fixes `nvim --remote-ui` which was failing because the version pattern `^%d` didn't match `nightly-<sha>` directory names.

## Test plan

- [x] `nvim --version` works
- [x] `nvim --remote-ui` starts server and connects
- [x] `make check` passes (0 warnings, 0 errors)
- [x] nvim tests pass
- [x] home tests pass