### PR TITLE
make: self-registering TEST_STAMPS and TOOLS

### DIFF
--- a/3p/ast-grep/cook.mk
+++ b/3p/ast-grep/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += ast-grep

--- a/3p/biome/cook.mk
+++ b/3p/biome/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += biome

--- a/3p/comrak/cook.mk
+++ b/3p/comrak/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += comrak

--- a/3p/cook.mk
+++ b/3p/cook.mk
@@ -19,13 +19,27 @@ export PATH := $(dir $(cosmos_bin)):$(PATH)
 
 make := $(make_bin)
 
-# Tool list
-TOOLS := nvim gh delta rg duckdb tree-sitter ast-grep biome comrak \
-         marksman ruff shfmt sqruff stylua superhtml uv
-
 # download-tool needs our custom lua binary with cosmo built-in
 lua_bin := results/bin/lua
 lib_lua = LUA_PATH="$(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;;" $(CURDIR)/$(lua_bin)
+
+# Tools self-register via TOOLS +=
+include 3p/ast-grep/cook.mk
+include 3p/biome/cook.mk
+include 3p/comrak/cook.mk
+include 3p/delta/cook.mk
+include 3p/duckdb/cook.mk
+include 3p/gh/cook.mk
+include 3p/marksman/cook.mk
+include 3p/nvim/cook.mk
+include 3p/rg/cook.mk
+include 3p/ruff/cook.mk
+include 3p/shfmt/cook.mk
+include 3p/sqruff/cook.mk
+include 3p/stylua/cook.mk
+include 3p/superhtml/cook.mk
+include 3p/tree-sitter/cook.mk
+include 3p/uv/cook.mk
 
 # download-tool target
 download_tool := lib/build/download-tool.lua
@@ -50,8 +64,7 @@ $(foreach tool,$(TOOLS),$(eval $(call tool_download_rule,$(tool))))
 # Generate {tool}_binaries variables for each tool
 $(foreach tool,$(TOOLS),$(eval $(tool)_binaries := $(foreach p,$(PLATFORMS),$(3p)/$(tool)/$(p)/.extracted)))
 
-# nvim needs plugin bundling after extraction
-include 3p/nvim/cook.mk
+# nvim needs plugin bundling after extraction (defined in 3p/nvim/cook.mk)
 nvim_binaries := $(nvim_bundled)
 
 # Aggregate all_binaries

--- a/3p/delta/cook.mk
+++ b/3p/delta/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += delta

--- a/3p/duckdb/cook.mk
+++ b/3p/duckdb/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += duckdb

--- a/3p/gh/cook.mk
+++ b/3p/gh/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += gh

--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -49,6 +49,9 @@ $(lua_bin): $(lua_ape)
 
 lua: $(lua_bin) ## Build lua with bundled modules
 
+TEST_STAMPS += o/3p/lua/test_modules.lua.ok
+TEST_STAMPS += o/3p/lua/test_funcs.lua.ok
+
 o/3p/lua/test_modules.lua.ok: private .UNVEIL = r:3p/lua rx:$(lua_test) rw:/dev/null
 o/3p/lua/test_modules.lua.ok: private .PLEDGE = stdio rpath wpath cpath proc exec
 o/3p/lua/test_modules.lua.ok: private .CPU = 60

--- a/3p/marksman/cook.mk
+++ b/3p/marksman/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += marksman

--- a/3p/nvim/cook.mk
+++ b/3p/nvim/cook.mk
@@ -1,3 +1,5 @@
+TOOLS += nvim
+
 nvim-latest:
 nvim-latest: private .PLEDGE = stdio rpath wpath cpath inet dns
 nvim-latest: private .INTERNET = 1

--- a/3p/rg/cook.mk
+++ b/3p/rg/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += rg

--- a/3p/ruff/cook.mk
+++ b/3p/ruff/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += ruff

--- a/3p/shfmt/cook.mk
+++ b/3p/shfmt/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += shfmt

--- a/3p/sqruff/cook.mk
+++ b/3p/sqruff/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += sqruff

--- a/3p/stylua/cook.mk
+++ b/3p/stylua/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += stylua

--- a/3p/superhtml/cook.mk
+++ b/3p/superhtml/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += superhtml

--- a/3p/tree-sitter/cook.mk
+++ b/3p/tree-sitter/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += tree-sitter

--- a/3p/uv/cook.mk
+++ b/3p/uv/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += uv

--- a/lib/aerosnap/cook.mk
+++ b/lib/aerosnap/cook.mk
@@ -1,5 +1,7 @@
 # lib/aerosnap/cook.mk - aerosnap module tests
 
+TEST_STAMPS += o/lib/aerosnap/test.lua.ok
+
 o/lib/aerosnap/test.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rw:/dev/null
 o/lib/aerosnap/test.lua.ok: private .PLEDGE = stdio rpath proc exec
 o/lib/aerosnap/test.lua.ok: private .CPU = 30

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -1,5 +1,7 @@
 # lib/build/cook.mk - build tools
 
+TEST_STAMPS += o/lib/build/test.lua.ok
+
 o/lib/build/test.lua.ok: private .UNVEIL = r:lib r:3p rx:$(lua_test) rwc:/tmp rw:/dev/null
 o/lib/build/test.lua.ok: private .PLEDGE = stdio rpath wpath cpath proc exec
 o/lib/build/test.lua.ok: private .CPU = 60

--- a/lib/claude/cook.mk
+++ b/lib/claude/cook.mk
@@ -1,5 +1,8 @@
 # lib/claude/cook.mk - claude module
 
+TEST_STAMPS += o/lib/claude/test.lua.ok
+TEST_STAMPS += o/lib/claude/test_skills.lua.ok
+
 claude-latest:
 claude-latest: private .PLEDGE = stdio rpath wpath cpath inet dns
 claude-latest: private .INTERNET = 1

--- a/lib/daemonize/cook.mk
+++ b/lib/daemonize/cook.mk
@@ -1,5 +1,7 @@
 # lib/daemonize/cook.mk - daemonize module
 
+TEST_STAMPS += o/lib/daemonize/test.lua.ok
+
 o/lib/daemonize/test.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rwc:/tmp rw:/dev/null
 o/lib/daemonize/test.lua.ok: private .PLEDGE = stdio rpath wpath cpath proc exec
 o/lib/daemonize/test.lua.ok: private .CPU = 30

--- a/lib/environ/cook.mk
+++ b/lib/environ/cook.mk
@@ -1,5 +1,7 @@
 # lib/environ/cook.mk - environ module
 
+TEST_STAMPS += o/lib/environ/test.lua.ok
+
 o/lib/environ/test.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rw:/dev/null
 o/lib/environ/test.lua.ok: private .PLEDGE = stdio rpath proc exec
 o/lib/environ/test.lua.ok: private .CPU = 30

--- a/lib/home/cook.mk
+++ b/lib/home/cook.mk
@@ -104,6 +104,8 @@ results/bin/home: $(lua_bin) results/dotfiles.zip $(home_platform_deps) lib/home
 
 home: results/bin/home ## Build universal home binary
 
+TEST_STAMPS += o/lib/home/test_main.lua.ok
+
 o/lib/home/test_main.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rw:/dev/null
 o/lib/home/test_main.lua.ok: private .PLEDGE = stdio rpath wpath cpath proc exec
 o/lib/home/test_main.lua.ok: private .CPU = 60

--- a/lib/nvim/cook.mk
+++ b/lib/nvim/cook.mk
@@ -1,5 +1,7 @@
 # lib/nvim/cook.mk - nvim module
 
+TEST_STAMPS += o/lib/nvim/test.lua.ok
+
 o/lib/nvim/test.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rwc:/tmp rw:/dev/null
 o/lib/nvim/test.lua.ok: private .PLEDGE = stdio rpath wpath cpath proc exec
 o/lib/nvim/test.lua.ok: private .CPU = 60

--- a/lib/spawn/cook.mk
+++ b/lib/spawn/cook.mk
@@ -1,6 +1,8 @@
 spawn_dir = lib/spawn
 spawn_sources = $(filter-out %test%.lua,$(wildcard $(spawn_dir)/*.lua))
 
+TEST_STAMPS += o/lib/spawn/test_spawn.lua.ok
+
 o/lib/spawn/test_spawn.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rwc:/tmp rw:/dev/null
 o/lib/spawn/test_spawn.lua.ok: private .PLEDGE = stdio rpath wpath cpath proc exec
 o/lib/spawn/test_spawn.lua.ok: private .CPU = 30

--- a/lib/test.mk
+++ b/lib/test.mk
@@ -8,29 +8,9 @@ include lib/build/cook.mk
 include lib/aerosnap/cook.mk
 include lib/work/cook.mk
 # lib/spawn/cook.mk included via lib/home/cook.mk
+# 3p/lua/cook.mk included via Makefile
 
-TEST_STAMPS := \
-	o/3p/lua/test_modules.lua.ok \
-	o/3p/lua/test_funcs.lua.ok \
-	o/lib/whereami/test.lua.ok \
-	o/lib/daemonize/test.lua.ok \
-	o/lib/home/test_main.lua.ok \
-	o/lib/claude/test.lua.ok \
-	o/lib/claude/test_skills.lua.ok \
-	o/lib/nvim/test.lua.ok \
-	o/lib/environ/test.lua.ok \
-	o/lib/build/test.lua.ok \
-	o/lib/spawn/test_spawn.lua.ok \
-	o/lib/aerosnap/test.lua.ok \
-	o/lib/work/test_backup.lua.ok \
-	o/lib/work/test_blocked_on_display.lua.ok \
-	o/lib/work/test_blockers.lua.ok \
-	o/lib/work/test_command_blocked.lua.ok \
-	o/lib/work/test_file_locking.lua.ok \
-	o/lib/work/test_orphaned_blocks.lua.ok \
-	o/lib/work/test_string_sanitization.lua.ok \
-	o/lib/work/test_validate_blocks.lua.ok
-
+# TEST_STAMPS accumulated from cook.mk files via +=
 test: $(TEST_STAMPS) ## Run all tests
 
 # check for orphaned test files not in TEST_STAMPS

--- a/lib/whereami/cook.mk
+++ b/lib/whereami/cook.mk
@@ -1,5 +1,7 @@
 # lib/whereami/cook.mk - whereami module
 
+TEST_STAMPS += o/lib/whereami/test.lua.ok
+
 o/lib/whereami/test.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rw:/dev/null
 o/lib/whereami/test.lua.ok: private .PLEDGE = stdio rpath proc exec
 o/lib/whereami/test.lua.ok: private .CPU = 30

--- a/lib/work/cook.mk
+++ b/lib/work/cook.mk
@@ -3,6 +3,15 @@
 
 work_src := $(filter-out lib/work/test%.lua,$(wildcard lib/work/*.lua))
 
+TEST_STAMPS += o/lib/work/test_backup.lua.ok
+TEST_STAMPS += o/lib/work/test_blocked_on_display.lua.ok
+TEST_STAMPS += o/lib/work/test_blockers.lua.ok
+TEST_STAMPS += o/lib/work/test_command_blocked.lua.ok
+TEST_STAMPS += o/lib/work/test_file_locking.lua.ok
+TEST_STAMPS += o/lib/work/test_orphaned_blocks.lua.ok
+TEST_STAMPS += o/lib/work/test_string_sanitization.lua.ok
+TEST_STAMPS += o/lib/work/test_validate_blocks.lua.ok
+
 o/lib/work/test_backup.lua.ok: private .UNVEIL = r:lib rx:$(lua_test) rwc:/tmp rw:/dev/null
 o/lib/work/test_backup.lua.ok: private .PLEDGE = stdio rpath wpath cpath proc exec
 o/lib/work/test_backup.lua.ok: private .CPU = 30


### PR DESCRIPTION
## Summary

Replace central lists with self-registering patterns where cook.mk files register themselves.

## Changes

- Each `lib/*/cook.mk` adds `TEST_STAMPS +=` for its test targets
- Each `3p/*/cook.mk` adds `TOOLS +=` for its tool
- `lib/test.mk` removes explicit TEST_STAMPS list (now accumulated from includes)
- `3p/cook.mk` removes explicit TOOLS list, includes tool cook.mk files

This makes it easier to add new tests and tools - just add the cook.mk file and it registers itself.

## Test plan

- [x] `make test` passes
- [x] `make check-test-coverage` passes
- [x] `make -n --warn-undefined-variables build test clean` shows no warnings

Depends on #144