### PR TITLE
Make local spawn require callable

### DIFF
--- a/lib/spawn/init.lua
+++ b/lib/spawn/init.lua
@@ -154,6 +154,14 @@ local function spawn(argv, opts)
 	return handle
 end
 
-return {
+local M = {
 	spawn = spawn,
 }
+
+setmetatable(M, {
+	__call = function(_, ...)
+		return spawn(...)
+	end,
+})
+
+return M

--- a/lib/spawn/test_spawn.lua
+++ b/lib/spawn/test_spawn.lua
@@ -1,6 +1,6 @@
 local lu = require("luaunit")
 local unix = require("cosmo.unix")
-local spawn = require("spawn").spawn
+local spawn = require("spawn")
 
 TestSpawn = {}
 


### PR DESCRIPTION
Add __call metamethod to spawn module to allow direct invocation. Maintains backwards compatibility with .spawn accessor.