### PR TITLE
workflow: remove prerelease flag

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -112,13 +112,11 @@ jobs:
           sha256sum * > SHA256SUMS
           cat SHA256SUMS
 
-      # TODO: remove --prerelease once stable
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "${{ steps.version.outputs.tag }}" \
-            --prerelease \
             --title "home ${{ steps.version.outputs.tag }}" \
             --notes "## Home binaries
           Platform-specific dotfiles and tool installers.


### PR DESCRIPTION
## Summary
Remove `--prerelease` flag from release creation so future releases are marked as stable.

## Test plan
- [x] Build passes
- [ ] Next merge to main creates a non-prerelease