### PR TITLE
spawn: use execvpe for PATH commands, remove custom daemon

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,6 +1,6 @@
 return {
   format="zip",
-  platforms={["*"]={sha="d9f0e79e093f5504008b766f7bf342c964a916305fb4b0dbc7de8286eba04cc0"}},
+  platforms={["*"]={sha="994a45a2a9c9e611a8edc936274f4e418a38643f688e304ae160e39609db3e2f"}},
   url="https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version="2025.12.31-d6ec29cf9"
+  version="2025.12.31-b0b834275"
 }

--- a/lib/daemonize/init.lua
+++ b/lib/daemonize/init.lua
@@ -2,50 +2,6 @@ local unix = require("cosmo.unix")
 
 local M = {}
 
-M.daemon = function(opts)
-  opts = opts or {}
-
-  local pid = unix.fork()
-  if pid == nil then
-    return nil, "first fork failed"
-  end
-  if pid > 0 then
-    unix.exit(0)
-  end
-
-  if not unix.setsid() then
-    return nil, "setsid failed"
-  end
-
-  pid = unix.fork()
-  if pid == nil then
-    return nil, "second fork failed"
-  end
-  if pid > 0 then
-    unix.exit(0)
-  end
-
-  unix.umask(0)
-
-  if not opts.nochdir then
-    unix.chdir("/")
-  end
-
-  if not opts.noclose then
-    local null_fd = unix.open("/dev/null", unix.O_RDWR)
-    if null_fd then
-      unix.dup(null_fd, 0)
-      unix.dup(null_fd, 1)
-      unix.dup(null_fd, 2)
-      if null_fd > 2 then
-        unix.close(null_fd)
-      end
-    end
-  end
-
-  return true
-end
-
 M.write_pidfile = function(path)
   if not path or path == "" then
     return nil, "pid file path required"

--- a/lib/nvim/main.lua
+++ b/lib/nvim/main.lua
@@ -1,8 +1,8 @@
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
-local daemonize = require("daemonize")
 local version = require("version")
 local whereami = require("whereami")
+local daemonize = require("daemonize")
 
 local HOME = os.getenv("HOME")
 local DEFAULT_SOCK = path.join(HOME, ".config", "nvim", "nvim.sock")
@@ -205,9 +205,9 @@ local function cmd_start(paths, nvim_bin)
 
   local child_pid = unix.fork()
   if child_pid == 0 then
-    ok, err = daemonize.daemon({nochdir = true, noclose = true})
+    ok = unix.daemon(true, true)
     if not ok then
-      io.stderr:write("daemonize failed: " .. err .. "\n")
+      io.stderr:write("daemon failed\n")
       unix.exit(1)
     end
 


### PR DESCRIPTION
## Summary
- Remove custom `daemon()` from daemonize module in favor of built-in `unix.daemon()`
- Use `unix.execvpe` for PATH-based command execution instead of manual resolution + `execve`
- Add missing fork failure check in spawn module
- Pass argv directly to exec instead of reconstructing it

## Requirements
- Requires cosmos version 2025.12.31+ which adds `unix.execvpe`
- Run `make cosmos-latest` to update

## Test plan
- [x] `make check` passes
- [x] `make test` passes