### PR TITLE
cosmos: download individual binaries instead of full zip

### DIFF
--- a/3p/cosmos/cook.mk
+++ b/3p/cosmos/cook.mk
@@ -1,1 +1,10 @@
-$(eval $(call download_zip_rule,cosmos,https://github.com/jart/cosmopolitan/releases/download/4.0.2/cosmos-4.0.2.zip,494ecbd87c2f2f622f91066d4fe5d9ffc1aaaa13de02db1714dd84d014ed398f,bin/make))
+cosmos_dir := $(3p)/cosmos
+cosmos_version := 4.0.2
+cosmos_url := https://cosmo.zip/pub/cosmos/v/$(cosmos_version)/bin
+$(eval $(call download_binary_rule,cosmos,zip,$(cosmos_url)/zip,6741fead27d6431939921e75f86b42f1dc3e3a2ec8a82b31490747185c7b9349))
+$(eval $(call download_binary_rule,cosmos,unzip,$(cosmos_url)/unzip,e96740f10b773c158d471027285cc694d410f9387bc206c93e5bd075238fead6))
+$(eval $(call download_binary_rule,cosmos,make,$(cosmos_url)/make,15317323a22b13dfd213bce47a39d302e74065f42199deb17c85852c04934fd9))
+cosmos_bin := $(cosmos_make_bin)
+
+$(cosmos_dir)/bin:
+	mkdir -p $@

--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -122,11 +122,6 @@ $(lua_patched): $(cosmopolitan_src) | $(lua_build_dir)
 	cd $(lua_cosmo_dir) && patch -N -p1 < $(CURDIR)/$(lua_patch_dir)/lfuncs.c.patch || true
 	touch $@
 
-# cosmos zip is needed for APE binaries (system zip doesn't work with APE format)
-cosmos_zip_bin := $(cosmos_dir)/bin/zip
-
-$(cosmos_zip_bin): $(cosmos_bin)
-
 $(lua_bin): private .UNVEIL = r:$(lua_build_dir) r:$(luaunit_lua_dir) r:$(luacheck_lua_dir) r:$(cosmocc_dir) r:$(cosmos_dir) rwc:results/bin rw:/dev/null
 $(lua_bin): private .PLEDGE = stdio rpath wpath cpath fattr exec proc
 $(lua_bin): private .CPU = 120


### PR DESCRIPTION
Switch from downloading the full cosmos-4.0.2.zip (~large) to
fetching only the 3 binaries actually used: zip, unzip, make.
Downloads from versioned URL cosmo.zip/pub/cosmos/v/4.0.2/bin/
with SHA256 verification.

Adds `download_binary_rule` macro to lib/make/macros.mk for
downloading individual executables with checksum validation.