### PR TITLE
aerospace: chain aerosnap load on config reload

### DIFF
--- a/.aerospace.toml
+++ b/.aerospace.toml
@@ -72,7 +72,7 @@ alt-shift-o = 'layout horizontal vertical'   # Toggle orientation
 alt-r = 'mode resize'
 
 # Reload config
-alt-shift-r = 'reload-config'
+alt-shift-r = ['reload-config', 'exec-and-forget aerosnap load']
 
 # Close window
 alt-shift-q = 'close'


### PR DESCRIPTION
## Summary
- Chains `aerosnap load` after `reload-config` on alt-shift-r
- Restores window-to-workspace assignments automatically after config reload

## Test plan
- [ ] Press alt-shift-r, verify windows restore to saved workspaces