### PR TITLE
bootstrap: add session start hook and make target

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,17 @@
 {
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "make --no-print-directory -C \"$CLAUDE_PROJECT_DIR\" bootstrap"
+          }
+        ]
+      }
+    ]
+  },
   "env": {
     "DISABLE_AUTOUPDATER": "1"
   },

--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,4 @@ dist/
 o/
 results/
 .ape*
+bin/

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,18 @@ ast_grep_dir := $(3p)/ast-grep
 ast_grep_bin := $(ast_grep_dir)/$(PLATFORM)/sg
 ast_grep_extracted := $(ast_grep_dir)/$(PLATFORM)/.extracted
 
+bin := ./bin
+cosmo := whilp/cosmopolitan
+release ?= latest
+
+bootstrap: $(bin)/lua ## Bootstrap Claude environment
+	@[ -n "$$CLAUDE_ENV_FILE" ] && echo "PATH=$(bin):\$$PATH" >> "$$CLAUDE_ENV_FILE"; true
+
+$(bin)/lua:
+	@mkdir -p $(@D)
+	@curl -sL -o $@ "https://github.com/$(cosmo)/releases/$(release)/download/lua"
+	@chmod +x $@
+
 .DEFAULT_GOAL := build
 
 help:
@@ -82,4 +94,4 @@ check: $(ast_grep_extracted) lua
 	@echo ""
 	@$(MAKE) --no-print-directory check-test-coverage
 
-.PHONY: help build deps latest clean check
+.PHONY: help build deps latest clean check bootstrap


### PR DESCRIPTION
Add a SessionStart hook that runs `make bootstrap` when Claude starts.
The bootstrap target downloads the lua binary from whilp/cosmopolitan
and adds bin/ to PATH via CLAUDE_ENV_FILE.