### PR TITLE
make: add self-documenting help target

### DIFF
--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -31,7 +31,7 @@ $(lua_bin): $(lua_ape)
 	cp $< $@
 	./$@ --assimilate || true
 
-lua: $(lua_bin)
+lua: $(lua_bin) ## Build lua with bundled modules
 
 test-3p-lua: private .UNVEIL = r:3p/lua rx:$(lua_bin) r:$(test_runner) rwc:3p/lua/o rw:/dev/null
 test-3p-lua: private .PLEDGE = stdio rpath wpath cpath proc exec
@@ -39,7 +39,7 @@ test-3p-lua: private .CPU = 60
 test-3p-lua: lua
 	cd 3p/lua && $(CURDIR)/$(lua_bin) $(CURDIR)/$(test_runner) test.lua
 
-clean-lua:
+clean-lua: ## Remove lua build artifacts
 	rm -rf $(lua_bin) $(lua_ape) o/3p/lib
 
 .PHONY: lua clean-lua test-3p-lua

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,20 @@ ast_grep_dir := $(3p)/ast-grep
 ast_grep_bin := $(ast_grep_dir)/$(PLATFORM)/sg
 ast_grep_extracted := $(ast_grep_dir)/$(PLATFORM)/.extracted
 
-build: lua
+.DEFAULT_GOAL := build
 
+help: ## Show available targets
+	@echo "Usage: make [target]"
+	@echo ""
+	@grep -hE '^[a-zA-Z_-]+:.*## ' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*## "}; {printf "  %-18s %s\n", $$1, $$2}' | sort
+	@echo ""
+	@echo "Individual test targets:"
+	@for t in $(TEST_TARGETS); do printf "  %s\n" "$$t"; done
+
+build: lua ## Build lua binary [default]
+
+clean: ## Remove o/ and results/
 clean: private .PLEDGE = stdio rpath wpath cpath
 clean:
 	rm -rf o results
@@ -31,6 +43,7 @@ $(foreach p,$(PLATFORMS),$(eval $(call platform_binaries_zip_rule,$(p))))
 results:
 	mkdir -p $@
 
+check: ## Run linters (ast-grep, luacheck)
 check: private .UNVEIL = r:$(CURDIR) rx:$(3p)/ast-grep rx:results/bin rw:/dev/null
 check: private .PLEDGE = stdio rpath proc exec
 check: private .CPU = 120
@@ -46,4 +59,4 @@ check: $(ast_grep_extracted) lua
 		--exclude-files '.config/nvim/**/*.lua' \
 		--exclude-files '.config/hammerspoon/**/*.lua'
 
-.PHONY: build clean check
+.PHONY: help build clean check

--- a/lib/home/cook.mk
+++ b/lib/home/cook.mk
@@ -70,7 +70,7 @@ endef
 
 $(foreach p,$(PLATFORMS),$(eval $(call platform_home_rule,$(p))))
 
-platform-assets: $(foreach p,$(PLATFORMS),results/bin/home-$(p))
+platform-assets: $(foreach p,$(PLATFORMS),results/bin/home-$(p)) ## Build platform-specific binaries
 
 # universal home binary with dotfiles + platform metadata
 HOME_VERSION ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -101,7 +101,7 @@ results/bin/home: $(lua_bin) results/dotfiles.zip $(home_platform_deps) lib/home
 	@cd results/home-universal && $(cosmos_zip_bin) -qr $(CURDIR)/$@ .lua
 	@rm -rf results/home-universal
 
-home: results/bin/home
+home: results/bin/home ## Build universal home binary
 
 test-home: private .UNVEIL = r:lib/home r:lib rx:$(lua_bin) r:$(test_runner) rwc:lib/home/o rw:/dev/null
 test-home: private .PLEDGE = stdio rpath wpath cpath proc exec

--- a/lib/test.mk
+++ b/lib/test.mk
@@ -11,6 +11,6 @@ TEST_TARGETS := test-3p-lua test-lib-whereami test-home test-lib-daemonize \
 
 test-all: $(TEST_TARGETS)
 
-test: test-all
+test: test-all ## Run all tests
 
 .PHONY: test-all test


### PR DESCRIPTION
## Summary
- Add `make help` target that auto-generates documentation from `## comment` annotations
- Document all main targets: build, lua, home, platform-assets, test, check, clean, clean-lua
- Individual test targets listed dynamically from `TEST_TARGETS` variable

## Test plan
- [x] `make help` shows all documented targets
- [x] `make` still defaults to `build`