### PR TITLE
ast-grep: add rule to avoid magic number comparisons

### DIFF
--- a/.ast-grep/rules/avoid-magic-number-comparison.yml
+++ b/.ast-grep/rules/avoid-magic-number-comparison.yml
@@ -1,0 +1,23 @@
+id: avoid-magic-number-comparison
+language: lua
+severity: error
+message: |
+  Avoid comparing against magic numbers. Extract to a named constant or use a predicate function.
+
+  Example:
+    Bad:  if kind == 8 then
+    Bad:  if status == 256 then
+    Good: local DT_REG = 8; if kind == DT_REG then
+    Good: if unix.S_ISREG(st:mode()) then
+note: Magic numbers obscure intent and are error-prone. Use named constants or predicate functions.
+
+rule:
+  any:
+    - pattern: $X == $N
+    - pattern: $X ~= $N
+    - pattern: $N == $X
+    - pattern: $N ~= $X
+constraints:
+  N:
+    kind: number
+    regex: "^[2-9]|^[1-9]\\d+"


### PR DESCRIPTION
## Summary

- Add ast-grep rule to flag comparisons against numeric literals >= 2
- Encourages named constants or predicate functions for clarity
- Exclude nvim and hammerspoon dirs from ast-grep (matches luacheck config)

## Test plan

- [ ] Verify rule catches patterns like `kind == 8`, `status == 256`
- [ ] Verify rule does not flag `== 0` or `== 1`