### PR TITLE
nvim: add bundled site to runtimepath based on binary location

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -4,6 +4,13 @@
 local home = vim.fn.expand("~")
 package.path = home .. "/lib/?.lua;" .. home .. "/lib/3p/?.lua;" .. package.path
 
+-- Add bundled site directory (relative to nvim binary) to runtimepath
+local version_dir = vim.fn.fnamemodify(vim.v.progpath, ":h:h")
+local bundled_site = version_dir .. "/share/nvim/site"
+if vim.fn.isdirectory(bundled_site) == 1 then
+  vim.opt.runtimepath:prepend(bundled_site)
+end
+
 -- Add extras to runtimepath if it exists
 local extras_nvim = home .. "/extras/nvim"
 if vim.fn.isdirectory(extras_nvim) == 1 then


### PR DESCRIPTION
## Summary
- Derive site directory from `vim.v.progpath` so nvim finds pre-built treesitter parsers
- Eliminates need for symlink from `~/.local/share/nvim/site` to versioned site directory
- Fixes issue where parsers were being recompiled at runtime despite being pre-built

## Test plan
- [ ] Restart nvim and verify bundled site appears first in runtimepath
- [ ] Confirm treesitter parsers load without downloading/compiling