### PR TITLE
ast-grep: make errors fail the build

### DIFF
--- a/.ast-grep/rules/unsafe-path-concat.yml
+++ b/.ast-grep/rules/unsafe-path-concat.yml
@@ -1,6 +1,6 @@
 id: unsafe-path-concat
 language: lua
-severity: warning
+severity: error
 message: |
   Unsafe path concatenation detected. Use cosmo.path.join() instead of string concatenation.
 

--- a/lib/home/gen-manifest.lua
+++ b/lib/home/gen-manifest.lua
@@ -11,7 +11,7 @@ local function walk_dir(dir, base, files)
   for name in unix.opendir(dir) do
     if name ~= "." and name ~= ".." then
       local full_path = path.join(dir, name)
-      local rel_path = base == "" and name or (base .. "/" .. name)
+      local rel_path = base == "" and name or path.join(base, name)
       local st = unix.stat(full_path)
 
       if st then

--- a/lib/home/main.lua
+++ b/lib/home/main.lua
@@ -494,7 +494,8 @@ local function cmd_unpack(dest, force, opts)
     end
 
     local plat_manifest = load_platform_manifest(current)
-    local url = platform_url or (interpolate(platforms.base_url, { tag = platforms.tag }) .. "/" .. plat_info.asset)
+    local base_url = interpolate(platforms.base_url, { tag = platforms.tag })
+    local url = platform_url or string.format("%s/%s", base_url, plat_info.asset)
     local tmp_path = path.join(dest, ".home-platform-download")
 
     if not dry_run then

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,14 +1,8 @@
 ruleDirs:
   - .ast-grep/rules
 
-# Scan all lua files including tests and configs
-# Exclude nvim and hammerspoon (they use their own lua environments)
-# Exclude work tests (separate work in progress)
 languageGlobs:
   lua:
     - "**/*.lua"
     - ".local/bin/*"
     - ".claude/skills/*/main.lua"
-    - "!.config/nvim/**/*.lua"
-    - "!.config/hammerspoon/**/*.lua"
-    - "!lib/test/work/**/*.lua"


### PR DESCRIPTION
## Summary
- Change `unsafe-path-concat` severity from warning to error so build fails on violations
- Remove excludes from sgconfig.yml (nvim, hammerspoon, work tests)
- Fix existing violations:
  - `gen-manifest.lua`: use `path.join` for relative path construction
  - `main.lua`: use `string.format` for URL construction (not a filesystem path)

## Test plan
- [x] `make check` passes with no errors
- [x] `sg scan` exits with code 1 on violations