### PR TITLE
make: add makefile validation to check target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ check: private .UNVEIL = r:$(CURDIR) rx:$(3p)/ast-grep rx:results/bin rw:/dev/nu
 check: private .PLEDGE = stdio rpath proc exec
 check: private .CPU = 120
 check: $(ast_grep_extracted) lua
+	@echo "Validating Makefiles..."
+	@bash -o pipefail -c '$(MAKE) -n --warn-undefined-variables build test clean 2>&1 | (! grep warning:)'
 	$(ast_grep_bin) scan --color always
 	@echo ""
 	@echo "Running luacheck..."


### PR DESCRIPTION
## Summary
- Adds Makefile validation step to `make check`
- Uses `make -n --warn-undefined-variables` to catch undefined variables and syntax errors
- Fails on both warnings and errors via pipefail

## Test plan
- [x] Verified `make check` passes with current Makefiles
- [x] Verified warning detection fails when undefined variable is present