### PR TITLE
make: add help comments to -latest targets

### DIFF
--- a/3p/nvim/cook.mk
+++ b/3p/nvim/cook.mk
@@ -1,3 +1,4 @@
+nvim-latest: ## Fetch latest nvim version
 nvim-latest: private .PLEDGE = stdio rpath wpath cpath inet dns
 nvim-latest: private .INTERNET = 1
 nvim-latest: $(lua_bin)

--- a/lib/claude/cook.mk
+++ b/lib/claude/cook.mk
@@ -1,3 +1,4 @@
+claude-latest: ## Fetch latest claude version
 claude-latest: private .PLEDGE = stdio rpath wpath cpath inet dns
 claude-latest: private .INTERNET = 1
 claude-latest: $(lua_bin)

--- a/lib/cosmos/cook.mk
+++ b/lib/cosmos/cook.mk
@@ -1,3 +1,4 @@
+cosmos-latest: ## Fetch latest cosmos version
 cosmos-latest: private .PLEDGE = stdio rpath wpath cpath inet dns
 cosmos-latest: private .INTERNET = 1
 cosmos-latest: $(lua_bin)


### PR DESCRIPTION
## Summary
- Add `## ` help comments to `claude-latest` and `cosmos-latest` targets
- Both now show up in `make help` output

## Test plan
- [x] `make help` shows both targets