### PR TITLE
make: self-registering TOOLS via cook.mk includes

### DIFF
--- a/3p/ast-grep/cook.mk
+++ b/3p/ast-grep/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += ast-grep

--- a/3p/biome/cook.mk
+++ b/3p/biome/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += biome

--- a/3p/comrak/cook.mk
+++ b/3p/comrak/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += comrak

--- a/3p/cook.mk
+++ b/3p/cook.mk
@@ -19,13 +19,27 @@ export PATH := $(dir $(cosmos_bin)):$(PATH)
 
 make := $(make_bin)
 
-# Tool list
-TOOLS := nvim gh delta rg duckdb tree-sitter ast-grep biome comrak \
-         marksman ruff shfmt sqruff stylua superhtml uv
-
 # download-tool needs our custom lua binary with cosmo built-in
 lua_bin := results/bin/lua
 lib_lua = LUA_PATH="$(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;;" $(CURDIR)/$(lua_bin)
+
+# Tools self-register via TOOLS +=
+include 3p/ast-grep/cook.mk
+include 3p/biome/cook.mk
+include 3p/comrak/cook.mk
+include 3p/delta/cook.mk
+include 3p/duckdb/cook.mk
+include 3p/gh/cook.mk
+include 3p/marksman/cook.mk
+include 3p/nvim/cook.mk
+include 3p/rg/cook.mk
+include 3p/ruff/cook.mk
+include 3p/shfmt/cook.mk
+include 3p/sqruff/cook.mk
+include 3p/stylua/cook.mk
+include 3p/superhtml/cook.mk
+include 3p/tree-sitter/cook.mk
+include 3p/uv/cook.mk
 
 # download-tool target
 download_tool := lib/build/download-tool.lua
@@ -50,8 +64,7 @@ $(foreach tool,$(TOOLS),$(eval $(call tool_download_rule,$(tool))))
 # Generate {tool}_binaries variables for each tool
 $(foreach tool,$(TOOLS),$(eval $(tool)_binaries := $(foreach p,$(PLATFORMS),$(3p)/$(tool)/$(p)/.extracted)))
 
-# nvim needs plugin bundling after extraction
-include 3p/nvim/cook.mk
+# nvim needs plugin bundling after extraction (defined in 3p/nvim/cook.mk)
 nvim_binaries := $(nvim_bundled)
 
 # Aggregate all_binaries

--- a/3p/delta/cook.mk
+++ b/3p/delta/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += delta

--- a/3p/duckdb/cook.mk
+++ b/3p/duckdb/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += duckdb

--- a/3p/gh/cook.mk
+++ b/3p/gh/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += gh

--- a/3p/marksman/cook.mk
+++ b/3p/marksman/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += marksman

--- a/3p/nvim/cook.mk
+++ b/3p/nvim/cook.mk
@@ -1,3 +1,5 @@
+TOOLS += nvim
+
 nvim-latest:
 nvim-latest: private .PLEDGE = stdio rpath wpath cpath inet dns
 nvim-latest: private .INTERNET = 1

--- a/3p/rg/cook.mk
+++ b/3p/rg/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += rg

--- a/3p/ruff/cook.mk
+++ b/3p/ruff/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += ruff

--- a/3p/shfmt/cook.mk
+++ b/3p/shfmt/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += shfmt

--- a/3p/sqruff/cook.mk
+++ b/3p/sqruff/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += sqruff

--- a/3p/stylua/cook.mk
+++ b/3p/stylua/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += stylua

--- a/3p/superhtml/cook.mk
+++ b/3p/superhtml/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += superhtml

--- a/3p/tree-sitter/cook.mk
+++ b/3p/tree-sitter/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += tree-sitter

--- a/3p/uv/cook.mk
+++ b/3p/uv/cook.mk
@@ -1,0 +1,1 @@
+TOOLS += uv


### PR DESCRIPTION
## Summary
Each tool now has its own `cook.mk` with `TOOLS += <name>`:
- `3p/ast-grep/cook.mk`, `3p/biome/cook.mk`, `3p/comrak/cook.mk`, etc.

`3p/cook.mk` includes all tool cook.mk files instead of maintaining a hardcoded `TOOLS` list. This makes it easier to add new tools - just create a `cook.mk` with `TOOLS += toolname` and add the include.

## Test plan
- [x] `make -n build` succeeds
- [x] `make check` passes