### PR TITLE
build: invoke lua explicitly to fix parallel build races

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,22 @@ export LUA_PATH := $(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;$(CURDIR)/o/any/
 export PATH := $(CURDIR)/o/$(current_platform)/cosmos/bin:$(CURDIR)/o/any/lua/bin:$(PATH)
 
 lua_bin := o/any/lua/bin/lua
-fetch := lib/build/fetch.lua
-extract := lib/build/extract.lua
-install := lib/build/install.lua
-runner := lib/build/test.lua
+
+# Script paths (for dependencies)
+fetch_script := lib/build/fetch.lua
+extract_script := lib/build/extract.lua
+install_script := lib/build/install.lua
+runner_script := lib/build/test.lua
+
+# Commands (invoke lua explicitly to avoid APE "Text file busy" errors)
+fetch = $(lua_bin) $(fetch_script)
+extract = $(lua_bin) $(extract_script)
+install = $(lua_bin) $(install_script)
+runner = $(lua_bin) $(runner_script)
+
 luaunit := o/any/luaunit/lib/luaunit.lua
 
-$(fetch) $(extract) $(install): | $(lua_bin)
+$(fetch_script) $(extract_script) $(install_script) $(runner_script): | $(lua_bin)
 cosmo := whilp/cosmopolitan
 release ?= latest
 


### PR DESCRIPTION
## Summary
- Fix "Text file busy" errors during parallel builds (`make -j4`)
- APE binaries write to themselves on first execution, causing race conditions when multiple make jobs invoke the same lua binary via shebang
- Invoke lua explicitly (`$(lua_bin) script.lua`) instead of relying on `#!/usr/bin/env lua` shebangs

## Test plan
- [x] Tested locally with `make home-all lua-all -j4` (clean build)