### PR TITLE
fetch: increase maxresponse to 300MB

### DIFF
--- a/lib/build/download-tool.lua
+++ b/lib/build/download-tool.lua
@@ -98,7 +98,7 @@ local function download_file(url, dest_path)
   local status, headers, body
   local last_err
   local max_attempts = 8
-  local fetch_opts = {headers = {["User-Agent"] = "curl/8.0"}, maxresponse = 200 * 1024 * 1024}
+  local fetch_opts = {headers = {["User-Agent"] = "curl/8.0"}, maxresponse = 300 * 1024 * 1024}
   for attempt = 1, max_attempts do
     status, headers, body = cosmo.Fetch(url, fetch_opts)
     if status then

--- a/lib/build/fetch-plugin.lua
+++ b/lib/build/fetch-plugin.lua
@@ -105,7 +105,7 @@ local function fetch_plugin(plugin_name, output_dir)
   local status, headers, body
   local last_err
   local max_attempts = 8
-  local fetch_opts = {headers = {["User-Agent"] = "curl/8.0"}, maxresponse = 200 * 1024 * 1024}
+  local fetch_opts = {headers = {["User-Agent"] = "curl/8.0"}, maxresponse = 300 * 1024 * 1024}
   for attempt = 1, max_attempts do
     status, headers, body = cosmo.Fetch(url, fetch_opts)
     if status then

--- a/lib/home/main.lua
+++ b/lib/home/main.lua
@@ -209,7 +209,7 @@ local function sha256_file(filepath)
 end
 
 local function download_file(url, dest_path)
-  local status, _, body = cosmo.Fetch(url, {maxresponse = 200 * 1024 * 1024})
+  local status, _, body = cosmo.Fetch(url, {maxresponse = 300 * 1024 * 1024})
   if not status then
     return nil, "fetch failed: " .. tostring(body or "unknown error")
   end

--- a/lib/home/setup/claude.lua
+++ b/lib/home/setup/claude.lua
@@ -20,7 +20,7 @@ local function get_latest_version()
 end
 
 local function get_sha256(url)
-	local status, _, body = cosmo.Fetch(url, {maxresponse = 200 * 1024 * 1024})
+	local status, _, body = cosmo.Fetch(url, {maxresponse = 300 * 1024 * 1024})
 	if not status then
 		io.stderr:write("error: failed to download claude binary\n")
 		return nil
@@ -69,7 +69,7 @@ local function run(env)
 		else
 			unix.makedirs(version_dir)
 
-			local status, _, body = cosmo.Fetch(CLAUDE_URL, {maxresponse = 200 * 1024 * 1024})
+			local status, _, body = cosmo.Fetch(CLAUDE_URL, {maxresponse = 300 * 1024 * 1024})
 			if not status or status ~= 200 then
 				io.stderr:write("error: failed to download claude binary\n")
 				return 1


### PR DESCRIPTION
## Summary
- Increase maxresponse from 200MB to 300MB
- Claude binary is ~224MB, exceeding the previous limit

## Test plan
- [x] Verified Claude binary size: 224637238 bytes (~224MB)