### PR TITLE
lua: fix octal-looking file permission literals

### DIFF
--- a/.ast-grep/rules/avoid-octal-literals.yml
+++ b/.ast-grep/rules/avoid-octal-literals.yml
@@ -1,0 +1,16 @@
+id: avoid-octal-literals
+language: lua
+severity: error
+message: |
+  Avoid octal-looking literals for file permissions. Lua has no octal notation, so 0755 is decimal 755.
+
+  Example:
+    Bad:  unix.open(path, flags, 0644)
+    Bad:  unix.chmod(path, 0755)
+    Good: unix.open(path, flags, tonumber("0644", 8))
+    Good: unix.chmod(path, tonumber("0755", 8))
+note: Use tonumber("0NNN", 8) to explicitly convert octal strings to numbers.
+
+rule:
+  kind: number
+  regex: "^0[0-7]{3}$"

--- a/lib/build/download-tool.lua
+++ b/lib/build/download-tool.lua
@@ -117,7 +117,7 @@ local function download_file(url, dest_path)
     return nil, "fetch failed with status " .. tostring(status)
   end
 
-  local fd = unix.open(dest_path, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, 0644)
+  local fd = unix.open(dest_path, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("0644", 8))
   if not fd or fd < 0 then
     return nil, "failed to open destination file"
   end
@@ -208,7 +208,7 @@ local function extract_gz(archive_path, tool_name, output_dir)
   local uncompressed_path = path.join(output_dir, tool_name)
   local binary_path = path.join(bin_dir, tool_name)
   unix.rename(uncompressed_path, binary_path)
-  unix.chmod(binary_path, 493)
+  unix.chmod(binary_path, tonumber("0755", 8))
   return true
 end
 
@@ -223,7 +223,7 @@ local function make_executable(file_path, tool_name, output_dir)
 
   local binary_path = path.join(bin_dir, tool_name)
   unix.rename(file_path, binary_path)
-  unix.chmod(binary_path, 493)
+  unix.chmod(binary_path, tonumber("0755", 8))
   return true
 end
 
@@ -253,7 +253,7 @@ end
 
 -- Write file with error checking
 local function write_file(filepath, content)
-  local fd = unix.open(filepath, unix.O_CREAT | unix.O_WRONLY | unix.O_TRUNC, 420)
+  local fd = unix.open(filepath, unix.O_CREAT | unix.O_WRONLY | unix.O_TRUNC, tonumber("0644", 8))
   if not fd then
     return nil, "failed to open " .. filepath .. " for writing"
   end

--- a/lib/build/fetch-plugin.lua
+++ b/lib/build/fetch-plugin.lua
@@ -124,7 +124,7 @@ local function fetch_plugin(plugin_name, output_dir)
     return nil, "fetch failed with status " .. tostring(status)
   end
 
-  local fd = unix.open(tarball, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, 0644)
+  local fd = unix.open(tarball, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("0644", 8))
   if not fd or fd < 0 then
     return nil, "failed to create tarball"
   end

--- a/lib/daemonize.lua
+++ b/lib/daemonize.lua
@@ -68,7 +68,7 @@ M.acquire_lock = function(path)
     return nil, "lock file path required"
   end
 
-  local fd, err = unix.open(path, unix.O_CREAT + unix.O_RDWR, 384)
+  local fd, err = unix.open(path, unix.O_CREAT + unix.O_RDWR, tonumber("0600", 8))
   if not fd then
     return nil, "failed to open lock file: " .. tostring(err)
   end
@@ -107,7 +107,7 @@ M.redirect_output = function(stdout_path, stderr_path, append)
   end
 
   if stdout_path and stderr_path and stdout_path == stderr_path then
-    local fd = unix.open(stdout_path, flags, 420)
+    local fd = unix.open(stdout_path, flags, tonumber("0644", 8))
     if not fd then
       return nil, "failed to open output file: " .. stdout_path
     end
@@ -118,7 +118,7 @@ M.redirect_output = function(stdout_path, stderr_path, append)
     end
   else
     if stdout_path then
-      local fd = unix.open(stdout_path, flags, 420)
+      local fd = unix.open(stdout_path, flags, tonumber("0644", 8))
       if not fd then
         return nil, "failed to open stdout file: " .. stdout_path
       end
@@ -129,7 +129,7 @@ M.redirect_output = function(stdout_path, stderr_path, append)
     end
 
     if stderr_path then
-      local fd = unix.open(stderr_path, flags, 420)
+      local fd = unix.open(stderr_path, flags, tonumber("0644", 8))
       if not fd then
         return nil, "failed to open stderr file: " .. stderr_path
       end

--- a/lib/home/main.lua
+++ b/lib/home/main.lua
@@ -217,7 +217,7 @@ local function download_file(url, dest_path)
     return nil, "fetch failed with status " .. tostring(status)
   end
 
-  local fd = unix.open(dest_path, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, 0644)
+  local fd = unix.open(dest_path, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("0644", 8))
   if not fd or fd < 0 then
     return nil, "failed to open destination file"
   end
@@ -265,7 +265,7 @@ local function copy_file(src, dst, mode, overwrite)
     flags = flags | unix.O_EXCL
   end
 
-  local fd = unix.open(dst, flags, 0600)
+  local fd = unix.open(dst, flags, tonumber("0600", 8))
   if not fd or fd < 0 then
     if overwrite then
       return false, "failed to open destination for writing"
@@ -526,7 +526,7 @@ local function cmd_unpack(dest, force, opts)
         return 1
       end
 
-      unix.chmod(tmp_path, 493)
+      unix.chmod(tmp_path, tonumber("0755", 8))
 
       local bin_filter = nil
       if filter and plat_manifest and plat_manifest.files then

--- a/lib/home/setup/backup.lua
+++ b/lib/home/setup/backup.lua
@@ -20,7 +20,7 @@ local function run(env)
 				unix.close(src_fd)
 
 				if data then
-					local dst_fd = unix.open(dst_path, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, 0644)
+					local dst_fd = unix.open(dst_path, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("0644", 8))
 					if dst_fd and dst_fd >= 0 then
 						unix.write(dst_fd, data)
 						unix.close(dst_fd)

--- a/lib/home/setup/claude.lua
+++ b/lib/home/setup/claude.lua
@@ -81,7 +81,7 @@ local function run(env)
 				return 1
 			end
 
-			local fd = unix.open(claude_bin, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, 0755)
+			local fd = unix.open(claude_bin, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("0755", 8))
 			if not fd or fd < 0 then
 				io.stderr:write("error: failed to create claude binary\n")
 				return 1
@@ -101,7 +101,7 @@ local function run(env)
 		local creds_dir = path.join(env.DST, ".claude")
 		unix.makedirs(creds_dir)
 		local creds_file = path.join(creds_dir, ".credentials.json")
-		local fd = unix.open(creds_file, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, 0600)
+		local fd = unix.open(creds_file, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("0600", 8))
 		if fd and fd >= 0 then
 			unix.write(fd, claude_credentials)
 			unix.close(fd)
@@ -117,7 +117,7 @@ local function run(env)
   "bypassPermissionsModeAccepted": true
 }]]
 
-	local fd = unix.open(config, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, 0644)
+	local fd = unix.open(config, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("0644", 8))
 	if fd and fd >= 0 then
 		unix.write(fd, settings)
 		unix.close(fd)

--- a/lib/home/setup/shell.lua
+++ b/lib/home/setup/shell.lua
@@ -16,7 +16,7 @@ local function run(env)
 	end
 
 	local bashrc = path.join(env.DST, ".bashrc")
-	local fd = unix.open(bashrc, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, 0644)
+	local fd = unix.open(bashrc, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("0644", 8))
 	if fd and fd >= 0 then
 		unix.write(fd, "export SHELL=/bin/zsh\n")
 		unix.close(fd)

--- a/lib/work/data.lua
+++ b/lib/work/data.lua
@@ -284,7 +284,7 @@ M.acquire_lock = function(dir)
 
   -- Open or create lock file
   local fd
-  fd, err = fcntl.open(lock_path, fcntl.O_CREAT + fcntl.O_RDWR, 384) -- 384 = 0600 octal
+  fd, err = fcntl.open(lock_path, fcntl.O_CREAT + fcntl.O_RDWR, tonumber("0600", 8))
   if not fd then
     return nil, "failed to open lock file: " .. tostring(err)
   end


### PR DESCRIPTION
## Summary

- Add ast-grep rule to catch octal-looking literals (0644, 0755, etc.)
- Replace all misused octal-looking literals with explicit `tonumber("0NNN", 8)` calls

Lua has no octal notation, so `0755` is decimal 755, not octal 493. The `tonumber("0755", 8)` approach is explicit and self-documenting.

## Test plan

- [ ] Verify ast-grep rule catches new octal-looking literals
- [ ] Run home setup to verify file permissions are correct