### PR TITLE
cosmos: update to 2025.12.27-ea9307ab0

### DIFF
--- a/3p/cosmos/cook.mk
+++ b/3p/cosmos/cook.mk
@@ -1,9 +1,9 @@
 # cosmos binaries from whilp/cosmopolitan fork
 cosmos_dir := $(3p)/cosmos
-cosmos_version := 2025.12.26-0ce9031da
+cosmos_version := 2025.12.27-ea9307ab0
 cosmos_url := https://github.com/whilp/cosmopolitan/releases/download/$(cosmos_version)
 
-$(eval $(call download_binary_rule,cosmos,lua,$(cosmos_url)/lua,0b571d8a5c4ebc5c23319e2fd06683656bf5e235bc70e9c24a9931b9e1768988))
+$(eval $(call download_binary_rule,cosmos,lua,$(cosmos_url)/lua,499e036d5d6dc3327640bb538766f1118f500f0d690cc8e59f5c4bc12e5ff514))
 $(eval $(call download_binary_rule,cosmos,zip,$(cosmos_url)/zip,357ae4715d03e7eecfaf65645b8f5e7507f02258fb4296670e17776ffc39c380))
 $(eval $(call download_binary_rule,cosmos,unzip,$(cosmos_url)/unzip,54b5aa8b3ef97c4360430dd1325325c17745f3cbbc34740c2c6f02a779991f31))
 $(eval $(call download_binary_rule,cosmos,make,$(cosmos_url)/make,3804b0ed4dc50b10acdac766280d71fe066b349f456e10eb59cca4fbb456b569))


### PR DESCRIPTION
## Summary
- Update cosmos binaries from whilp/cosmopolitan release 2025.12.27-ea9307ab0
- Updated lua binary hash (only changed binary in this release)

## Test plan
- [ ] Verify cosmos binaries download correctly