### PR TITLE
workflow: combine make targets now that APE race is fixed

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -18,11 +18,7 @@ jobs:
         run: make bootstrap
 
       - name: Build home and lua binaries
-        # TODO: combining these in one make call causes ETXTBSY with high parallelism
-        # Using -j4 to reduce race conditions with APE binary assimilation
-        run: |
-          make home-all -j4
-          make lua-all -j4
+        run: make home-all lua-all -j4
 
       - name: Run checks
         run: make check


### PR DESCRIPTION
## Summary
- Remove obsolete TODO comment about ETXTBSY race condition
- Combine `make home-all` and `make lua-all` into single call

Follows up on #169 which fixed the root cause by invoking lua explicitly.

## Test plan
- [x] Tested locally with `make home-all lua-all -j4`