### PR TITLE
lua: fix spurious lib rebuild with stamp file

### DIFF
--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -10,15 +10,17 @@ results/bin:
 
 lib_lua_files := $(filter-out lib/test_%.lua lib/run-test.lua,$(wildcard lib/*.lua))
 lib_lua_dir := o/3p/lib/.lua
+lib_lua_stamp := $(lib_lua_dir)/.copied
 
-$(lib_lua_dir): $(lib_lua_files) $(spawn_sources)
-	mkdir -p $@
-	cp $(lib_lua_files) $@
-	cp -r lib/spawn $@
+$(lib_lua_stamp): $(lib_lua_files) $(wildcard lib/spawn/*.lua)
+	mkdir -p $(lib_lua_dir)
+	cp $(lib_lua_files) $(lib_lua_dir)
+	cp -r lib/spawn $(lib_lua_dir)
+	touch $@
 
 $(lua_ape): private .UNVEIL = rx:$(cosmos_lua_bin) r:$(luaunit_lua_dir) r:$(luacheck_lua_dir) r:lib r:o/3p/lib rx:$(cosmos_zip_bin) rwc:results/bin rwc:o/3p/lib rw:/dev/null
 $(lua_ape): private .PLEDGE = stdio rpath wpath cpath fattr exec proc
-$(lua_ape): $(cosmos_lua_bin) $(cosmos_zip_bin) $(luaunit_lua_dir)/luaunit.lua $(luacheck_lua_dir)/bin/luacheck $(lib_lua_dir) | results/bin
+$(lua_ape): $(cosmos_lua_bin) $(cosmos_zip_bin) $(luaunit_lua_dir)/luaunit.lua $(luacheck_lua_dir)/bin/luacheck $(lib_lua_stamp) | results/bin
 	cp $(cosmos_lua_bin) $@
 	chmod +x $@
 	cd $(luaunit_lua_dir)/.. && $(cosmos_zip_bin) -qr $(CURDIR)/$@ $(notdir $(luaunit_lua_dir))


### PR DESCRIPTION
## Summary
- Use a stamp file instead of directory target to track lib file copies
- Fixes unnecessary rebuilds when running make targets

Make compares source file mtimes against the directory mtime rather than the files inside, causing spurious rebuilds every time.