### PR TITLE
aerosnap: use sqlite for per-window workspace mappings

### DIFF
--- a/.aerospace.toml
+++ b/.aerospace.toml
@@ -8,8 +8,6 @@ start-at-login = true
 # Load window snapshot on startup
 after-startup-command = ['exec-and-forget aerosnap load']
 
-# Save window snapshot on workspace change
-exec-on-workspace-change = ['/bin/bash', '-c', 'aerosnap save']
 
 # Normalizations (keeps layout tree sensible)
 enable-normalization-flatten-containers = true
@@ -91,8 +89,8 @@ alt-shift-q = 'close'
 # Minimize window
 alt-m = 'macos-native-minimize'
 
-# Window snapshot (save/restore workspace assignments)
-alt-shift-s = 'exec-and-forget aerosnap save'
+# Window snapshot (seed all/restore workspace assignments)
+alt-shift-s = 'exec-and-forget aerosnap seed'
 alt-shift-w = 'exec-and-forget aerosnap load'
 
 # Workspace switching
@@ -102,12 +100,12 @@ alt-3 = 'workspace 3'
 alt-4 = 'workspace 4'
 alt-5 = 'workspace 5'
 
-# Move window to workspace (and follow, then snapshot)
-alt-shift-1 = ['move-node-to-workspace 1', 'workspace 1', 'exec-and-forget aerosnap save']
-alt-shift-2 = ['move-node-to-workspace 2', 'workspace 2', 'exec-and-forget aerosnap save']
-alt-shift-3 = ['move-node-to-workspace 3', 'workspace 3', 'exec-and-forget aerosnap save']
-alt-shift-4 = ['move-node-to-workspace 4', 'workspace 4', 'exec-and-forget aerosnap save']
-alt-shift-5 = ['move-node-to-workspace 5', 'workspace 5', 'exec-and-forget aerosnap save']
+# Move window to workspace (and follow, then record)
+alt-shift-1 = ['move-node-to-workspace 1', 'workspace 1', 'exec-and-forget aerosnap record']
+alt-shift-2 = ['move-node-to-workspace 2', 'workspace 2', 'exec-and-forget aerosnap record']
+alt-shift-3 = ['move-node-to-workspace 3', 'workspace 3', 'exec-and-forget aerosnap record']
+alt-shift-4 = ['move-node-to-workspace 4', 'workspace 4', 'exec-and-forget aerosnap record']
+alt-shift-5 = ['move-node-to-workspace 5', 'workspace 5', 'exec-and-forget aerosnap record']
 
 # Resize mode
 [mode.resize.binding]

--- a/.local/bin/aerosnap
+++ b/.local/bin/aerosnap
@@ -3,157 +3,250 @@
 local cosmo = require("cosmo")
 local unix = cosmo.unix
 local path = cosmo.path
+local sqlite3 = cosmo.sqlite3
 local spawn = require("spawn").spawn
 
-local SNAPSHOT_DIR = path.join(os.getenv("HOME"), ".cache", "aerospace")
-local SNAPSHOT_FILE = path.join(SNAPSHOT_DIR, "window-snapshot.json")
+local DB_DIR = path.join(os.getenv("HOME"), ".cache", "aerospace")
+local DB_FILE = path.join(DB_DIR, "window-mappings.db")
 
-local function get_all_windows()
-  local handle = spawn({"aerospace", "list-windows", "--all", "--json"})
-  if not handle then
-    return nil, "failed to get windows from aerospace"
-  end
-  local _, json_output = handle:read()
-  if not json_output or json_output == "" then
-    return nil, "failed to get windows from aerospace"
-  end
-
-  local windows = cosmo.DecodeJson(json_output)
-  local enriched = {}
-
-  handle = spawn({
-    "aerospace", "list-windows", "--all",
-    "--format", "%{window-id}|%{app-bundle-id}|%{app-pid}|%{workspace}|%{monitor-id}"
-  })
-  local _, format_output = handle:read()
-  for _, win in ipairs(windows) do
-    for line in (format_output or ""):gmatch("[^\n]+") do
-      local window_id, bundle_id, pid_str, workspace, monitor_id = line:match("^(%d+)|([^|]*)|([^|]*)|([^|]*)|([^|]*)")
-      if window_id and tonumber(window_id) == win["window-id"] then
-        table.insert(enriched, {
-          ["window-id"] = tonumber(window_id),
-          ["app-name"] = win["app-name"],
-          ["app-bundle-id"] = bundle_id,
-          ["app-pid"] = tonumber(pid_str),
-          ["workspace"] = workspace,
-          ["monitor-id"] = tonumber(monitor_id),
-          ["window-title"] = win["window-title"],
-        })
-        break
-      end
-    end
-  end
-  return enriched
+local function open_db()
+  unix.makedirs(DB_DIR)
+  local db = sqlite3.open(DB_FILE)
+  db:exec([[
+    create table if not exists window_mappings (
+      id integer primary key autoincrement,
+      app_bundle_id text not null,
+      app_name text,
+      window_title text not null,
+      workspace text not null,
+      created_at text default current_timestamp,
+      updated_at text default current_timestamp
+    );
+    create unique index if not exists idx_bundle_title
+      on window_mappings(app_bundle_id, window_title);
+  ]])
+  return db
 end
 
-local function cmd_save(args)
+local function get_focused_window()
+  local handle = spawn({
+    "aerospace", "list-windows", "--focused",
+    "--format", "%{window-id}\t%{app-bundle-id}\t%{app-name}\t%{workspace}\t%{window-title}"
+  })
+  if not handle then return nil, "failed to get focused window" end
+  local _, output = handle:read()
+  if not output or output == "" then
+    return nil, "no focused window"
+  end
+
+  local window_id, bundle_id, app_name, workspace, title = output:match("^(%d+)\t([^\t]*)\t([^\t]*)\t([^\t]*)\t([^\n]*)")
+  if window_id then
+    return {
+      ["window-id"] = tonumber(window_id),
+      ["app-name"] = app_name,
+      ["app-bundle-id"] = bundle_id,
+      ["workspace"] = workspace,
+      ["window-title"] = title or "",
+    }
+  end
+  return nil, "failed to parse focused window"
+end
+
+local function get_all_windows()
+  local handle = spawn({
+    "aerospace", "list-windows", "--all",
+    "--format", "%{window-id}\t%{app-bundle-id}\t%{app-name}\t%{workspace}\t%{window-title}"
+  })
+  if not handle then return nil, "failed to get windows" end
+  local _, output = handle:read()
+  if not output or output == "" then
+    return nil, "failed to get windows"
+  end
+
+  local windows = {}
+  for line in output:gmatch("[^\n]+") do
+    local window_id, bundle_id, app_name, workspace, title = line:match("^(%d+)\t([^\t]*)\t([^\t]*)\t([^\t]*)\t(.*)")
+    if window_id then
+      table.insert(windows, {
+        ["window-id"] = tonumber(window_id),
+        ["app-name"] = app_name,
+        ["app-bundle-id"] = bundle_id,
+        ["workspace"] = workspace,
+        ["window-title"] = title or "",
+      })
+    end
+  end
+  return windows
+end
+
+local function cmd_record(args)
+  local win, err = get_focused_window()
+  if not win then
+    io.stderr:write("error: " .. err .. "\n")
+    return 1
+  end
+
+  if not win["app-bundle-id"] or win["app-bundle-id"] == "" then
+    io.stderr:write("error: window has no bundle id\n")
+    return 1
+  end
+
+  local db = open_db()
+  local stmt = db:prepare([[
+    insert into window_mappings (app_bundle_id, app_name, window_title, workspace)
+    values (?, ?, ?, ?)
+    on conflict(app_bundle_id, window_title) do update set
+      app_name = excluded.app_name,
+      workspace = excluded.workspace,
+      updated_at = current_timestamp
+  ]])
+  stmt:bind_values(
+    win["app-bundle-id"],
+    win["app-name"] or "",
+    win["window-title"] or "",
+    win.workspace
+  )
+  stmt:step()
+  stmt:finalize()
+  db:close()
+
+  io.write(string.format("recorded: %s '%s' -> workspace %s\n",
+    win["app-name"] or win["app-bundle-id"],
+    win["window-title"] or "(untitled)",
+    win.workspace))
+  return 0
+end
+
+local function cmd_load(args)
+  local db = open_db()
+  local current_windows, err = get_all_windows()
+  if not current_windows then
+    io.stderr:write("error: " .. err .. "\n")
+    db:close()
+    return 1
+  end
+
+  local moved, matched = 0, 0
+
+  for _, win in ipairs(current_windows) do
+    local target_workspace = nil
+    local match_type = nil
+
+    for row in db:nrows([[
+      select workspace, app_name, window_title from window_mappings
+      where app_bundle_id = ?
+      order by
+        case when window_title = ? then 0 else 1 end,
+        updated_at desc
+      limit 1
+    ]], win["app-bundle-id"], win["window-title"] or "") do
+      target_workspace = row.workspace
+      if row.window_title == (win["window-title"] or "") then
+        match_type = "exact"
+      else
+        match_type = "bundle"
+      end
+    end
+
+    if target_workspace and target_workspace ~= win.workspace then
+      spawn({"aerospace", "move-node-to-workspace", target_workspace,
+             "--window-id", tostring(win["window-id"])}):wait()
+      moved = moved + 1
+      io.write(string.format("moved (%s): %s '%s' -> %s\n",
+        match_type,
+        win["app-name"] or win["app-bundle-id"],
+        win["window-title"] or "(untitled)",
+        target_workspace))
+    elseif target_workspace then
+      matched = matched + 1
+    end
+  end
+
+  db:close()
+  io.write(string.format("already in place: %d, moved: %d\n", matched, moved))
+  return 0
+end
+
+local function cmd_show(args)
+  local db = open_db()
+  io.write("window mappings:\n")
+  io.write(string.format("%-30s %-40s %s\n", "app", "title", "workspace"))
+  io.write(string.rep("-", 80) .. "\n")
+  for row in db:nrows([[
+    select app_name, app_bundle_id, window_title, workspace, updated_at
+    from window_mappings
+    order by workspace, app_name, window_title
+  ]]) do
+    local app = row.app_name
+    if #app > 28 then app = app:sub(1, 28) .. ".." end
+    local title = row.window_title
+    if #title > 38 then title = title:sub(1, 38) .. ".." end
+    io.write(string.format("%-30s %-40s %s\n", app, title, row.workspace))
+  end
+  db:close()
+  return 0
+end
+
+local function cmd_seed(args)
   local windows, err = get_all_windows()
   if not windows then
     io.stderr:write("error: " .. err .. "\n")
     return 1
   end
 
-  unix.makedirs(SNAPSHOT_DIR)
-  local snapshot = {
-    timestamp = os.date("!%Y-%m-%dT%H:%M:%SZ"),
-    windows = windows,
-  }
-  local ok, write_err = pcall(cosmo.Barf, SNAPSHOT_FILE, cosmo.EncodeJson(snapshot, {pretty = true}))
-  if not ok then
-    io.stderr:write("error: " .. (write_err or "failed to write snapshot") .. "\n")
-    return 1
-  end
+  local db = open_db()
+  local stmt = db:prepare([[
+    insert into window_mappings (app_bundle_id, app_name, window_title, workspace)
+    values (?, ?, ?, ?)
+    on conflict(app_bundle_id, window_title) do update set
+      app_name = excluded.app_name,
+      workspace = excluded.workspace,
+      updated_at = current_timestamp
+  ]])
 
-  io.write(string.format("saved %d windows to snapshot\n", #windows))
-  return 0
-end
-
-local function cmd_load(args)
-  local content = cosmo.Slurp(SNAPSHOT_FILE)
-  if not content then
-    io.stderr:write("error: snapshot not found: " .. SNAPSHOT_FILE .. "\n")
-    return 1
-  end
-
-  local snapshot = cosmo.DecodeJson(content)
-  if not snapshot or not snapshot.windows then
-    io.stderr:write("error: invalid snapshot format\n")
-    return 1
-  end
-
-  local current_windows, get_err = get_all_windows()
-  if not current_windows then
-    io.stderr:write("error: " .. get_err .. "\n")
-    return 1
-  end
-
-  local current_by_id = {}
-  for _, win in ipairs(current_windows) do
-    current_by_id[win["window-id"]] = win
-  end
-
-  local moved, matched_by_id, matched_by_attrs, not_found = 0, 0, 0, 0
-
-  for _, snap_win in ipairs(snapshot.windows) do
-    local target_workspace = snap_win.workspace
-    local current_win = current_by_id[snap_win["window-id"]]
-
-    if current_win then
-      if current_win.workspace ~= target_workspace then
-        spawn({"aerospace", "move-node-to-workspace", target_workspace, "--window-id", tostring(snap_win["window-id"])}):wait()
-        moved = moved + 1
-      end
-      matched_by_id = matched_by_id + 1
-    else
-      local found = false
-      for _, cur_win in ipairs(current_windows) do
-        if cur_win["app-bundle-id"] == snap_win["app-bundle-id"] and
-           cur_win["window-title"] == snap_win["window-title"] then
-          if cur_win.workspace ~= target_workspace then
-            spawn({"aerospace", "move-node-to-workspace", target_workspace, "--window-id", tostring(cur_win["window-id"])}):wait()
-            moved = moved + 1
-          end
-          matched_by_attrs = matched_by_attrs + 1
-          found = true
-          break
-        end
-      end
-      if not found then
-        not_found = not_found + 1
-      end
+  local recorded = 0
+  for _, win in ipairs(windows) do
+    if win["app-bundle-id"] and win["app-bundle-id"] ~= "" then
+      stmt:bind_values(
+        win["app-bundle-id"],
+        win["app-name"] or "",
+        win["window-title"] or "",
+        win.workspace
+      )
+      stmt:step()
+      stmt:reset()
+      recorded = recorded + 1
     end
   end
+  stmt:finalize()
+  db:close()
 
-  io.write(string.format("snapshot from: %s\n", snapshot.timestamp))
-  io.write(string.format("matched by window-id: %d\n", matched_by_id))
-  io.write(string.format("matched by attributes: %d\n", matched_by_attrs))
-  io.write(string.format("not found: %d\n", not_found))
-  io.write(string.format("moved: %d\n", moved))
+  io.write(string.format("recorded %d windows\n", recorded))
   return 0
 end
 
-local function cmd_show(args)
-  local content = cosmo.Slurp(SNAPSHOT_FILE)
-  if not content then
-    io.stderr:write("error: snapshot not found: " .. SNAPSHOT_FILE .. "\n")
-    return 1
-  end
-  io.write(content)
+local function cmd_clear(args)
+  local db = open_db()
+  db:exec("delete from window_mappings")
+  db:close()
+  io.write("cleared all window mappings\n")
   return 0
 end
 
 local function cmd_help(args)
-  io.write("aerosnap - snapshot and restore aerospace window assignments\n")
+  io.write("aerosnap - record and restore window-to-workspace mappings\n")
   io.write("\n")
   io.write("usage: aerosnap <command>\n")
   io.write("\n")
   io.write("commands:\n")
-  io.write("  save    capture current window-to-workspace assignments\n")
-  io.write("  load    restore windows to workspaces from snapshot\n")
-  io.write("  show    display current snapshot contents\n")
+  io.write("  record  save focused window's workspace assignment\n")
+  io.write("  seed    save all current windows' workspace assignments\n")
+  io.write("  load    restore windows to their recorded workspaces\n")
+  io.write("  show    display all recorded mappings\n")
+  io.write("  clear   remove all mappings\n")
   io.write("  help    show this help\n")
   io.write("\n")
-  io.write("snapshot location: " .. SNAPSHOT_FILE .. "\n")
+  io.write("database: " .. DB_FILE .. "\n")
   return 0
 end
 
@@ -164,9 +257,11 @@ local function cmd_unknown(command)
 end
 
 local commands = {
-  save = cmd_save,
+  record = cmd_record,
+  seed = cmd_seed,
   load = cmd_load,
   show = cmd_show,
+  clear = cmd_clear,
   help = cmd_help,
 }
 
@@ -194,4 +289,5 @@ end
 return {
   main = main,
   get_all_windows = get_all_windows,
+  get_focused_window = get_focused_window,
 }


### PR DESCRIPTION
## Summary
- Replace JSON snapshot with SQLite database for window-to-workspace mappings
- Only record on explicit user moves (alt-shift-N), not on every workspace change
- Prevents overwrites of intended window arrangements

## Test plan
- [x] `aerosnap record` saves focused window
- [x] `aerosnap seed` saves all current windows
- [x] `aerosnap load` restores windows to recorded workspaces
- [x] `aerosnap show` displays all mappings
- [x] alt-shift-N moves and records window