### PR TITLE
make: add test target using pre-built lua from releases

### DIFF
--- a/3p/lua-release/cook.mk
+++ b/3p/lua-release/cook.mk
@@ -1,0 +1,26 @@
+# pre-built lua from dotfiles releases
+# to update: set version, then run:
+#   curl -fsSL https://github.com/whilp/dotfiles/releases/download/<version>/SHA256SUMS | grep lua
+lua_release_dir := $(3p)/lua-release
+lua_release_bin := $(lua_release_dir)/lua
+lua_release_version := home-2025-12-25-c11d85b
+lua_release_url := https://github.com/whilp/dotfiles/releases/download/$(lua_release_version)/lua
+lua_release_sha := e2f6ff7a1c7f85e87b6014d60ac17eeda9b94f0be7b31acad0acd8ac1ea4bdb4
+
+$(lua_release_bin): private .UNVEIL = r:/etc/resolv.conf r:/etc/ssl rwc:$(lua_release_dir) rw:/dev/null
+$(lua_release_bin): private .PLEDGE = stdio rpath wpath cpath inet dns
+$(lua_release_bin): private .INTERNET = 1
+$(lua_release_bin): | $(lua_release_dir)
+	$(curl) -o $@ $(lua_release_url)
+	cd $(dir $@) && echo "$(lua_release_sha)  $(notdir $@)" | $(sha256sum) -c
+	chmod +x $@
+
+$(lua_release_dir):
+	mkdir -p $@
+
+lua-release: $(lua_release_bin)
+
+clean-lua-release:
+	rm -rf $(lua_release_dir)
+
+.PHONY: lua-release clean-lua-release

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ include 3p/luacheck/cook.mk
 include 3p/cosmopolitan/cook.mk
 include 3p/make/cook.mk
 include 3p/lua/cook.mk
+include 3p/lua-release/cook.mk
 include lib/home/cook.mk
 include lib/test.mk
 

--- a/lib/test.mk
+++ b/lib/test.mk
@@ -11,4 +11,18 @@ TEST_TARGETS := test-3p-lua test-lib-whereami test-home test-lib-daemonize \
 
 test-all: $(TEST_TARGETS)
 
-.PHONY: test-all
+test: private .UNVEIL = r:$(CURDIR) rx:$(lua_release_bin) rw:/dev/null
+test: private .PLEDGE = stdio rpath wpath cpath proc exec
+test: private .CPU = 120
+test: lua-release
+	$(lua_release_bin) $(test_runner) 3p/lua/test.lua
+	$(lua_release_bin) $(test_runner) lib/test_whereami.lua
+	$(lua_release_bin) $(test_runner) lib/home/test_main.lua
+	$(lua_release_bin) $(test_runner) lib/test_daemonize.lua
+	$(lua_release_bin) $(test_runner) lib/claude/test.lua
+	$(lua_release_bin) $(test_runner) lib/nvim/test.lua
+	$(lua_release_bin) $(test_runner) lib/claude/test_skills.lua
+	$(lua_release_bin) $(test_runner) lib/environ/test.lua
+	$(lua_release_bin) $(test_runner) lib/build/test.lua
+
+.PHONY: test-all test


### PR DESCRIPTION
Downloads lua binary from dotfiles releases instead of building from
source. The test target runs all lua tests using the downloaded binary.