### PR TITLE
cosmo: add gVisor TLS compatibility

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -33,8 +33,9 @@ jobs:
         with:
           path: |
             o/lua
+            o/cosmo
             results/bin/lua
-          key: lua-build-${{ hashFiles('3p/lua/**', 'lib/run-test.lua') }}
+          key: lua-build-${{ hashFiles('3p/lua/**', 'lib/cosmo/**', 'lib/run-test.lua') }}
           restore-keys: |
             lua-build-
 
@@ -54,6 +55,7 @@ jobs:
           path: |
             results/bin/home
             results/bin/home-*
+            results/bin/lua
 
   test:
     runs-on: ${{ matrix.os }}
@@ -123,7 +125,7 @@ jobs:
       - name: Create checksums
         run: |
           cd results
-          sha256sum bin/home bin/home-* > SHA256SUMS
+          sha256sum bin/home bin/home-* bin/lua > SHA256SUMS
           cat SHA256SUMS
 
       - name: Create release
@@ -143,4 +145,5 @@ jobs:
             results/bin/home-darwin-arm64 \
             results/bin/home-linux-arm64 \
             results/bin/home-linux-x86_64 \
+            results/bin/lua \
             results/SHA256SUMS

--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -63,6 +63,9 @@ lua_ext_net_srcs := lpath.c lre.c lsqlite3.c largon2.c lfuncs.c
 # cosmo module (lfuncs_register.c registers lfuncs as cosmo module)
 lua_cosmo_srcs := lfuncs_register.c
 
+# gVisor TLS compatibility (from shared lib/cosmo)
+include lib/cosmo/cosmo.mk
+
 # linenoise source
 lua_linenoise_srcs := linenoise.c
 
@@ -100,7 +103,8 @@ lua_regex_objs := $(addprefix $(lua_build_dir)/regex/,$(lua_regex_srcs:.c=.o))
 lua_sqlite3_objs := $(addprefix $(lua_build_dir)/sqlite3/,$(lua_sqlite3_srcs:.c=.o))
 lua_cosmo_objs := $(addprefix $(lua_build_dir)/cosmo/,$(lua_cosmo_srcs:.c=.o))
 
-lua_all_objs := $(lua_core_objs) $(lua_ext_lua_objs) $(lua_ext_net_objs) $(lua_linenoise_objs) $(lua_argon2_objs) $(lua_regex_objs) $(lua_sqlite3_objs) $(lua_cosmo_objs)
+# cosmo override objects must come first to take precedence over libc
+lua_all_objs := $(cosmo_override_objs) $(lua_core_objs) $(lua_ext_lua_objs) $(lua_ext_net_objs) $(lua_linenoise_objs) $(lua_argon2_objs) $(lua_regex_objs) $(lua_sqlite3_objs) $(lua_cosmo_objs)
 
 # output
 lua_bin := results/bin/lua

--- a/lib/cosmo/cosmo.mk
+++ b/lib/cosmo/cosmo.mk
@@ -1,0 +1,37 @@
+# Cosmopolitan libc overrides for gVisor compatibility
+#
+# Include this in any 3p build that uses cosmocc to get gVisor support.
+#
+# Usage in your cook.mk:
+#   include lib/cosmo/cosmo.mk
+#   my_all_objs := $(cosmo_override_objs) $(my_objs)
+#
+# The override objects MUST come first in the link order to take
+# precedence over the pre-built cosmopolitan libc.
+#
+# Prerequisites:
+#   - $(cosmocc_bin) must be defined (path to cosmocc compiler)
+#   - $(cosmopolitan_src) should be defined (path to cosmopolitan sources)
+
+cosmo_override_dir := lib/cosmo
+cosmo_override_build_dir := o/cosmo
+
+# Source files for cosmopolitan overrides
+cosmo_override_srcs := set_tls_gvisor.c
+
+# Object files
+cosmo_override_objs := $(addprefix $(cosmo_override_build_dir)/,$(cosmo_override_srcs:.c=.o))
+
+# Use cosmopolitan_src if defined, otherwise use the standard 3p path
+cosmo_include_dir ?= $(3p)/cosmopolitan/cosmopolitan-4.0.2
+
+# Build rule for override objects
+$(cosmo_override_build_dir)/%.o: $(cosmo_override_dir)/%.c | $(cosmo_override_build_dir)
+	$(cosmocc_bin) -mcosmo -include stdbool.h -I$(cosmo_include_dir) -c $< -o $@
+
+$(cosmo_override_build_dir):
+	mkdir -p $@
+
+# Phony target to build just the overrides
+cosmo-overrides: $(cosmo_override_objs)
+.PHONY: cosmo-overrides

--- a/lib/cosmo/set_tls_gvisor.c
+++ b/lib/cosmo/set_tls_gvisor.c
@@ -1,0 +1,79 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│ vi: set et ft=c ts=2 sts=2 sw=2 fenc=utf-8                               :vi │
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2022 Justine Alexandra Roberts Tunney                              │
+│ Copyright 2024 Will Maier                                                    │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for         │
+│ any purpose with or without fee is hereby granted, provided that the         │
+│ above copyright notice and this permission notice appear in all copies.      │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL                │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED                │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE             │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL         │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR        │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER               │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR             │
+│ PERFORMANCE OF THIS SOFTWARE.                                                │
+╚─────────────────────────────────────────────────────────────────────────────*/
+/*
+ * gVisor-compatible TLS initialization
+ *
+ * gVisor's Linux syscall emulation doesn't support ARCH_SET_GS, only ARCH_SET_FS.
+ * This override detects gVisor at runtime by trying ARCH_SET_GS first; if it
+ * fails with EINVAL, we fall back to ARCH_SET_FS and morph the TLS opcodes.
+ *
+ * See: https://gvisor.dev/docs/user_guide/compatibility/
+ */
+#include "libc/assert.h"
+#include "libc/calls/calls.h"
+#include "libc/calls/syscall-sysv.internal.h"
+#include "libc/dce.h"
+#include "libc/nexgen32e/msr.internal.h"
+#include "libc/nt/thread.h"
+#include "libc/sysv/consts/arch.h"
+#include "libc/thread/tls.h"
+
+#define AMD64_SET_FSBASE 129
+#define AMD64_SET_GSBASE 131
+
+int sys_set_tls(uintptr_t, void *);
+void __morph_tls(void);
+
+char __tls_using_fs;
+
+dontinstrument textstartup void __set_tls(struct CosmoTib *tib) {
+  tib = __adj_tls(tib);
+#ifdef __x86_64__
+  if (IsWindows()) {
+    __set_tls_win32(tib);
+  } else if (IsLinux()) {
+    long rc = sys_set_tls(ARCH_SET_GS, tib);
+    if (rc == -22) {
+      sys_set_tls(ARCH_SET_FS, tib);
+      __tls_using_fs = 1;
+      __morph_tls();
+    }
+  } else if (IsFreebsd()) {
+    sys_set_tls(AMD64_SET_GSBASE, tib);
+  } else if (IsNetbsd()) {
+    sys_set_tls((uintptr_t)tib, 0);
+  } else if (IsOpenbsd()) {
+    sys_set_tls((uintptr_t)tib, 0);
+  } else if (IsXnu()) {
+    sys_set_tls((intptr_t)tib - 0x30, 0);
+  } else {
+    uint64_t val = (uint64_t)tib;
+    asm volatile("wrmsr"
+                 : /* no outputs */
+                 : "c"(MSR_IA32_GS_BASE), "a"((uint32_t)val),
+                   "d"((uint32_t)(val >> 32)));
+  }
+#elif defined(__aarch64__)
+  register long x28 asm("x28") = (long)tib;
+  asm volatile("" : "+r"(x28));
+#else
+#error "unsupported architecture"
+#endif
+}


### PR DESCRIPTION
## Summary
- Add runtime TLS detection that falls back to `ARCH_SET_FS` when `ARCH_SET_GS` fails (gVisor returns EINVAL)
- Create reusable `lib/cosmo/cosmo.mk` for any cosmopolitan build needing gVisor support
- Update lua build to use the shared override with correct link order

## Test plan
- [ ] Build lua with `make lua`
- [ ] Verify native Linux works: `./results/bin/lua -e "print(unix.getpid())"`
- [ ] Verify gVisor works by running the binary in a gVisor sandbox (e.g., claude.ai/code)