### PR TITLE
workflow: fix test LUA_PATH for bundled luaunit

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -19,15 +19,16 @@ jobs:
 
       - name: Build home and lua binaries
         # TODO: combining these in one make call causes ETXTBSY with high parallelism
+        # Using -j4 to reduce race conditions with APE binary assimilation
         run: |
-          make home-all -j$(nproc)
-          make lua-all -j$(nproc)
+          make home-all -j4
+          make lua-all -j4
 
       - name: Run checks
         run: make check
 
       - name: Run tests
-        run: make test -j$(nproc)
+        run: make test -j4
 
       - name: Upload home artifacts
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -71,8 +71,6 @@ jobs:
           ln -sf lua.dist o/${{ matrix.platform }}/lua/bin/lua
 
       - name: Run home tests
-        env:
-          LUA_PATH: lib/?.lua;lib/?/init.lua
         run: |
           o/${{ matrix.platform }}/lua/bin/lua lib/home/test_main.lua
 
@@ -113,6 +111,7 @@ jobs:
           sha256sum * > SHA256SUMS
           cat SHA256SUMS
 
+      # TODO: remove --prerelease once stable
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/lib/home/main.lua
+++ b/lib/home/main.lua
@@ -10,6 +10,11 @@ local PLATFORMS = {
     ["arm64"] = "darwin-arm64",
     ["aarch64"] = "darwin-arm64",
   },
+  -- cosmo.GetHostOs() returns "XNU" on macOS (the kernel name)
+  ["Xnu"] = {
+    ["arm64"] = "darwin-arm64",
+    ["aarch64"] = "darwin-arm64",
+  },
   ["Linux"] = {
     ["x86_64"] = "linux-x86_64",
     ["aarch64"] = "linux-arm64",

--- a/lib/home/test_main.lua
+++ b/lib/home/test_main.lua
@@ -1167,8 +1167,11 @@ end
 -- Test: detect_platform
 --------------------------------------------------------------------------------
 function test_detect_platform_returns_string()
-  local platform = home.detect_platform()
-  lu.assertNotNil(platform)
+  local cosmo = require("cosmo")
+  print("DEBUG: GetHostOs=" .. tostring(cosmo.GetHostOs()) .. " GetHostIsa=" .. tostring(cosmo.GetHostIsa()))
+  local platform, err = home.detect_platform()
+  print("DEBUG: platform=" .. tostring(platform) .. " err=" .. tostring(err))
+  lu.assertNotNil(platform, "detect_platform failed: " .. tostring(err))
   lu.assertTrue(type(platform) == "string")
   -- Platform should be one of the known values
   lu.assertTrue(

--- a/lib/home/test_main.lua
+++ b/lib/home/test_main.lua
@@ -1167,10 +1167,7 @@ end
 -- Test: detect_platform
 --------------------------------------------------------------------------------
 function test_detect_platform_returns_string()
-  local cosmo = require("cosmo")
-  print("DEBUG: GetHostOs=" .. tostring(cosmo.GetHostOs()) .. " GetHostIsa=" .. tostring(cosmo.GetHostIsa()))
   local platform, err = home.detect_platform()
-  print("DEBUG: platform=" .. tostring(platform) .. " err=" .. tostring(err))
   lu.assertNotNil(platform, "detect_platform failed: " .. tostring(err))
   lu.assertTrue(type(platform) == "string")
   -- Platform should be one of the known values


### PR DESCRIPTION
## Summary
- Remove explicit LUA_PATH override that prevented lua.dist from finding bundled luaunit module
- Add Xnu platform alias for macOS (cosmo.GetHostOs() returns "XNU" not "DARWIN")
- Reduce parallelism to -j4 to avoid ETXTBSY race conditions with APE binary assimilation
- Add TODO comment to track prerelease flag removal

## Root cause
1. **LUA_PATH issue**: The test job was setting `LUA_PATH: lib/?.lua;lib/?/init.lua` which overrode the bundled `/zip/.lua/` paths in lua.dist. This caused `require("luaunit")` to fail because luaunit is bundled inside lua.dist.

2. **macOS platform detection**: `cosmo.GetHostOs()` returns "XNU" (the macOS kernel name) rather than "DARWIN", so the PLATFORMS table needed an alias.

3. **ETXTBSY errors**: High parallelism with `-j$(nproc)` caused race conditions during APE binary "assimilation" (self-modification on first run).

## Test plan
- [x] Build passes on all platforms
- [x] Tests pass on linux-x86_64, linux-arm64, darwin-arm64
- [x] Release job completes successfully