### PR TITLE
nvim: pass WHEREAMI env var from wrapper to neovim

### DIFF
--- a/.config/nvim/plugin/interface.lua
+++ b/.config/nvim/plugin/interface.lua
@@ -19,9 +19,9 @@ opt.shortmess:append('A')  -- ignore swap file messages
 opt.shortmess:append('a')  -- shorter message formats
 
 -- Set terminal title with host identifier
-local ok_whereami, whereami = pcall(require, 'whereami')
-if ok_whereami then
-  opt.titlestring = whereami.get_with_emoji()
+local whereami = vim.env.WHEREAMI
+if whereami then
+  opt.titlestring = whereami
 end
 
 -- Wild menu (command completion)

--- a/.config/nvim/plugin/mini.lua
+++ b/.config/nvim/plugin/mini.lua
@@ -59,8 +59,7 @@ if ok_hues then
   end
 
   -- Get host identifier and generate deterministic color scheme
-  local ok_whereami, whereami = pcall(require, 'whereami')
-  local host_id = ok_whereami and whereami.get() or 'default'
+  local host_id = vim.env.WHEREAMI or 'default'
   local seed = "1"  -- Change this to get a different color scheme
   local hue = string_to_hue(host_id .. seed)
 

--- a/.config/nvim/plugin/tab.lua
+++ b/.config/nvim/plugin/tab.lua
@@ -156,39 +156,12 @@ _G.render_tabline = function()
     s = s .. '%' .. i .. 'T' .. ' ' .. tab_number .. ' '
   end
 
-  -- Add right-aligned section with environment variables
+  -- Add right-aligned section with host identifier
   s = s .. '%#TabLineFill#%T'
 
-  -- Get environment variables with hostname fallback
-  local github_repo = os.getenv('GITHUB_REPOSITORY') or ''
-  local codespace_name = os.getenv('CODESPACE_NAME') or ''
-
-  -- Use hostname as fallback if neither environment variable is set
-  local hostname = ''
-  if github_repo == '' and codespace_name == '' then
-    local ok, whereami = pcall(require, 'whereami')
-    if ok then
-      hostname = whereami.get_with_emoji()
-    end
-  end
-
-  -- Build right section
-  local right_section = ''
-  if github_repo ~= '' then
-    right_section = right_section .. github_repo
-  end
-  if codespace_name ~= '' then
-    if right_section ~= '' then
-      right_section = right_section .. ' | '
-    end
-    right_section = right_section .. codespace_name
-  end
-  if hostname ~= '' and right_section == '' then
-    right_section = hostname
-  end
-
-  if right_section ~= '' then
-    s = s .. '%=' .. '%#TabLine# ' .. right_section .. ' '
+  local whereami = os.getenv('WHEREAMI') or ''
+  if whereami ~= '' then
+    s = s .. '%=' .. '%#TabLine# ' .. whereami .. ' '
   end
 
   return s

--- a/lib/nvim/main.lua
+++ b/lib/nvim/main.lua
@@ -8,24 +8,6 @@ local whereami = require("whereami")
 local HOME = os.getenv("HOME")
 local DEFAULT_SOCK = path.join(HOME, ".config", "nvim", "nvim.sock")
 
-local function get_whereami_env()
-  return {
-    WHEREAMI = whereami.get(),
-    WHEREAMI_EMOJI = whereami.get_with_emoji(),
-  }
-end
-
-local function enhance_environ()
-  local env = {}
-  for _, entry in ipairs(unix.environ()) do
-    table.insert(env, entry)
-  end
-  for k, v in pairs(get_whereami_env()) do
-    table.insert(env, k .. "=" .. v)
-  end
-  return env
-end
-
 local function resolve_nvim_bin()
   local bin_path = version.resolve_bin("nvim")
   if bin_path then
@@ -184,9 +166,7 @@ end
 local function setup_nvim_environment()
   local env_table = load_zsh_environment()
   env_table["NVIM_SERVER_MODE"] = "1"
-  for k, v in pairs(get_whereami_env()) do
-    env_table[k] = v
-  end
+  env_table["WHEREAMI"] = whereami.get_with_emoji()
   local env = {}
   for k, v in pairs(env_table) do
     table.insert(env, k .. "=" .. v)
@@ -389,7 +369,7 @@ local function client_mode(args, nvim_bin)
     for _, arg in ipairs(args) do
       table.insert(new_args, arg)
     end
-    unix.execve(nvim_bin, new_args, enhance_environ())
+    unix.execve(nvim_bin, new_args, unix.environ())
     return
   end
 
@@ -419,13 +399,13 @@ local function client_mode(args, nvim_bin)
       table.insert(new_args, arg)
     end
 
-    unix.execve(nvim_bin, new_args, enhance_environ())
+    unix.execve(nvim_bin, new_args, unix.environ())
   else
     local new_args = {"nvim"}
     for _, arg in ipairs(remaining_args) do
       table.insert(new_args, arg)
     end
-    unix.execve(nvim_bin, new_args, enhance_environ())
+    unix.execve(nvim_bin, new_args, unix.environ())
   end
 end
 


### PR DESCRIPTION
## Summary
- Call `whereami.get_with_emoji()` in nvim wrapper, pass result as `WHEREAMI` env var
- Update nvim config to use `WHEREAMI` env var instead of requiring whereami module
- Simplify whereami.lua to use cosmo/spawn directly (no fallbacks)
- Use `CODESPACE_NAME` with random suffix stripped for codespaces display

## Test plan
- [x] Run `whereami` command, verify output shows `dotfiles | glorious-succotash 🥒`
- [x] Run whereami tests with `lua lib/run-test.lua lib/test_whereami.lua`