### PR TITLE
cosmos: update to 2025.12.28-57af99c51

### DIFF
--- a/3p/cosmos/cook.mk
+++ b/3p/cosmos/cook.mk
@@ -1,9 +1,9 @@
 # cosmos binaries from whilp/cosmopolitan fork
 cosmos_dir := $(3p)/cosmos
-cosmos_version := 2025.12.27-86af6353f
+cosmos_version := 2025.12.28-57af99c51
 cosmos_url := https://github.com/whilp/cosmopolitan/releases/download/$(cosmos_version)
 
-$(eval $(call download_binary_rule,cosmos,lua,$(cosmos_url)/lua,937e73b32dffaf1b01dfe0a9567d46c2118580248a7ce577ae04ae8c9bfb608e))
+$(eval $(call download_binary_rule,cosmos,lua,$(cosmos_url)/lua,2607d8aaeb42712f340e0fec78c258e0b894d9bf7d032eaf980a9be6dda465b3))
 $(eval $(call download_binary_rule,cosmos,zip,$(cosmos_url)/zip,357ae4715d03e7eecfaf65645b8f5e7507f02258fb4296670e17776ffc39c380))
 $(eval $(call download_binary_rule,cosmos,unzip,$(cosmos_url)/unzip,54b5aa8b3ef97c4360430dd1325325c17745f3cbbc34740c2c6f02a779991f31))
 $(eval $(call download_binary_rule,cosmos,make,$(cosmos_url)/make,3804b0ed4dc50b10acdac766280d71fe066b349f456e10eb59cca4fbb456b569))


### PR DESCRIPTION
## Summary
- Update cosmos lua binary to 2025.12.28-57af99c51
- Adds HTTP proxy support to lfetch

## Test plan
- [ ] Verify lua binary downloads correctly