### PR TITLE
make: improve help organization and fix bare clone error

### DIFF
--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -39,7 +39,7 @@ test-3p-lua: private .CPU = 60
 test-3p-lua: lua
 	cd 3p/lua && $(CURDIR)/$(lua_bin) $(CURDIR)/$(test_runner) test.lua
 
-clean-lua: ## Remove lua build artifacts
+clean-lua:
 	rm -rf $(lua_bin) $(lua_ape) o/3p/lib
 
 .PHONY: lua clean-lua test-3p-lua

--- a/3p/nvim/cook.mk
+++ b/3p/nvim/cook.mk
@@ -1,4 +1,4 @@
-nvim-latest: ## Fetch latest nvim version
+nvim-latest:
 nvim-latest: private .PLEDGE = stdio rpath wpath cpath inet dns
 nvim-latest: private .INTERNET = 1
 nvim-latest: $(lua_bin)
@@ -9,7 +9,11 @@ nvim-latest: $(lua_bin)
 nvim_pack_lock := .config/nvim/nvim-pack-lock.json
 nvim_plugins_dir := $(3p)/nvim/plugins
 
+ifneq ($(wildcard $(lua_bin)),)
 nvim_plugins := $(shell $(lib_lua) lib/build/list-plugins.lua)
+else
+nvim_plugins :=
+endif
 
 fetch_plugin := lib/build/fetch-plugin.lua
 $(nvim_plugins_dir)/%/.fetched: private .PLEDGE = stdio rpath wpath cpath inet dns exec proc

--- a/Makefile
+++ b/Makefile
@@ -22,18 +22,35 @@ ast_grep_extracted := $(ast_grep_dir)/$(PLATFORM)/.extracted
 
 .DEFAULT_GOAL := build
 
-help: ## Show available targets
+help:
 	@echo "Usage: make [target]"
 	@echo ""
-	@grep -hE '^[a-zA-Z_-]+:.*## ' $(MAKEFILE_LIST) | \
-		awk 'BEGIN {FS = ":.*## "}; {printf "  %-18s %s\n", $$1, $$2}' | sort
+	@echo "Getting started:"
+	@echo "  deps               Build dependencies (run this first)"
+	@echo ""
+	@echo "Build:"
+	@echo "  build              Build lua binary [default]"
+	@echo "  home               Build universal home binary"
+	@echo "  platform-assets    Build platform-specific binaries"
+	@echo ""
+	@echo "Development:"
+	@echo "  check              Run linters (ast-grep, luacheck)"
+	@echo "  test               Run all tests"
+	@echo ""
+	@echo "Maintenance:"
+	@echo "  latest             Fetch latest versions (claude, cosmos, nvim)"
+	@echo "  clean              Remove build artifacts"
 	@echo ""
 	@echo "Individual test targets:"
 	@for t in $(TEST_TARGETS); do printf "  %s\n" "$$t"; done
 
 build: lua ## Build lua binary [default]
 
-clean: ## Remove o/ and results/
+deps: lua ## Build dependencies (run this first)
+
+latest: claude-latest cosmos-latest nvim-latest ## Fetch latest versions
+
+clean: ## Remove build artifacts
 clean: private .PLEDGE = stdio rpath wpath cpath
 clean:
 	rm -rf o results
@@ -59,4 +76,4 @@ check: $(ast_grep_extracted) lua
 		--exclude-files '.config/nvim/**/*.lua' \
 		--exclude-files '.config/hammerspoon/**/*.lua'
 
-.PHONY: help build clean check
+.PHONY: help build deps latest clean check

--- a/lib/claude/cook.mk
+++ b/lib/claude/cook.mk
@@ -1,4 +1,4 @@
-claude-latest: ## Fetch latest claude version
+claude-latest:
 claude-latest: private .PLEDGE = stdio rpath wpath cpath inet dns
 claude-latest: private .INTERNET = 1
 claude-latest: $(lua_bin)

--- a/lib/cosmos/cook.mk
+++ b/lib/cosmos/cook.mk
@@ -1,4 +1,4 @@
-cosmos-latest: ## Fetch latest cosmos version
+cosmos-latest:
 cosmos-latest: private .PLEDGE = stdio rpath wpath cpath inet dns
 cosmos-latest: private .INTERNET = 1
 cosmos-latest: $(lua_bin)


### PR DESCRIPTION
## Summary
- Group help output by workflow: getting started, build, development, maintenance
- Add `deps` target as entry point for new users
- Add `latest` target consolidating `*-latest` targets
- Fix `make help` error on bare clone by deferring `nvim_plugins` evaluation

## Test plan
- [x] Verify `make help` works on bare clone without lua binary
- [x] Verify help output shows grouped targets