### PR TITLE
fetch: increase maxresponse to 200MB

### DIFF
--- a/.config/nvim/lua/work/form.lua
+++ b/.config/nvim/lua/work/form.lua
@@ -1,4 +1,4 @@
--- work.form - native implementation without nui-components
+-- work.form - native implementation
 local work = require("work")
 local api = work.api
 local render = require("work.render")

--- a/lib/build/download-tool.lua
+++ b/lib/build/download-tool.lua
@@ -98,7 +98,7 @@ local function download_file(url, dest_path)
   local status, headers, body
   local last_err
   local max_attempts = 8
-  local fetch_opts = {headers = {["User-Agent"] = "curl/8.0"}}
+  local fetch_opts = {headers = {["User-Agent"] = "curl/8.0"}, maxresponse = 200 * 1024 * 1024}
   for attempt = 1, max_attempts do
     status, headers, body = cosmo.Fetch(url, fetch_opts)
     if status then

--- a/lib/build/fetch-plugin.lua
+++ b/lib/build/fetch-plugin.lua
@@ -105,7 +105,7 @@ local function fetch_plugin(plugin_name, output_dir)
   local status, headers, body
   local last_err
   local max_attempts = 8
-  local fetch_opts = {headers = {["User-Agent"] = "curl/8.0"}}
+  local fetch_opts = {headers = {["User-Agent"] = "curl/8.0"}, maxresponse = 200 * 1024 * 1024}
   for attempt = 1, max_attempts do
     status, headers, body = cosmo.Fetch(url, fetch_opts)
     if status then

--- a/lib/build/fetch-plugin.lua
+++ b/lib/build/fetch-plugin.lua
@@ -4,7 +4,6 @@
 -- Reads plugin info from .config/nvim/nvim-pack-lock.json
 
 local cosmo = require("cosmo")
-local path = cosmo.path
 local unix = cosmo.unix
 local spawn = require("spawn").spawn
 
@@ -143,10 +142,6 @@ local function fetch_plugin(plugin_name, output_dir)
 
   -- Cleanup tarball
   unix.unlink(tarball)
-
-  if plugin_name == "nui-components.nvim" then
-    unix.rmrf(path.join(output_dir, "docs/public"))
-  end
 
   return true
 end

--- a/lib/home/main.lua
+++ b/lib/home/main.lua
@@ -209,7 +209,7 @@ local function sha256_file(filepath)
 end
 
 local function download_file(url, dest_path)
-  local status, _, body = cosmo.Fetch(url)
+  local status, _, body = cosmo.Fetch(url, {maxresponse = 200 * 1024 * 1024})
   if not status then
     return nil, "fetch failed: " .. tostring(body or "unknown error")
   end

--- a/lib/home/setup/claude.lua
+++ b/lib/home/setup/claude.lua
@@ -20,7 +20,7 @@ local function get_latest_version()
 end
 
 local function get_sha256(url)
-	local status, _, body = cosmo.Fetch(url)
+	local status, _, body = cosmo.Fetch(url, {maxresponse = 200 * 1024 * 1024})
 	if not status then
 		io.stderr:write("error: failed to download claude binary\n")
 		return nil
@@ -69,7 +69,7 @@ local function run(env)
 		else
 			unix.makedirs(version_dir)
 
-			local status, _, body = cosmo.Fetch(CLAUDE_URL)
+			local status, _, body = cosmo.Fetch(CLAUDE_URL, {maxresponse = 200 * 1024 * 1024})
 			if not status or status ~= 200 then
 				io.stderr:write("error: failed to download claude binary\n")
 				return 1


### PR DESCRIPTION
## Summary
- Increase `cosmo.Fetch` maxresponse limit from 100MB to 200MB
- Fixes platform binary downloads (~141MB) failing with "response too large" error

## Test plan
- [x] Verified 141MB platform binary downloads successfully with new limit