### PR TITLE
nvim: update to 2025.12.28-49450c1

### DIFF
--- a/3p/nvim/cook.mk
+++ b/3p/nvim/cook.mk
@@ -1,3 +1,10 @@
+nvim-latest: private .PLEDGE = stdio rpath wpath cpath inet dns
+nvim-latest: private .INTERNET = 1
+nvim-latest: $(lua_bin)
+	$(lua_bin) 3p/nvim/latest.lua
+
+.PHONY: nvim-latest
+
 nvim_pack_lock := .config/nvim/nvim-pack-lock.json
 nvim_plugins_dir := $(3p)/nvim/plugins
 

--- a/3p/nvim/latest.lua
+++ b/3p/nvim/latest.lua
@@ -1,0 +1,125 @@
+local cosmo = require("cosmo")
+
+local repo = "whilp/neovim"
+local api_url = "https://api.github.com/repos/" .. repo .. "/releases/latest"
+
+local function fetch_json(url)
+  local status, headers, body = cosmo.Fetch(url, {
+    headers = {["User-Agent"] = "curl/8.0", ["Accept"] = "application/vnd.github+json"},
+  })
+  if status ~= 200 then
+    return nil, "fetch failed: " .. tostring(status)
+  end
+  return cosmo.DecodeJson(body)
+end
+
+local function fetch_sha256(url)
+  local status, headers, body = cosmo.Fetch(url, {
+    headers = {["User-Agent"] = "curl/8.0"},
+    maxresponse = 300 * 1024 * 1024,
+  })
+  if status ~= 200 then
+    return nil, "fetch failed: " .. tostring(status)
+  end
+  return cosmo.EncodeHex(cosmo.Sha256(body)):lower()
+end
+
+local function get_commit_info(short_sha)
+  local url = "https://api.github.com/repos/" .. repo .. "/commits/" .. short_sha
+  local commit, err = fetch_json(url)
+  if not commit then
+    return nil, err
+  end
+  return commit.sha
+end
+
+local platform_map = {
+  ["nvim-macos-arm64.tar.gz"] = "darwin-arm64",
+  ["nvim-linux-arm64.tar.gz"] = "linux-arm64",
+  ["nvim-linux-x86_64.tar.gz"] = "linux-x86_64",
+}
+
+local function main()
+  io.stderr:write("fetching release info...\n")
+  local release, err = fetch_json(api_url)
+  if not release then
+    io.stderr:write("error: " .. err .. "\n")
+    os.exit(1)
+  end
+
+  local tag = release.tag_name
+  local date, short_sha = tag:match("^(%d+%.%d+%.%d+)%-([0-9a-f]+)$")
+  if not date or not short_sha then
+    io.stderr:write("error: could not parse tag: " .. tag .. "\n")
+    os.exit(1)
+  end
+
+  local assets = {}
+  for _, asset in ipairs(release.assets) do
+    local platform = platform_map[asset.name]
+    if platform then
+      assets[platform] = asset.browser_download_url
+    end
+  end
+
+  io.stderr:write("fetching commit info...\n")
+  local full_sha, sha_err = get_commit_info(short_sha)
+  if not full_sha then
+    io.stderr:write("error: " .. sha_err .. "\n")
+    os.exit(1)
+  end
+  local version = "0.12.0-dev-" .. full_sha:sub(1, 10)
+
+  local platforms = {}
+  for platform, url in pairs(assets) do
+    io.stderr:write("fetching sha256 for " .. platform .. "...\n")
+    local sha, sha_err = fetch_sha256(url)
+    if not sha then
+      io.stderr:write("error: " .. sha_err .. "\n")
+      os.exit(1)
+    end
+    platforms[platform] = {sha = sha}
+    if platform == "darwin-arm64" then
+      platforms[platform].platform = "macos-arm64"
+    end
+  end
+
+  local result = {
+    version = version,
+    date = date,
+    tag = tag,
+    format = "tar.gz",
+    strip_components = 1,
+    url = "https://github.com/" .. repo .. "/releases/download/{tag}/nvim-{platform}.tar.gz",
+    platforms = platforms,
+  }
+
+  -- TODO: switch to cosmo.EncodeLua when it supports pretty printing
+  local function pretty_print(t, indent)
+    indent = indent or 0
+    local pad = string.rep("  ", indent)
+    local pad1 = string.rep("  ", indent + 1)
+    local parts = {}
+    local keys = {}
+    for k in pairs(t) do
+      keys[#keys + 1] = k
+    end
+    table.sort(keys)
+    for _, k in ipairs(keys) do
+      local v = t[k]
+      local key = k:match("^%a[%w_]*$") and k or '["' .. k .. '"]'
+      if type(v) == "table" then
+        parts[#parts + 1] = pad1 .. key .. " = " .. pretty_print(v, indent + 1)
+      elseif type(v) == "string" then
+        parts[#parts + 1] = pad1 .. key .. ' = "' .. v .. '"'
+      else
+        parts[#parts + 1] = pad1 .. key .. " = " .. tostring(v)
+      end
+    end
+    return "{\n" .. table.concat(parts, ",\n") .. ",\n" .. pad .. "}"
+  end
+
+  print("return " .. pretty_print(result))
+end
+
+main()

--- a/3p/nvim/version.lua
+++ b/3p/nvim/version.lua
@@ -1,20 +1,20 @@
 return {
-  version = "0.12.0-dev-fddae5c8a5",
-  date = "2025.12.26",
-  tag = "2025.12.26-fddae5c",
+  version = "0.12.0-dev-49450c182c",
+  date = "2025.12.28",
+  tag = "2025.12.28-49450c1",
   format = "tar.gz",
   strip_components = 1,
   url = "https://github.com/whilp/neovim/releases/download/{tag}/nvim-{platform}.tar.gz",
   platforms = {
     ["darwin-arm64"] = {
       platform = "macos-arm64",
-      sha = "2a20f80a1d5683fad8ce6dbb54584e6c2ecf1835f1882bd3079226cd8a95a3d6",
+      sha = "72822ecff07775ea103728ff48f39571f1433129ba60d27815ababf3949b096e",
     },
     ["linux-arm64"] = {
-      sha = "d785cf242bc30a577a39a7ca442f420994d6c3c03bf4566d43e5ed712819efc6",
+      sha = "2625f71dbf764db2251921c128fb83248e5e763eaebe119290ba4e2e7f039b4f",
     },
     ["linux-x86_64"] = {
-      sha = "4636b7564a9cb854a5b858b22e33cb80a3d9d6133b51268d6dadec2b912c731e",
+      sha = "91a8b837a7e3665b5bd2a5b9419a5619262cdb8450f2707aa5febccfd81d9907",
     },
   },
 }


### PR DESCRIPTION
## Summary
- Update nvim to 2025.12.28-49450c1
- Add `nvim-latest` make target to fetch latest release info

Run `make nvim-latest > 3p/nvim/version.lua` to update to the latest release.