### PR TITLE
nvim: fix VIMRUNTIME by installing share directory

### DIFF
--- a/3p/nvim/cook.mk
+++ b/3p/nvim/cook.mk
@@ -26,6 +26,7 @@ o/any/nvim/.plugins-fetched: $(nvim_plugin_dirs)
 
 o/%/nvim/bin/nvim: $(nvim_version) $(install) o/%/nvim/staging/bin/nvim o/any/nvim/.plugins-fetched $(nvim_bundle)
 	$(install) $(nvim_version) $* o/$*/nvim bin o/$*/nvim/staging/bin/nvim
+	$(install) $(nvim_version) $* o/$*/nvim share o/$*/nvim/staging/share
 	$(nvim_bundle) $* o/$*/nvim o/any/nvim/plugins
 
 o/%/nvim/test.ok: 3p/nvim/test.lua o/%/nvim/bin/nvim $(runner)

--- a/3p/nvim/test.lua
+++ b/3p/nvim/test.lua
@@ -42,3 +42,50 @@ function TestNvim:test_parser_lua()
   })
   lu.assertEquals(handle:wait(), 0)
 end
+
+function TestNvim:test_vimruntime_exists()
+  local runtime_dir = path.join(bin_dir, "share", "nvim", "runtime")
+  local unix = require("cosmo.unix")
+  local st = unix.stat(runtime_dir)
+  lu.assertNotNil(st, "share/nvim/runtime directory should exist")
+end
+
+function TestNvim:test_vimruntime_has_syntax()
+  local syntax_file = path.join(bin_dir, "share", "nvim", "runtime", "syntax", "syntax.vim")
+  local unix = require("cosmo.unix")
+  local st = unix.stat(syntax_file)
+  lu.assertNotNil(st, "runtime/syntax/syntax.vim should exist")
+end
+
+function TestNvim:test_vim_health_loads()
+  local env = "VIMRUNTIME=" .. path.join(bin_dir, "share", "nvim", "runtime")
+  local handle = spawn({
+    "env", env,
+    bin, "--headless",
+    "+lua assert(vim.health ~= nil, 'vim.health should load')",
+    "+qa"
+  })
+  lu.assertEquals(handle:wait(), 0, "vim.health module should load")
+end
+
+function TestNvim:test_vim_lsp_loads()
+  local env = "VIMRUNTIME=" .. path.join(bin_dir, "share", "nvim", "runtime")
+  local handle = spawn({
+    "env", env,
+    bin, "--headless",
+    "+lua assert(vim.lsp ~= nil, 'vim.lsp should load')",
+    "+qa"
+  })
+  lu.assertEquals(handle:wait(), 0, "vim.lsp module should load")
+end
+
+function TestNvim:test_vim_pack_loads()
+  local env = "VIMRUNTIME=" .. path.join(bin_dir, "share", "nvim", "runtime")
+  local handle = spawn({
+    "env", env,
+    bin, "--headless",
+    "+lua assert(vim.pack ~= nil, 'vim.pack should load')",
+    "+qa"
+  })
+  lu.assertEquals(handle:wait(), 0, "vim.pack module should load")
+end

--- a/3p/nvim/test.lua
+++ b/3p/nvim/test.lua
@@ -1,6 +1,7 @@
 local lu = require("luaunit")
 local spawn = require("spawn").spawn
 local path = require("cosmo.path")
+local unix = require("cosmo.unix")
 
 local bin_dir = os.getenv("TEST_BIN_DIR")
 local bin = path.join(bin_dir, "bin", "nvim")
@@ -45,14 +46,12 @@ end
 
 function TestNvim:test_vimruntime_exists()
   local runtime_dir = path.join(bin_dir, "share", "nvim", "runtime")
-  local unix = require("cosmo.unix")
   local st = unix.stat(runtime_dir)
   lu.assertNotNil(st, "share/nvim/runtime directory should exist")
 end
 
 function TestNvim:test_vimruntime_has_syntax()
   local syntax_file = path.join(bin_dir, "share", "nvim", "runtime", "syntax", "syntax.vim")
-  local unix = require("cosmo.unix")
   local st = unix.stat(syntax_file)
   lu.assertNotNil(st, "runtime/syntax/syntax.vim should exist")
 end

--- a/lib/nvim/test.lua
+++ b/lib/nvim/test.lua
@@ -15,7 +15,10 @@ function test_load_zsh_environment_completes_without_error()
 end
 
 function test_setup_nvim_environment_sets_server_mode()
-  local env = nvim.setup_nvim_environment()
+  local bin = nvim.resolve_nvim_bin()
+  if not bin then return end
+
+  local env = nvim.setup_nvim_environment(bin)
 
   local found = false
   for _, entry in ipairs(env) do
@@ -28,7 +31,10 @@ function test_setup_nvim_environment_sets_server_mode()
 end
 
 function test_setup_nvim_environment_preserves_loaded_env()
-  local env = nvim.setup_nvim_environment()
+  local bin = nvim.resolve_nvim_bin()
+  if not bin then return end
+
+  local env = nvim.setup_nvim_environment(bin)
 
   local has_server_mode = false
   for _, entry in ipairs(env) do
@@ -42,9 +48,28 @@ function test_setup_nvim_environment_preserves_loaded_env()
 end
 
 function test_setup_nvim_environment_returns_table()
-  local env = nvim.setup_nvim_environment()
+  local bin = nvim.resolve_nvim_bin()
+  if not bin then return end
+
+  local env = nvim.setup_nvim_environment(bin)
 
   lu.assertTrue(type(env) == "table", "should return a table")
+end
+
+function test_setup_nvim_environment_sets_vimruntime()
+  local bin = nvim.resolve_nvim_bin()
+  if not bin then return end
+
+  local env = nvim.setup_nvim_environment(bin)
+
+  local found = false
+  for _, entry in ipairs(env) do
+    if entry:match("^VIMRUNTIME=") then
+      found = true
+      break
+    end
+  end
+  lu.assertTrue(found, "should set VIMRUNTIME")
 end
 
 function test_resolve_nvim_bin_returns_path_when_exists()


### PR DESCRIPTION
## Summary

- Fix nvim failing to start due to invalid VIMRUNTIME
- Install `share` directory alongside `bin` in build process
- Set VIMRUNTIME environment variable in wrapper script
- Add tests to catch this regression in CI

## Test plan

- [x] `make o/linux-x86_64/nvim/test.ok` passes (11 tests)
- [x] `make o/any/nvim/test.ok` passes (8 tests)
- [x] `nvim --headless -c "checkhealth" -c "qa"` runs without errors
- [x] `nvim -c "echo \$VIMRUNTIME"` shows correct path