### PR TITLE
Run matrix tests only on release builds

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -48,6 +48,7 @@ jobs:
             results/bin/lua
 
   test:
+    if: github.ref == 'refs/heads/main'
     runs-on: ${{ matrix.os }}
     needs: build
     strategy:


### PR DESCRIPTION
Run cross-platform matrix tests only on main branch pushes (releases). PR builds will run tests once on the main ubuntu-latest builder.