### PR TITLE
hammerspoon: move clock to left side of menu bar

### DIFF
--- a/.aerospace.toml
+++ b/.aerospace.toml
@@ -72,7 +72,7 @@ alt-shift-o = 'layout horizontal vertical'   # Toggle orientation
 alt-r = 'mode resize'
 
 # Reload config
-alt-shift-r = 'reload-config'
+alt-shift-r = ['reload-config', 'exec-and-forget aerosnap load']
 
 # Close window
 alt-shift-q = 'close'

--- a/.config/hammerspoon/notch-clock.lua
+++ b/.config/hammerspoon/notch-clock.lua
@@ -12,12 +12,10 @@ local function updateClockText()
 end
 
 local function getClockPosition()
-	local screen = hs.screen.mainScreen()
-	local fullFrame = screen:fullFrame()
 	local clockWidth = 130
 
 	return {
-		x = fullFrame.w - clockWidth - 19,
+		x = 10,
 		y = 6,
 		w = clockWidth,
 		h = 24,


### PR DESCRIPTION
## Summary
- Move notch-clock from right side of menu bar to left side (x=10)

## Test plan
- [x] Verified clock displays on left side of menu bar after reload