### PR TITLE
make: wire up orphaned tests, add coverage check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,5 +79,7 @@ check: $(ast_grep_extracted) lua
 		--exclude-files '.claude/skills/lua/templates/*.lua' \
 		--exclude-files '.config/nvim/**/*.lua' \
 		--exclude-files '.config/hammerspoon/**/*.lua'
+	@echo ""
+	@$(MAKE) --no-print-directory check-test-coverage
 
 .PHONY: help build deps latest clean check

--- a/lib/aerosnap/cook.mk
+++ b/lib/aerosnap/cook.mk
@@ -1,0 +1,9 @@
+# lib/aerosnap/cook.mk - aerosnap module tests
+
+o/lib/aerosnap/test.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rw:/dev/null
+o/lib/aerosnap/test.lua.ok: private .PLEDGE = stdio rpath proc exec
+o/lib/aerosnap/test.lua.ok: private .CPU = 30
+o/lib/aerosnap/test.lua.ok: $(lua_test) lib/aerosnap/test.lua lib/aerosnap/init.lua
+	@mkdir -p $(@D)
+	$(lua_test) lib/aerosnap/test.lua
+	@touch $@

--- a/lib/test.mk
+++ b/lib/test.mk
@@ -4,6 +4,9 @@ include lib/cosmos/cook.mk
 include lib/nvim/cook.mk
 include lib/environ/cook.mk
 include lib/build/cook.mk
+include lib/aerosnap/cook.mk
+include lib/work/cook.mk
+# lib/spawn/cook.mk included via lib/home/cook.mk
 
 TEST_STAMPS := \
 	o/3p/lua/test_modules.lua.ok \
@@ -16,8 +19,34 @@ TEST_STAMPS := \
 	o/lib/nvim/test.lua.ok \
 	o/lib/environ/test.lua.ok \
 	o/lib/build/test.lua.ok \
-	o/lib/spawn/test_spawn.lua.ok
+	o/lib/spawn/test_spawn.lua.ok \
+	o/lib/aerosnap/test.lua.ok \
+	o/lib/work/test_backup.lua.ok \
+	o/lib/work/test_blocked_on_display.lua.ok \
+	o/lib/work/test_blockers.lua.ok \
+	o/lib/work/test_command_blocked.lua.ok \
+	o/lib/work/test_file_locking.lua.ok \
+	o/lib/work/test_orphaned_blocks.lua.ok \
+	o/lib/work/test_string_sanitization.lua.ok \
+	o/lib/work/test_validate_blocks.lua.ok
 
 test: $(TEST_STAMPS) ## Run all tests
 
-.PHONY: test
+# check for orphaned test files not in TEST_STAMPS
+check-test-coverage:
+	@echo "Checking for orphaned test files..."
+	@rg --files -g 'test*.lua' lib 3p | grep -v -e test_lib.lua -e setup/test.lua -e 'lib/work/test.lua' | sort > /tmp/test_files.txt
+	@echo '$(TEST_STAMPS)' | tr ' ' '\n' | sed 's|^o/\(.*\)\.ok$$|\1|' | sort > /tmp/test_stamps.txt
+	@if ! diff -q /tmp/test_files.txt /tmp/test_stamps.txt > /dev/null 2>&1; then \
+		orphans=$$(comm -23 /tmp/test_files.txt /tmp/test_stamps.txt); \
+		if [ -n "$$orphans" ]; then \
+			echo "ERROR: Test files not in TEST_STAMPS:"; \
+			echo "$$orphans" | sed 's/^/  /'; \
+			rm -f /tmp/test_files.txt /tmp/test_stamps.txt; \
+			exit 1; \
+		fi; \
+	fi
+	@rm -f /tmp/test_files.txt /tmp/test_stamps.txt
+	@echo "All test files are wired up."
+
+.PHONY: test check-test-coverage

--- a/lib/work/cook.mk
+++ b/lib/work/cook.mk
@@ -1,0 +1,68 @@
+# lib/work/cook.mk - work module tests
+# note: these tests require luaposix and will skip if not available
+
+work_src := $(filter-out lib/work/test%.lua,$(wildcard lib/work/*.lua))
+
+o/lib/work/test_backup.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rwc:/tmp rw:/dev/null
+o/lib/work/test_backup.lua.ok: private .PLEDGE = stdio rpath wpath cpath proc exec
+o/lib/work/test_backup.lua.ok: private .CPU = 30
+o/lib/work/test_backup.lua.ok: $(lua_test) lib/work/test_backup.lua $(work_src)
+	@mkdir -p $(@D)
+	$(lua_test) lib/work/test_backup.lua
+	@touch $@
+
+o/lib/work/test_blocked_on_display.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rw:/dev/null
+o/lib/work/test_blocked_on_display.lua.ok: private .PLEDGE = stdio rpath proc exec
+o/lib/work/test_blocked_on_display.lua.ok: private .CPU = 30
+o/lib/work/test_blocked_on_display.lua.ok: $(lua_test) lib/work/test_blocked_on_display.lua $(work_src)
+	@mkdir -p $(@D)
+	$(lua_test) lib/work/test_blocked_on_display.lua
+	@touch $@
+
+o/lib/work/test_blockers.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rw:/dev/null
+o/lib/work/test_blockers.lua.ok: private .PLEDGE = stdio rpath proc exec
+o/lib/work/test_blockers.lua.ok: private .CPU = 30
+o/lib/work/test_blockers.lua.ok: $(lua_test) lib/work/test_blockers.lua $(work_src)
+	@mkdir -p $(@D)
+	$(lua_test) lib/work/test_blockers.lua
+	@touch $@
+
+o/lib/work/test_command_blocked.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rw:/dev/null
+o/lib/work/test_command_blocked.lua.ok: private .PLEDGE = stdio rpath proc exec
+o/lib/work/test_command_blocked.lua.ok: private .CPU = 30
+o/lib/work/test_command_blocked.lua.ok: $(lua_test) lib/work/test_command_blocked.lua $(work_src)
+	@mkdir -p $(@D)
+	$(lua_test) lib/work/test_command_blocked.lua
+	@touch $@
+
+o/lib/work/test_file_locking.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rwc:/tmp rw:/dev/null
+o/lib/work/test_file_locking.lua.ok: private .PLEDGE = stdio rpath wpath cpath proc exec
+o/lib/work/test_file_locking.lua.ok: private .CPU = 30
+o/lib/work/test_file_locking.lua.ok: $(lua_test) lib/work/test_file_locking.lua $(work_src)
+	@mkdir -p $(@D)
+	$(lua_test) lib/work/test_file_locking.lua
+	@touch $@
+
+o/lib/work/test_orphaned_blocks.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rw:/dev/null
+o/lib/work/test_orphaned_blocks.lua.ok: private .PLEDGE = stdio rpath proc exec
+o/lib/work/test_orphaned_blocks.lua.ok: private .CPU = 30
+o/lib/work/test_orphaned_blocks.lua.ok: $(lua_test) lib/work/test_orphaned_blocks.lua $(work_src)
+	@mkdir -p $(@D)
+	$(lua_test) lib/work/test_orphaned_blocks.lua
+	@touch $@
+
+o/lib/work/test_string_sanitization.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rw:/dev/null
+o/lib/work/test_string_sanitization.lua.ok: private .PLEDGE = stdio rpath proc exec
+o/lib/work/test_string_sanitization.lua.ok: private .CPU = 30
+o/lib/work/test_string_sanitization.lua.ok: $(lua_test) lib/work/test_string_sanitization.lua $(work_src)
+	@mkdir -p $(@D)
+	$(lua_test) lib/work/test_string_sanitization.lua
+	@touch $@
+
+o/lib/work/test_validate_blocks.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rw:/dev/null
+o/lib/work/test_validate_blocks.lua.ok: private .PLEDGE = stdio rpath proc exec
+o/lib/work/test_validate_blocks.lua.ok: private .CPU = 30
+o/lib/work/test_validate_blocks.lua.ok: $(lua_test) lib/work/test_validate_blocks.lua $(work_src)
+	@mkdir -p $(@D)
+	$(lua_test) lib/work/test_validate_blocks.lua
+	@touch $@

--- a/lib/work/test_backup.lua
+++ b/lib/work/test_backup.lua
@@ -1,4 +1,14 @@
 local lu = require("luaunit")
+
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  function test_backup_skipped()
+    lu.skip("requires luaposix")
+  end
+  os.exit(lu.LuaUnit.run())
+end
+
 local cosmo = require("cosmo")
 local unix = cosmo.unix
 local path = cosmo.path
@@ -216,4 +226,4 @@ function TestBackup:test_backup_content_matches_original()
   lu.assertNotStrContains(backup_content, "updated content")
 end
 
-return TestBackup
+os.exit(lu.LuaUnit.run())

--- a/lib/work/test_blocked_on_display.lua
+++ b/lib/work/test_blocked_on_display.lua
@@ -1,5 +1,14 @@
 local lu = require("luaunit")
 
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  function test_blocked_on_display_skipped()
+    lu.skip("requires luaposix")
+  end
+  os.exit(lu.LuaUnit.run())
+end
+
 local data = require("work.data")
 local process = require("work.process")
 local store = require("work.store")
@@ -42,4 +51,4 @@ function TestBlockedOnDisplay:test_unresolved_blocks_display()
   lu.assertTrue(#unresolved > 0, "blocked item should show what items are blocking it, got: " .. #unresolved)
 end
 
-return TestBlockedOnDisplay
+os.exit(lu.LuaUnit.run())

--- a/lib/work/test_blockers.lua
+++ b/lib/work/test_blockers.lua
@@ -1,5 +1,14 @@
 local lu = require("luaunit")
 
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  function test_blockers_skipped()
+    lu.skip("requires luaposix")
+  end
+  os.exit(lu.LuaUnit.run())
+end
+
 local data = require("work.data")
 local process = require("work.process")
 local store = require("work.store")
@@ -34,4 +43,4 @@ function TestBlockers:test_item_blocking_relationship()
   lu.assertFalse(process.is_item_blocked(test_store, blocker))
 end
 
-return TestBlockers
+os.exit(lu.LuaUnit.run())

--- a/lib/work/test_command_blocked.lua
+++ b/lib/work/test_command_blocked.lua
@@ -1,5 +1,14 @@
 local lu = require("luaunit")
 
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  function test_command_blocked_skipped()
+    lu.skip("requires luaposix")
+  end
+  os.exit(lu.LuaUnit.run())
+end
+
 local data = require("work.data")
 local process = require("work.process")
 local store = require("work.store")
@@ -33,4 +42,4 @@ function TestCommandBlocked:test_blocked_items_list()
   lu.assertEquals(blocked_items[1].id, item1.id)
 end
 
-return TestCommandBlocked
+os.exit(lu.LuaUnit.run())

--- a/lib/work/test_file_locking.lua
+++ b/lib/work/test_file_locking.lua
@@ -1,4 +1,14 @@
 local lu = require("luaunit")
+
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  function test_file_locking_skipped()
+    lu.skip("requires luaposix")
+  end
+  os.exit(lu.LuaUnit.run())
+end
+
 local cosmo = require("cosmo")
 local unix = cosmo.unix
 local path = cosmo.path
@@ -133,4 +143,4 @@ function TestFileLocking:test_delete_with_locking()
   lu.assertNil(f, "work item file should not exist after delete")
 end
 
-return TestFileLocking
+os.exit(lu.LuaUnit.run())

--- a/lib/work/test_orphaned_blocks.lua
+++ b/lib/work/test_orphaned_blocks.lua
@@ -1,5 +1,14 @@
 local lu = require("luaunit")
 
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  function test_orphaned_blocks_skipped()
+    lu.skip("requires luaposix")
+  end
+  os.exit(lu.LuaUnit.run())
+end
+
 local process = require("work.process")
 local store = require("work.store")
 local Work = require("work.test_lib")
@@ -102,4 +111,4 @@ function TestOrphanedBlocks:test_find_items_blocking_on_multiple_blocks()
   lu.assertEquals(referencing_b[1].id, "01TEST0000000000000000003")
 end
 
-return TestOrphanedBlocks
+os.exit(lu.LuaUnit.run())

--- a/lib/work/test_string_sanitization.lua
+++ b/lib/work/test_string_sanitization.lua
@@ -1,5 +1,14 @@
 local lu = require("luaunit")
 
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  function test_string_sanitization_skipped()
+    lu.skip("requires luaposix")
+  end
+  os.exit(lu.LuaUnit.run())
+end
+
 local data = require("work.data")
 local store = require("work.store")
 local Work = require("work.test_lib")
@@ -114,4 +123,4 @@ function TestStringSanitization:test_error_message_includes_field_name()
   lu.assertStrContains(err, "title")
 end
 
-return TestStringSanitization
+os.exit(lu.LuaUnit.run())

--- a/lib/work/test_validate_blocks.lua
+++ b/lib/work/test_validate_blocks.lua
@@ -1,5 +1,14 @@
 local lu = require("luaunit")
 
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  function test_validate_blocks_skipped()
+    lu.skip("requires luaposix")
+  end
+  os.exit(lu.LuaUnit.run())
+end
+
 local process = require("work.process")
 local store = require("work.store")
 local Work = require("work.test_lib")
@@ -90,4 +99,4 @@ function TestValidateBlocks:test_validate_blocks_self_reference()
   lu.assertStrContains(err, "cannot block on itself")
 end
 
-return TestValidateBlocks
+os.exit(lu.LuaUnit.run())


### PR DESCRIPTION
## Summary

- Wire up previously orphaned tests (aerosnap, work module)
- Add `check-test-coverage` target to detect orphaned test files
- Work tests skip gracefully when luaposix is unavailable

## Changes

- Add `lib/aerosnap/cook.mk` with test target
- Add `lib/work/cook.mk` with test targets for all 8 work tests
- Update work test files to use skipIf pattern for luaposix dependency
- Add `check-test-coverage` target that compares test files to TEST_STAMPS
- Run `check-test-coverage` as part of `make check`

## Test plan

- [x] `make test` passes (work tests skip due to missing luaposix)
- [x] `make check-test-coverage` passes

Depends on #142