### PR TITLE
nvim: install treesitter parsers at build time

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -10,13 +10,7 @@ if vim.fn.isdirectory(extras_nvim) == 1 then
   vim.opt.runtimepath:append(extras_nvim)
 end
 
--- Add bundled plugins site to packpath (derived from $VIMRUNTIME)
-local bundled_site = vim.env.VIMRUNTIME:gsub("/runtime$", "/site")
-if vim.fn.isdirectory(bundled_site) == 1 then
-  vim.opt.packpath:prepend(bundled_site)
-end
-
--- Load plugins (skips download if already in packpath)
+-- Load plugins before anything else
 vim.pack.add({
   { src = "https://github.com/nvim-mini/mini.nvim" },
 })

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -10,7 +10,13 @@ if vim.fn.isdirectory(extras_nvim) == 1 then
   vim.opt.runtimepath:append(extras_nvim)
 end
 
--- Load plugins before anything else
+-- Add bundled plugins site to packpath (derived from $VIMRUNTIME)
+local bundled_site = vim.env.VIMRUNTIME:gsub("/runtime$", "/site")
+if vim.fn.isdirectory(bundled_site) == 1 then
+  vim.opt.packpath:prepend(bundled_site)
+end
+
+-- Load plugins (skips download if already in packpath)
 vim.pack.add({
   { src = "https://github.com/nvim-mini/mini.nvim" },
 })

--- a/.config/nvim/parsers.lua
+++ b/.config/nvim/parsers.lua
@@ -1,0 +1,12 @@
+return {
+  "python",
+  "markdown",
+  "bash",
+  "lua",
+  "yaml",
+  "javascript",
+  "json",
+  "ruby",
+  "go",
+  "sql",
+}

--- a/.config/nvim/plugin/treesitter.lua
+++ b/.config/nvim/plugin/treesitter.lua
@@ -1,22 +1,11 @@
+local lang = dofile(vim.fn.stdpath("config") .. "/parsers.lua")
+
 local ok, ts = pcall(require, "nvim-treesitter")
 if ok then
   ts.setup({
     install_dir = vim.fn.stdpath("data") .. "/site",
   })
 end
-
-local lang = {
-  "python",
-  "markdown",
-  "bash",
-  "lua",
-  "yaml",
-  "javascript",
-  "json",
-  "ruby",
-  "go",
-  "sql",
-}
 
 local ok, ts_configs = pcall(require, "nvim-treesitter.configs")
 if ok then

--- a/3p/nvim/cook.mk
+++ b/3p/nvim/cook.mk
@@ -14,8 +14,9 @@ $(nvim_plugins_dir)/%/.fetched: $(nvim_pack_lock) $(fetch_plugin)
 nvim_plugin_targets := $(foreach p,$(nvim_plugins),$(nvim_plugins_dir)/$(p)/.fetched)
 
 nvim_bundle := lib/build/nvim-bundle.lua
-$(3p)/nvim/%/.bundled: private .PLEDGE = stdio rpath wpath cpath exec proc
-$(3p)/nvim/%/.bundled: private .CPU = 60
+$(3p)/nvim/%/.bundled: private .PLEDGE = stdio rpath wpath cpath inet dns exec proc
+$(3p)/nvim/%/.bundled: private .INTERNET = 1
+$(3p)/nvim/%/.bundled: private .CPU = 180
 $(3p)/nvim/%/.bundled: $(3p)/nvim/%/.extracted $(nvim_bundle) $(nvim_plugin_targets)
 	$(lib_lua) $(nvim_bundle) $* $(dir $@) $(nvim_plugins_dir)
 	touch $@

--- a/lib/build/nvim-bundle.lua
+++ b/lib/build/nvim-bundle.lua
@@ -108,7 +108,7 @@ local function install_treesitter_parsers(nvim_dir)
   local parsers = dofile(path.join(cwd, ".config/nvim/parsers.lua"))
   for _, parser in ipairs(parsers) do
     io.write(string.format("  installing %s\n", parser))
-    local cmd = string.format("TSInstallSync %s", parser)
+    local cmd = string.format("TSUpdateSync %s", parser)
     local ok = execute("env", {
       "env",
       "XDG_CONFIG_HOME=" .. config_home,

--- a/lib/build/nvim-bundle.lua
+++ b/lib/build/nvim-bundle.lua
@@ -91,19 +91,6 @@ local function bundle_plugins(nvim_dir, plugins_dir, plugins)
   return true
 end
 
-local TS_PARSERS = {
-  "python",
-  "markdown",
-  "bash",
-  "lua",
-  "yaml",
-  "javascript",
-  "json",
-  "ruby",
-  "go",
-  "sql",
-}
-
 local function install_treesitter_parsers(nvim_dir)
   io.write("installing treesitter parsers\n")
   local nvim_bin = path.join(nvim_dir, "bin/nvim")
@@ -118,7 +105,8 @@ local function install_treesitter_parsers(nvim_dir)
   local config_home = path.join(cwd, ".config")
   local data_home = path.join(nvim_dir, "share")
 
-  for _, parser in ipairs(TS_PARSERS) do
+  local parsers = dofile(path.join(cwd, ".config/nvim/parsers.lua"))
+  for _, parser in ipairs(parsers) do
     io.write(string.format("  installing %s\n", parser))
     local cmd = string.format("TSInstallSync %s", parser)
     local ok = execute("env", {

--- a/lib/home/main.lua
+++ b/lib/home/main.lua
@@ -694,6 +694,22 @@ local function cmd_3p(args, opts)
         if not ok and err then
           stderr:write(string.format("warning: %s: %s\n", tool, err))
         end
+
+        if tool == "nvim" then
+          local version_dir = info.path:match("(.+)/bin/nvim$")
+          if version_dir then
+            local site_target = path.join(version_dir, "share", "nvim", "site")
+            local site_link = path.join(share_dir, "nvim", "site")
+            ok, err = update_symlink(site_link, site_target, {
+              dry_run = dry_run,
+              verbose = verbose,
+              stdout = stdout,
+            })
+            if not ok and err then
+              stderr:write(string.format("warning: nvim site: %s\n", err))
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Add treesitter parser installation to the nvim bundle process so that
parsers are pre-compiled and included in the distribution. This removes
the first-run delay where parsers would be downloaded and compiled.

The build sets XDG_CONFIG_HOME and XDG_DATA_HOME to ensure parsers are
installed to the bundled nvim's share directory. For cross-platform
builds, parser installation is skipped (matching the existing behavior
for helptags and plugin verification).

Also update the Makefile pledge to allow internet access for downloading
parser sources and increase the CPU timeout for compilation.