### PR TITLE
nvim: symlink bundled site directory in setup

### DIFF
--- a/lib/home/setup/nvim.lua
+++ b/lib/home/setup/nvim.lua
@@ -1,9 +1,30 @@
 local cosmo = require("cosmo")
 local unix = cosmo.unix
 local path = cosmo.path
+local version = require("version")
 
 local function run(env)
 	unix.rmrf(path.join(env.DST, ".local", "state", "nvim", "swap"))
+
+	local share_dir = path.join(env.DST, ".local", "share")
+	local nvim = version.find_latest("nvim", share_dir)
+	if not nvim then
+		return 0
+	end
+
+	local bundled_site = path.join(nvim.dir, "share", "nvim", "site")
+	local st = unix.stat(bundled_site)
+	if not st then
+		return 0
+	end
+
+	local nvim_data = path.join(share_dir, "nvim")
+	unix.makedirs(nvim_data, tonumber("755", 8))
+
+	local site_link = path.join(nvim_data, "site")
+	unix.rmrf(site_link)
+	unix.symlink(bundled_site, site_link)
+
 	return 0
 end
 


### PR DESCRIPTION
## Summary
- Symlink `~/.local/share/nvim/site` to the bundled site directory during setup
- This ensures nvim uses pre-bundled plugins and treesitter parsers instead of downloading them on first launch

## Problem
The treesitter parsers and plugins are bundled in the nvim version directory (e.g., `~/.local/share/nvim/0.12.0-dev-.../share/nvim/site`) but at runtime nvim looks for them in `~/.local/share/nvim/site`.

## Test plan
- [x] Run `make test-home` - all tests pass
- [x] Manually verified: after symlinking, `nvim --headless -c 'TSInstallInfo' ...` shows all parsers as installed
- [x] Manually verified: no "Installing plugins" message on nvim startup