### PR TITLE
build: replace curl with cosmo.Fetch

### DIFF
--- a/lib/build/download-tool.lua
+++ b/lib/build/download-tool.lua
@@ -97,13 +97,13 @@ local function download_file(url, dest_path)
 
   local status, _, body
   local last_err
-  for attempt = 1, 3 do
+  for attempt = 1, 5 do
     status, _, body = cosmo.Fetch(url)
     if status then
       break
     end
     last_err = tostring(body or "unknown error")
-    if attempt < 3 then
+    if attempt < 5 then
       unix.nanosleep(attempt, 0)
     end
   end

--- a/lib/build/download-tool.lua
+++ b/lib/build/download-tool.lua
@@ -87,7 +87,6 @@ local function load_tool_config(tool_name, platform)
   }
 end
 
--- Download file from URL using curl
 local function download_file(url, dest_path)
   if not url or url == "" then
     return nil, "url cannot be empty"
@@ -96,7 +95,24 @@ local function download_file(url, dest_path)
     return nil, "dest_path cannot be empty"
   end
 
-  return execute("/usr/bin/curl", {"curl", "-fsSL", "-o", dest_path, url})
+  local status, _, body = cosmo.Fetch(url)
+  if not status then
+    return nil, "fetch failed: " .. tostring(body or "unknown error")
+  end
+  if status ~= 200 then
+    return nil, "fetch failed with status " .. tostring(status)
+  end
+
+  local fd = unix.open(dest_path, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, 0644)
+  if not fd or fd < 0 then
+    return nil, "failed to open destination file"
+  end
+  local bytes_written = unix.write(fd, body)
+  unix.close(fd)
+  if bytes_written ~= #body then
+    return nil, "failed to write data"
+  end
+  return true
 end
 
 -- Verify SHA256 checksum

--- a/lib/build/fetch-plugin.lua
+++ b/lib/build/fetch-plugin.lua
@@ -99,34 +99,36 @@ local function fetch_plugin(plugin_name, output_dir)
   -- Ensure parent directory exists
   local parent = output_dir:match("(.+)/[^/]+$")
   if parent then
-    local parent_ok, parent_err = execute("mkdir", {"mkdir", "-p", parent})
-    if not parent_ok then
-      return nil, parent_err
-    end
+    unix.makedirs(parent)
   end
 
   -- Download
-  local curl_ok, curl_err = execute("curl", {"curl", "-fsSL", "-o", tarball, url})
-  if not curl_ok then
-    return nil, curl_err
+  local status, _, body = cosmo.Fetch(url)
+  if not status then
+    return nil, "fetch failed: " .. tostring(body or "unknown error")
+  end
+  if status ~= 200 then
+    return nil, "fetch failed with status " .. tostring(status)
   end
 
-  -- Extract
-  local mkdir_ok, mkdir_err = execute("mkdir", {"mkdir", "-p", output_dir})
-  if not mkdir_ok then
-    execute("rm", {"rm", "-f", tarball})
-    return nil, mkdir_err
+  local fd = unix.open(tarball, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, 0644)
+  if not fd or fd < 0 then
+    return nil, "failed to create tarball"
   end
+  unix.write(fd, body)
+  unix.close(fd)
+
+  -- Extract
+  unix.makedirs(output_dir)
 
   local tar_ok, tar_err = execute("tar", {"tar", "-xzf", tarball, "-C", output_dir, "--strip-components=1"})
   if not tar_ok then
-    execute("rm", {"rm", "-f", tarball})
-    execute("rm", {"rm", "-rf", output_dir})
+    unix.unlink(tarball)
     return nil, tar_err
   end
 
   -- Cleanup tarball
-  execute("rm", {"rm", "-f", tarball})
+  unix.unlink(tarball)
 
   if plugin_name == "nui-components.nvim" then
     execute("rm", {"rm", "-rf", path.join(output_dir, "docs/public")}, { allow_failure = true })

--- a/lib/build/fetch-plugin.lua
+++ b/lib/build/fetch-plugin.lua
@@ -105,13 +105,13 @@ local function fetch_plugin(plugin_name, output_dir)
   -- Download with retry
   local status, _, body
   local last_err
-  for attempt = 1, 3 do
+  for attempt = 1, 5 do
     status, _, body = cosmo.Fetch(url)
     if status then
       break
     end
     last_err = tostring(body or "unknown error")
-    if attempt < 3 then
+    if attempt < 5 then
       unix.nanosleep(attempt, 0)
     end
   end


### PR DESCRIPTION
## Summary
- Replace curl invocations with cosmo.Fetch API in download-tool.lua and fetch-plugin.lua
- Use unix.makedirs/unix.unlink instead of spawning mkdir/rm commands
- Eliminates external curl dependency for HTTP downloads

## Test plan
- [ ] Verify tool downloads work with `make 3p`
- [ ] Verify plugin fetches work with nvim plugin builds