### PR TITLE
cosmos: add latest version fetcher

### DIFF
--- a/lib/cosmos/cook.mk
+++ b/lib/cosmos/cook.mk
@@ -1,0 +1,6 @@
+cosmos-latest: private .PLEDGE = stdio rpath wpath cpath inet dns
+cosmos-latest: private .INTERNET = 1
+cosmos-latest: $(lua_bin)
+	$(lib_lua) lib/cosmos/latest.lua
+
+.PHONY: cosmos-latest

--- a/lib/cosmos/latest.lua
+++ b/lib/cosmos/latest.lua
@@ -1,0 +1,81 @@
+local cosmo = require("cosmo")
+
+local REPO = "whilp/cosmopolitan"
+local BINARIES = {"lua", "make", "unzip", "zip"}
+
+local function get_latest_version()
+  local url = "https://api.github.com/repos/" .. REPO .. "/releases"
+  local status, _, body = cosmo.Fetch(url, {
+    headers = {["User-Agent"] = "curl/8.0", ["Accept"] = "application/vnd.github+json"},
+  })
+  if not status then
+    io.stderr:write("error: failed to fetch releases\n")
+    return nil
+  end
+  if status ~= 200 then
+    io.stderr:write("error: fetch failed with status " .. tostring(status) .. "\n")
+    return nil
+  end
+  local releases = cosmo.DecodeJson(body)
+  if not releases then
+    io.stderr:write("error: invalid releases response\n")
+    return nil
+  end
+  for _, release in ipairs(releases) do
+    local tag = release.tag_name
+    if tag and not tag:match("^cosmocc%-") then
+      return tag
+    end
+  end
+  io.stderr:write("error: no matching release found\n")
+  return nil
+end
+
+local function get_sha256sums(version)
+  local url = string.format("https://github.com/%s/releases/download/%s/SHA256SUMS", REPO, version)
+  local status, _, body = cosmo.Fetch(url)
+  if not status or status ~= 200 then
+    return nil
+  end
+  local sums = {}
+  for line in body:gmatch("[^\n]+") do
+    local sha, name = line:match("^(%x+)%s+(.+)$")
+    if sha and name then
+      sums[name] = sha:lower()
+    end
+  end
+  return sums
+end
+
+local function main()
+  local version = get_latest_version()
+  if not version then
+    os.exit(1)
+  end
+
+  io.stderr:write("fetching sha256sums for " .. version .. "...\n")
+  local sums = get_sha256sums(version)
+  if not sums then
+    io.stderr:write("error: failed to fetch SHA256SUMS\n")
+    os.exit(1)
+  end
+
+  local binaries = {}
+  for _, name in ipairs(BINARIES) do
+    if sums[name] then
+      binaries[name] = sums[name]
+    else
+      io.stderr:write("warning: no sha256 for " .. name .. "\n")
+    end
+  end
+
+  local result = {
+    version = version,
+    url = "https://github.com/" .. REPO .. "/releases/download/{version}/{binary}",
+    binaries = binaries,
+  }
+
+  print("return " .. cosmo.EncodeLua(result, {pretty = true}))
+end
+
+main()

--- a/lib/cosmos/version.lua
+++ b/lib/cosmos/version.lua
@@ -1,0 +1,10 @@
+return {
+  binaries={
+    lua="95efff66299a577b26c50c44142f8fa21361185be0696efb11ff615ba84d7478",
+    make="3804b0ed4dc50b10acdac766280d71fe066b349f456e10eb59cca4fbb456b569",
+    unzip="54b5aa8b3ef97c4360430dd1325325c17745f3cbbc34740c2c6f02a779991f31",
+    zip="357ae4715d03e7eecfaf65645b8f5e7507f02258fb4296670e17776ffc39c380"
+  },
+  url="https://github.com/whilp/cosmopolitan/releases/download/{version}/{binary}",
+  version="2025.12.28-8bce2e27c"
+}

--- a/lib/test.mk
+++ b/lib/test.mk
@@ -2,6 +2,7 @@ test_runner := lib/run-test.lua
 
 include lib/cook.mk
 include lib/claude/cook.mk
+include lib/cosmos/cook.mk
 include lib/nvim/cook.mk
 include lib/environ/cook.mk
 include lib/build/cook.mk


### PR DESCRIPTION
## Summary
- Add `lib/cosmos` module for fetching the latest cosmos release from whilp/cosmopolitan
- Similar pattern to `lib/claude` with `latest.lua`, `version.lua`, and `cook.mk`
- Provides `make cosmos-latest` target to update version info

## Test plan
- [x] `make check` passes
- [x] `make cosmos-latest` generates valid version.lua