### PR TITLE
lua: add DecodeJson, EncodeJson, EncodeLua functions

### DIFF
--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -58,7 +58,7 @@ lua_core_srcs := \
 
 # lua extension sources - some in third_party/lua, some in tool/net
 lua_ext_lua_srcs := lunix.c lua.main.c
-lua_ext_net_srcs := lpath.c lre.c lsqlite3.c largon2.c lfuncs.c
+lua_ext_net_srcs := lpath.c lre.c lsqlite3.c largon2.c lfuncs.c ljson.c
 
 # cosmo module (lfuncs_register.c registers lfuncs as cosmo module)
 lua_cosmo_srcs := lfuncs_register.c
@@ -121,6 +121,7 @@ $(lua_patched): $(cosmopolitan_src) | $(lua_build_dir)
 	cp $(lua_patch_dir)/lsqlite3.h $(lua_cosmo_dir)/third_party/lua/
 	cp $(lua_patch_dir)/largon2.h $(lua_cosmo_dir)/third_party/lua/
 	cp $(lua_patch_dir)/lcosmo.h $(lua_cosmo_dir)/third_party/lua/
+	cp $(lua_patch_dir)/ljson.h $(lua_cosmo_dir)/tool/net/
 	cp $(lua_patch_dir)/lfuncs_register.c $(lua_cosmo_dir)/third_party/lua/
 	cd $(lua_cosmo_dir) && patch -N -p1 < $(CURDIR)/$(lua_patch_dir)/lua.main.c.patch || true
 	cd $(lua_cosmo_dir) && patch -N -p1 < $(CURDIR)/$(lua_patch_dir)/lfuncs.c.patch || true

--- a/3p/lua/lfuncs_register.c
+++ b/3p/lua/lfuncs_register.c
@@ -15,7 +15,84 @@
 #include "third_party/lua/lre.h"
 #include "third_party/lua/largon2.h"
 #include "third_party/lua/lsqlite3.h"
+#include "third_party/lua/cosmo.h"
 #include "tool/net/lfuncs.h"
+#include "tool/net/ljson.h"
+#include <stdlib.h>
+#include <limits.h>
+
+static int LuaDecodeJson(lua_State *L) {
+    size_t n;
+    const char *p;
+    struct DecodeJson r;
+    p = luaL_checklstring(L, 1, &n);
+    r = DecodeJson(L, p, n);
+    if (!r.rc) {
+        lua_pushnil(L);
+        lua_pushstring(L, "unexpected eof");
+        return 2;
+    }
+    if (r.rc == -1) {
+        lua_pushnil(L);
+        lua_pushstring(L, r.p);
+        return 2;
+    }
+    r = DecodeJson(L, r.p, n - (r.p - p));
+    if (r.rc) {
+        lua_pushnil(L);
+        lua_pushstring(L, "junk after expression");
+        return 2;
+    }
+    return 1;
+}
+
+static int LuaEncodeSmth(lua_State *L, int Encoder(lua_State *, char **, int,
+                                                   struct EncoderConfig)) {
+    char *p = 0;
+    struct EncoderConfig conf = {
+        .maxdepth = 64,
+        .sorted = 1,
+        .pretty = 0,
+        .indent = "  ",
+    };
+    if (lua_istable(L, 2)) {
+        lua_settop(L, 2);
+        lua_getfield(L, 2, "maxdepth");
+        if (!lua_isnoneornil(L, -1)) {
+            lua_Integer n = lua_tointeger(L, -1);
+            n = n < 0 ? 0 : (n > SHRT_MAX ? SHRT_MAX : n);
+            conf.maxdepth = n;
+        }
+        lua_getfield(L, 2, "sorted");
+        if (!lua_isnoneornil(L, -1)) {
+            conf.sorted = lua_toboolean(L, -1);
+        }
+        lua_getfield(L, 2, "pretty");
+        if (!lua_isnoneornil(L, -1)) {
+            conf.pretty = lua_toboolean(L, -1);
+            lua_getfield(L, 2, "indent");
+            if (!lua_isnoneornil(L, -1)) {
+                conf.indent = luaL_checkstring(L, -1);
+            }
+        }
+    }
+    lua_settop(L, 1);
+    if (Encoder(L, &p, -1, conf) == -1) {
+        free(p);
+        return 2;
+    }
+    lua_pushstring(L, p);
+    free(p);
+    return 1;
+}
+
+static int LuaEncodeJson(lua_State *L) {
+    return LuaEncodeSmth(L, LuaEncodeJsonData);
+}
+
+static int LuaEncodeLua(lua_State *L) {
+    return LuaEncodeSmth(L, LuaEncodeLuaData);
+}
 
 static const luaL_Reg kCosmoFuncs[] = {
     {"Bsf", LuaBsf},
@@ -27,12 +104,15 @@ static const luaL_Reg kCosmoFuncs[] = {
     {"DecodeBase32", LuaDecodeBase32},
     {"DecodeBase64", LuaDecodeBase64},
     {"DecodeHex", LuaDecodeHex},
+    {"DecodeJson", LuaDecodeJson},
     {"DecodeLatin1", LuaDecodeLatin1},
     {"Deflate", LuaDeflate},
     {"EncodeBase32", LuaEncodeBase32},
     {"EncodeBase64", LuaEncodeBase64},
     {"EncodeHex", LuaEncodeHex},
+    {"EncodeJson", LuaEncodeJson},
     {"EncodeLatin1", LuaEncodeLatin1},
+    {"EncodeLua", LuaEncodeLua},
     {"EscapeFragment", LuaEscapeFragment},
     {"EscapeHost", LuaEscapeHost},
     {"EscapeHtml", LuaEscapeHtml},

--- a/3p/lua/lfuncs_register.c
+++ b/3p/lua/lfuncs_register.c
@@ -95,8 +95,10 @@ static int LuaEncodeLua(lua_State *L) {
 }
 
 static const luaL_Reg kCosmoFuncs[] = {
+    {"Barf", LuaBarf},
     {"Bsf", LuaBsf},
     {"Bsr", LuaBsr},
+    {"bin", LuaBin},
     {"CategorizeIp", LuaCategorizeIp},
     {"Compress", LuaCompress},
     {"Crc32", LuaCrc32},
@@ -113,6 +115,7 @@ static const luaL_Reg kCosmoFuncs[] = {
     {"EncodeJson", LuaEncodeJson},
     {"EncodeLatin1", LuaEncodeLatin1},
     {"EncodeLua", LuaEncodeLua},
+    {"EncodeUrl", LuaEncodeUrl},
     {"EscapeFragment", LuaEscapeFragment},
     {"EscapeHost", LuaEscapeHost},
     {"EscapeHtml", LuaEscapeHtml},
@@ -135,6 +138,7 @@ static const luaL_Reg kCosmoFuncs[] = {
     {"GetTime", LuaGetTime},
     {"HasControlCodes", LuaHasControlCodes},
     {"HighwayHash64", LuaHighwayHash64},
+    {"hex", LuaHex},
     {"IndentLines", LuaIndentLines},
     {"Inflate", LuaInflate},
     {"IsAcceptableHost", LuaIsAcceptableHost},
@@ -148,13 +152,21 @@ static const luaL_Reg kCosmoFuncs[] = {
     {"IsValidHttpToken", LuaIsValidHttpToken},
     {"Lemur64", LuaLemur64},
     {"MeasureEntropy", LuaMeasureEntropy},
+    {"oct", LuaOct},
     {"ParseHost", LuaParseHost},
     {"ParseHttpDateTime", LuaParseHttpDateTime},
     {"ParseIp", LuaParseIp},
     {"ParseParams", LuaParseParams},
+    {"ParseUrl", LuaParseUrl},
     {"Popcnt", LuaPopcnt},
+    {"Rand64", LuaRand64},
+    {"ResolveIp", LuaResolveIp},
     {"Sleep", LuaSleep},
+    {"Slurp", LuaSlurp},
     {"Uncompress", LuaUncompress},
+    {"Underlong", LuaUnderlong},
+    {"UuidV4", LuaUuidV4},
+    {"UuidV7", LuaUuidV7},
     {"VisualizeControlCodes", LuaVisualizeControlCodes},
     {NULL, NULL}
 };

--- a/3p/lua/ljson.h
+++ b/3p/lua/ljson.h
@@ -1,0 +1,14 @@
+#ifndef COSMOPOLITAN_TOOL_NET_LJSON_H_
+#define COSMOPOLITAN_TOOL_NET_LJSON_H_
+#include "third_party/lua/lauxlib.h"
+COSMOPOLITAN_C_START_
+
+struct DecodeJson {
+  int rc;
+  const char *p;
+};
+
+struct DecodeJson DecodeJson(struct lua_State *, const char *, size_t);
+
+COSMOPOLITAN_C_END_
+#endif

--- a/3p/lua/test_funcs.lua
+++ b/3p/lua/test_funcs.lua
@@ -49,6 +49,61 @@ function test_cosmo_DecodeLatin1()
     lu.assertNotNil(cosmo.DecodeLatin1)
 end
 
+function test_cosmo_DecodeJson()
+    lu.assertNotNil(cosmo.DecodeJson)
+    local result = cosmo.DecodeJson('{"key": "value", "num": 42}')
+    lu.assertNotNil(result)
+    lu.assertEquals(result.key, "value")
+    lu.assertEquals(result.num, 42)
+end
+
+function test_cosmo_DecodeJson_array()
+    lu.assertNotNil(cosmo.DecodeJson)
+    local result = cosmo.DecodeJson('[1, 2, 3]')
+    lu.assertNotNil(result)
+    lu.assertEquals(result[1], 1)
+    lu.assertEquals(result[2], 2)
+    lu.assertEquals(result[3], 3)
+end
+
+function test_cosmo_DecodeJson_error()
+    lu.assertNotNil(cosmo.DecodeJson)
+    local result, err = cosmo.DecodeJson('invalid json')
+    lu.assertNil(result)
+    lu.assertNotNil(err)
+end
+
+function test_cosmo_EncodeJson()
+    lu.assertNotNil(cosmo.EncodeJson)
+    local json = cosmo.EncodeJson({key = "value", num = 42})
+    lu.assertNotNil(json)
+    lu.assertStrContains(json, '"key"')
+    lu.assertStrContains(json, '"value"')
+    lu.assertStrContains(json, '42')
+end
+
+function test_cosmo_EncodeJson_array()
+    lu.assertNotNil(cosmo.EncodeJson)
+    local json = cosmo.EncodeJson({1, 2, 3})
+    lu.assertNotNil(json)
+    lu.assertEquals(json, "[1,2,3]")
+end
+
+function test_cosmo_EncodeJson_pretty()
+    lu.assertNotNil(cosmo.EncodeJson)
+    local json = cosmo.EncodeJson({a = 1, b = 2}, {pretty = true})
+    lu.assertNotNil(json)
+    lu.assertStrContains(json, "\n")
+end
+
+function test_cosmo_EncodeLua()
+    lu.assertNotNil(cosmo.EncodeLua)
+    local lua_str = cosmo.EncodeLua({key = "value", num = 42})
+    lu.assertNotNil(lua_str)
+    lu.assertStrContains(lua_str, "key")
+    lu.assertStrContains(lua_str, "value")
+end
+
 -- escape functions
 function test_cosmo_EscapeHtml()
     lu.assertNotNil(cosmo.EscapeHtml)

--- a/3p/lua/test_funcs.lua
+++ b/3p/lua/test_funcs.lua
@@ -213,7 +213,6 @@ function test_cosmo_FormatIp()
 end
 
 function test_cosmo_ResolveIp()
-    lu.skipIf(missing("ResolveIp"), "not in lfuncs.c")
     lu.assertNotNil(cosmo.ResolveIp)
 end
 
@@ -245,19 +244,19 @@ function test_cosmo_GetRandomBytes()
     lu.assertEquals(#bytes, 16)
 end
 
--- uuid functions (not in lfuncs.c)
+-- uuid functions
 function test_cosmo_UuidV4()
-    lu.skipIf(missing("UuidV4"), "not in lfuncs.c")
     lu.assertNotNil(cosmo.UuidV4)
     local uuid = cosmo.UuidV4()
     lu.assertEquals(#uuid, 36)
+    lu.assertStrMatches(uuid, "%x%x%x%x%x%x%x%x%-%x%x%x%x%-4%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x")
 end
 
 function test_cosmo_UuidV7()
-    lu.skipIf(missing("UuidV7"), "not in lfuncs.c")
     lu.assertNotNil(cosmo.UuidV7)
     local uuid = cosmo.UuidV7()
     lu.assertEquals(#uuid, 36)
+    lu.assertStrMatches(uuid, "%x%x%x%x%x%x%x%x%-%x%x%x%x%-7%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x")
 end
 
 -- date/time functions (LFUNCS_LITE: FormatHttpDateTime excluded)
@@ -328,15 +327,22 @@ function test_cosmo_Decimate()
     lu.assertNotNil(cosmo.Decimate)
 end
 
--- not in lfuncs.c
+-- file I/O
 function test_cosmo_Slurp()
-    lu.skipIf(missing("Slurp"), "not in lfuncs.c")
     lu.assertNotNil(cosmo.Slurp)
 end
 
 function test_cosmo_Barf()
-    lu.skipIf(missing("Barf"), "not in lfuncs.c")
     lu.assertNotNil(cosmo.Barf)
+end
+
+function test_cosmo_Slurp_Barf_roundtrip()
+    local testfile = "/tmp/cosmo_test_" .. tostring(os.time()) .. ".txt"
+    local content = "hello world\ntest content"
+    cosmo.Barf(testfile, content)
+    local read = cosmo.Slurp(testfile)
+    lu.assertEquals(read, content)
+    os.remove(testfile)
 end
 
 function test_cosmo_Sleep()
@@ -358,26 +364,53 @@ end
 
 -- random number generators
 function test_cosmo_Rand64()
-    lu.skipIf(missing("Rand64"), "not in lfuncs.c")
     lu.assertNotNil(cosmo.Rand64)
+    local r = cosmo.Rand64()
+    lu.assertNotNil(r)
 end
 
 function test_cosmo_Lemur64()
     lu.assertNotNil(cosmo.Lemur64)
 end
 
--- low-level formatting (not in lfuncs.c)
+-- number formatting
 function test_cosmo_bin()
-    lu.skipIf(missing("bin"), "not in lfuncs.c")
     lu.assertNotNil(cosmo.bin)
+    lu.assertEquals(cosmo.bin(255), "0b11111111")
 end
 
 function test_cosmo_hex()
-    lu.skipIf(missing("hex"), "not in lfuncs.c")
     lu.assertNotNil(cosmo.hex)
+    lu.assertEquals(cosmo.hex(255), "0xff")
 end
 
 function test_cosmo_oct()
-    lu.skipIf(missing("oct"), "not in lfuncs.c")
     lu.assertNotNil(cosmo.oct)
+    lu.assertEquals(cosmo.oct(255), "0377")
+end
+
+-- URL functions
+function test_cosmo_ParseUrl()
+    lu.assertNotNil(cosmo.ParseUrl)
+    local url = cosmo.ParseUrl("https://user:pass@example.com:8080/path?foo=bar#frag")
+    lu.assertEquals(url.scheme, "https")
+    lu.assertEquals(url.user, "user")
+    lu.assertEquals(url.pass, "pass")
+    lu.assertEquals(url.host, "example.com")
+    lu.assertEquals(url.port, "8080")
+    lu.assertEquals(url.path, "/path")
+    lu.assertEquals(url.fragment, "frag")
+end
+
+function test_cosmo_EncodeUrl()
+    lu.assertNotNil(cosmo.EncodeUrl)
+    local url = cosmo.EncodeUrl({scheme = "https", host = "example.com", path = "/test"})
+    lu.assertEquals(url, "https://example.com/test")
+end
+
+-- encoding
+function test_cosmo_Underlong()
+    lu.assertNotNil(cosmo.Underlong)
+    local encoded = cosmo.Underlong("hello")
+    lu.assertNotNil(encoded)
 end


### PR DESCRIPTION
## Summary
Add redbean utility functions to standalone lua build:

**JSON:**
- `DecodeJson` - parse JSON string to Lua table
- `EncodeJson` - serialize Lua table to JSON string
- `EncodeLua` - serialize Lua table to Lua code string

**URL:**
- `ParseUrl` - parse URL into components (scheme, host, port, path, params, etc.)
- `EncodeUrl` - build URL from components table

**UUID:**
- `UuidV4` - generate random UUID v4
- `UuidV7` - generate time-ordered UUID v7

**File I/O:**
- `Slurp` - read file contents to string
- `Barf` - write string to file

**Random:**
- `Rand64` - random 64-bit integer

**Number formatting:**
- `bin` - format integer as binary string
- `hex` - format integer as hex string
- `oct` - format integer as octal string

**Encoding:**
- `Underlong` - underlong encoding

## Test plan
- [x] `make test-3p-lua` passes (79 tests, 0 failures)