### PR TITLE
nvim: Fix Ghostty notifications in Neovim terminal

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -16,6 +16,7 @@ window-save-state = "default"
 mouse-hide-while-typing = true
 clipboard-write = allow
 #adjust-cell-width = 0%
+desktop-notifications = true
 
 scrollback-limit = 0
 bell-features="no-audio,no-system,no-attention,no-title,no-border"

--- a/.config/nvim/plugin/system.lua
+++ b/.config/nvim/plugin/system.lua
@@ -17,3 +17,22 @@ vim.env.NVIM_INVIM = "true"
 
 -- OSC52 clipboard configuration
 vim.g.clipboard = "osc52"
+
+-- OSC passthrough to parent terminal for notifications
+-- Handles OSC 9 and OSC 777 sequences from applications running in :terminal
+vim.api.nvim_create_autocmd("TermRequest", {
+  group = vim.api.nvim_create_augroup("osc_passthrough", { clear = true }),
+  callback = function(args)
+    local payload = args.data and args.data.payload
+    if not payload then return end
+
+    -- Check for OSC 9 (notification) or OSC 777 (notify) sequences
+    -- OSC sequences start with ESC ] and end with BEL or ESC \
+    if payload:match("^9;") or payload:match("^777;notify;") then
+      -- Write the full OSC sequence to stdout to pass to parent terminal
+      -- ESC ] is \x1b], BEL is \x07
+      io.stdout:write(string.format("\x1b]%s\x07", payload))
+      io.stdout:flush()
+    end
+  end,
+})


### PR DESCRIPTION
Adds TermRequest autocmd handler to pass OSC 9 and OSC 777 notification sequences from terminal buffers to parent terminal. This enables Claude Code notifications to work when running in nvim terminal inside Ghostty.