### PR TITLE
hammerspoon: add aero-switcher with MRU tracking

### DIFF
--- a/.aerospace.toml
+++ b/.aerospace.toml
@@ -8,6 +8,8 @@ start-at-login = true
 # Load window snapshot on startup
 after-startup-command = ['exec-and-forget aerosnap load']
 
+# Track window focus for MRU (calls into Hammerspoon via IPC)
+on-focus-changed = ['exec-and-forget hs -c "aeroSwitcher.recordFocus(\'$AEROSPACE_WINDOW_ID\')"']
 
 # Normalizations (keeps layout tree sensible)
 enable-normalization-flatten-containers = true

--- a/.config/hammerspoon/aero-switcher.lua
+++ b/.config/hammerspoon/aero-switcher.lua
@@ -1,0 +1,246 @@
+-- Native switcher using aerospace directly with MRU tracking
+local M = {}
+
+local chooserStyle = require("chooser-style")
+local chooser = nil
+local cachedItems = {}
+local cachedApps = nil
+
+local AEROSPACE = "/opt/homebrew/bin/aerospace"
+local HOME = os.getenv("HOME")
+local DB_PATH = HOME .. "/.cache/switch/mru.db"
+local MRU_SIZE = 50
+
+local FILTERED_APPS = {
+  ["Chess"] = true,
+  ["Karabiner-VirtualHIDDevice-Manager"] = true,
+  ["Bigmac"] = true,
+  ["Books"] = true,
+  ["Archive Utility"] = true,
+  ["Font Book"] = true,
+  ["VoiceOver Utility"] = true,
+  ["Stickies"] = true,
+  ["TextEdit"] = true,
+}
+
+local APP_ADJUSTMENTS = {
+  ["Calendar"] = -150,
+  ["Calculator"] = -150,
+  ["Dictionary"] = -150,
+  ["Activity Monitor"] = -150,
+}
+
+-- MRU database
+local function openDb()
+  hs.fs.mkdir(HOME .. "/.cache/switch")
+  local db = hs.sqlite3.open(DB_PATH)
+  db:exec([[
+    create table if not exists mru (
+      id integer primary key autoincrement,
+      key text unique not null,
+      type text not null,
+      accessed_at text default current_timestamp
+    );
+    create index if not exists idx_mru_accessed on mru(accessed_at desc);
+  ]])
+  return db
+end
+
+local function getMruRankings()
+  local db = openDb()
+  local rankings = {}
+  local rank = 1
+  for row in db:nrows(string.format("select key from mru order by accessed_at desc limit %d", MRU_SIZE)) do
+    rankings[row.key] = rank
+    rank = rank + 1
+  end
+  db:close()
+  return rankings
+end
+
+local function recordAccess(key, itemType)
+  local db = openDb()
+  local stmt = db:prepare([[
+    insert into mru (key, type) values (?, ?)
+    on conflict(key) do update set type = excluded.type, accessed_at = current_timestamp
+  ]])
+  stmt:bind_values(key, itemType)
+  stmt:step()
+  stmt:finalize()
+  db:exec(string.format("delete from mru where id not in (select id from mru order by accessed_at desc limit %d)", MRU_SIZE))
+  db:close()
+end
+
+-- Installed apps (cached in memory)
+local function scanInstalledApps()
+  local apps = {}
+  local seen = {}
+  local dirs = {"/Applications", "/System/Applications", HOME .. "/Applications"}
+  for _, dir in ipairs(dirs) do
+    local iter, data = hs.fs.dir(dir)
+    if iter then
+      for file in iter, data do
+        if file:match("%.app$") then
+          local name = file:gsub("%.app$", "")
+          if not seen[name] and not FILTERED_APPS[name] then
+            seen[name] = true
+            table.insert(apps, name)
+          end
+        end
+      end
+    end
+  end
+  table.sort(apps)
+  return apps
+end
+
+local function getInstalledApps()
+  if not cachedApps then
+    cachedApps = scanInstalledApps()
+  end
+  return cachedApps
+end
+
+-- Scoring
+local function computeScore(item, mruRankings)
+  local score = 0
+  local typePriority = item.type == "window" and 10 or 2
+  score = score + (typePriority * 15)
+
+  local mruRank = mruRankings[item.key]
+  if mruRank then
+    score = score + math.max(0, 100 - (mruRank * 2))
+    item.mruRank = mruRank
+  end
+
+  local adj = APP_ADJUSTMENTS[item.appName] or 0
+  score = score + adj
+  return score
+end
+
+local function getWindows(callback)
+  hs.task.new(AEROSPACE, function(code, stdout, stderr)
+    if code ~= 0 then
+      callback({})
+      return
+    end
+
+    local items = {}
+    for line in stdout:gmatch("[^\n]+") do
+      local window_id, _, app_name, title = line:match("^(%d+)\t([^\t]*)\t([^\t]*)\t(.*)")
+      if window_id and not FILTERED_APPS[app_name] then
+        local display_title = (title and title ~= "") and title or app_name
+        local sub_text = (title and title ~= "") and app_name or "Application window"
+
+        if app_name == "Google Chrome" then
+          local profile = title:match(" %- Google Chrome %- (.+)$")
+          if profile then
+            display_title = title:gsub(" %- Google Chrome %- .+$", "")
+            sub_text = app_name .. " - " .. profile
+          end
+        end
+
+        table.insert(items, {
+          text = display_title,
+          subText = sub_text,
+          key = "window:" .. window_id,
+          window_id = tonumber(window_id),
+          appName = app_name,
+          type = "window",
+        })
+      end
+    end
+    callback(items)
+  end, {"list-windows", "--all", "--format", "%{window-id}\t%{app-bundle-id}\t%{app-name}\t%{window-title}"}):start()
+end
+
+local function refreshItems(callback)
+  getWindows(function(windows)
+    local mruRankings = getMruRankings()
+    local seenApps = {}
+
+    -- Score windows
+    for _, item in ipairs(windows) do
+      item.score = computeScore(item, mruRankings)
+      if item.appName then seenApps[item.appName] = true end
+    end
+
+    -- Add installed apps not already showing as windows
+    local allItems = {}
+    for _, item in ipairs(windows) do
+      table.insert(allItems, item)
+    end
+
+    for _, appName in ipairs(getInstalledApps()) do
+      if not seenApps[appName] then
+        local item = {
+          text = appName,
+          subText = "Launch application",
+          key = "app:" .. appName,
+          appName = appName,
+          type = "installed_app",
+        }
+        item.score = computeScore(item, mruRankings)
+        table.insert(allItems, item)
+      end
+    end
+
+    -- Sort by score
+    table.sort(allItems, function(a, b) return a.score > b.score end)
+
+    -- Move MRU rank 1 to second position
+    if allItems[1] and allItems[1].mruRank == 1 and allItems[2] then
+      local current = table.remove(allItems, 1)
+      table.insert(allItems, 2, current)
+    end
+
+    cachedItems = allItems
+    if callback then callback() end
+  end)
+end
+
+local function onSelect(choice)
+  if not choice or not choice.key then return end
+
+  -- Defer everything so chooser closes immediately
+  hs.timer.doAfter(0, function()
+    local item_type, id = choice.key:match("^(%w+):(.+)$")
+    if item_type == "window" then
+      hs.task.new(AEROSPACE, nil, {"focus", "--window-id", id}):start()
+      recordAccess(choice.key, "window")
+    elseif item_type == "app" then
+      hs.task.new("/usr/bin/open", nil, {"-a", id}):start()
+      recordAccess(choice.key, "app")
+    end
+  end)
+end
+
+-- Record focus from aerospace on-focus-changed callback
+-- Called via: hs -c "aeroSwitcher.recordFocus('$AEROSPACE_WINDOW_ID')"
+function M.recordFocus(windowId)
+  if windowId and windowId ~= "" then
+    recordAccess("window:" .. windowId, "window")
+  end
+end
+
+function M.show()
+  if chooser then
+    chooser:delete()
+  end
+
+  chooser = hs.chooser.new(onSelect)
+  chooserStyle.apply(chooser)
+  chooser:choices(cachedItems)
+  chooser:show()
+
+  refreshItems(function()
+    if chooser then
+      chooser:choices(cachedItems)
+    end
+  end)
+end
+
+-- Preload on module load
+refreshItems()
+
+return M

--- a/.config/hammerspoon/chooser-style.lua
+++ b/.config/hammerspoon/chooser-style.lua
@@ -13,6 +13,8 @@ M.apply = function(chooser)
   chooser:width(widthPercent)
   chooser:rows(15)
   chooser:searchSubText(true)
+  chooser:showImages(false)
+  chooser:showShortcuts(false)
 end
 
 return M

--- a/.config/hammerspoon/init.lua
+++ b/.config/hammerspoon/init.lua
@@ -1,6 +1,8 @@
 local HyperKey = require("hyper-key")
-local windowSwitcher = require("window-switcher")
 local notchClock = require("notch-clock")
+
+-- Global for IPC access (aerospace on-focus-changed callback)
+aeroSwitcher = require("aero-switcher")
 local leaderModal = require("leader-modal")
 local leaderDsl = require("leader-dsl")
 local emojiPicker = require("emoji-picker")
@@ -20,10 +22,10 @@ local function showEmojiChooser()
   end)
 
   chooserStyle.apply(chooser)
+  chooser:initialSelectedRow(1)
   chooser:choices(choices)
   chooser:query("")
   chooser:show()
-  chooser:selectedRow(1)
 end
 
 local function showSymbolChooser()
@@ -35,10 +37,10 @@ local function showSymbolChooser()
   end)
 
   chooserStyle.apply(chooser)
+  chooser:initialSelectedRow(1)
   chooser:choices(choices)
   chooser:query("")
   chooser:show()
-  chooser:selectedRow(1)
 end
 
 local clue_dir = hs.configdir .. "/clues"
@@ -71,20 +73,13 @@ end
 leaderModal.setup(leaderDsl.get_tree(), { timeout_ms = 3000 }, {
   emoji = showEmojiChooser,
   symbol = showSymbolChooser,
-  unfiltered_switcher = function() windowSwitcher.showUnfiltered() end,
+  unfiltered_switcher = function() aeroSwitcher.show() end,
 })
 
-windowSwitcher.setup(hyper)
 notchClock.start({ offsetMinutes = 4 })
 
--- cmd+space opens dispatcher
-hs.hotkey.bind({"cmd"}, "space", function()
-  windowSwitcher.showUnfiltered()
-end)
-
--- cmd+tab opens dispatcher
-hs.hotkey.bind({"cmd"}, "tab", function()
-  windowSwitcher.showUnfiltered()
-end)
+-- Window switcher bindings
+hs.hotkey.bind({"alt"}, "space", function() aeroSwitcher.show() end)
+hs.hotkey.bind({"cmd"}, "space", function() aeroSwitcher.show() end)
 
 hs.alert.show("Hammerspoon loaded")


### PR DESCRIPTION
## Summary

Native Hammerspoon window/app switcher using aerospace and SQLite MRU tracking.

### What's included

- `aero-switcher.lua`: Native switcher calling aerospace via `hs.task`
- Shows windows + installed apps (not currently showing as windows)
- SQLite MRU tracking (50 entries) via `hs.sqlite3`
- Previous window shown first (current window moved to second position)
- Uses `showImages(false)`, `showShortcuts(false)` for faster rendering

### MRU tracking
- aerospace `on-focus-changed` callback records all focus changes via Hammerspoon IPC
- cmd-backtick, alt-h/j/k/l navigation all update MRU

### Bindings
- `alt-space`: Open switcher
- `cmd-space`: Open switcher (replaces Spotlight)

## Test plan
- [x] Verify switcher opens with alt-space and cmd-space
- [x] Verify windows and installed apps appear in list
- [x] Verify MRU ordering (previous window first)
- [x] Verify selection focuses window or launches app
- [ ] Verify cmd-backtick navigation updates MRU