### PR TITLE
ast-grep: add rules for temp directory/file creation

### DIFF
--- a/.ast-grep/rules/avoid-os-tmpname.yml
+++ b/.ast-grep/rules/avoid-os-tmpname.yml
@@ -1,0 +1,18 @@
+id: avoid-os-tmpname
+language: lua
+severity: error
+message: |
+  Avoid os.tmpname(). Use unix.mkdtemp() or unix.mkstemp() instead.
+
+  Example:
+    Bad:  local tmpfile = os.tmpname()
+    Good: local tmpdir = unix.mkdtemp("/tmp/myapp_XXXXXX")
+          local tmpfile = path.join(tmpdir, "file")
+
+    Bad:  local f = io.open(os.tmpname(), "w")
+    Good: local fd, tmpfile = unix.mkstemp("/tmp/myapp_XXXXXX")
+          local f = unix.fdopen(fd, "w")
+note: os.tmpname() is deprecated, not secure, and has platform-specific behavior. Use unix.mkdtemp() for temp directories or unix.mkstemp() for temp files.
+
+rule:
+  pattern: os.tmpname($$$)

--- a/.ast-grep/rules/hardcoded-tmp-path.yml
+++ b/.ast-grep/rules/hardcoded-tmp-path.yml
@@ -1,0 +1,24 @@
+id: hardcoded-tmp-path
+language: lua
+severity: warning
+message: |
+  Hardcoded /tmp path detected. Consider using unix.mkdtemp() for temp directories.
+
+  Example:
+    Bad:  local lock_path = "/tmp/test_daemonize_lock"
+    Good: local tmpdir = unix.mkdtemp("/tmp/myapp_XXXXXX")
+          local lock_path = path.join(tmpdir, "lock")
+
+    Bad:  local tmp = "/tmp/spawn_test_checkfile"
+    Good: local tmpdir = unix.mkdtemp("/tmp/spawn_XXXXXX")
+          local tmp = path.join(tmpdir, "checkfile")
+note: Hardcoded /tmp paths can lead to race conditions and collisions. Use unix.mkdtemp() to create secure temp directories with unique names.
+
+rule:
+  pattern: $VAR = $PATH
+  not:
+    has:
+      regex: 'XXXXXX'
+constraints:
+  PATH:
+    regex: '^"/tmp/[^"]+"$'

--- a/.ast-grep/rules/hardcoded-tmp-path.yml
+++ b/.ast-grep/rules/hardcoded-tmp-path.yml
@@ -1,6 +1,6 @@
 id: hardcoded-tmp-path
 language: lua
-severity: warning
+severity: error
 message: |
   Hardcoded /tmp path detected. Consider using unix.mkdtemp() for temp directories.
 

--- a/.ast-grep/rules/manual-temp-dir.yml
+++ b/.ast-grep/rules/manual-temp-dir.yml
@@ -1,6 +1,6 @@
 id: manual-temp-dir
 language: lua
-severity: warning
+severity: error
 message: |
   Potential manual temp directory construction detected. Consider using unix.mkdtemp() instead.
 

--- a/.ast-grep/rules/manual-temp-dir.yml
+++ b/.ast-grep/rules/manual-temp-dir.yml
@@ -1,0 +1,20 @@
+id: manual-temp-dir
+language: lua
+severity: warning
+message: |
+  Potential manual temp directory construction detected. Consider using unix.mkdtemp() instead.
+
+  Example:
+    Bad:  local tmp = "/tmp/myapp_test"
+          unix.makedirs(tmp)
+    Good: local tmp = unix.mkdtemp("/tmp/myapp_XXXXXX")
+
+    Bad:  unix.makedirs("/tmp/test_dir")
+    Good: local tmp = unix.mkdtemp("/tmp/test_XXXXXX")
+note: Manually constructing temp directory paths is unsafe and can lead to race conditions or collisions. Use unix.mkdtemp() for secure temp directory creation.
+
+rule:
+  pattern: unix.makedirs($PATH)
+constraints:
+  PATH:
+    regex: '/tmp/'

--- a/.ast-grep/rules/manual-temp-file.yml
+++ b/.ast-grep/rules/manual-temp-file.yml
@@ -1,0 +1,21 @@
+id: manual-temp-file
+language: lua
+severity: error
+message: |
+  Manual temp file construction detected. Temp files should use unix.mkdtemp() or unix.mkstemp().
+
+  Example:
+    Bad:  local tmp = path .. ".tmp." .. os.time() .. "." .. getpid()
+    Good: local tmpdir = unix.mkdtemp("/tmp/myapp_XXXXXX")
+          local tmp = path.join(tmpdir, "file.tmp")
+
+    Bad:  local f = io.open("/tmp/myfile.tmp", "w")
+    Good: local fd, tmpfile = unix.mkstemp("/tmp/myfile_XXXXXX")
+          local f = unix.fdopen(fd, "w")
+note: Manually constructing temp file paths can lead to race conditions and security issues. Use unix.mkdtemp() to create a secure temp directory first, or unix.mkstemp() for atomic temp file creation.
+
+rule:
+  pattern: string.format($FMT, $$$)
+constraints:
+  FMT:
+    regex: '.*\.tmp.*'

--- a/.ast-grep/rules/tmp-path-concat.yml
+++ b/.ast-grep/rules/tmp-path-concat.yml
@@ -1,0 +1,19 @@
+id: tmp-path-concat
+language: lua
+severity: error
+message: |
+  Temp path construction via concatenation detected. Use unix.mkdtemp() instead.
+
+  Example:
+    Bad:  local temp = "/tmp/myapp_" .. os.time()
+    Good: local temp = unix.mkdtemp("/tmp/myapp_XXXXXX")
+
+    Bad:  local path = "/tmp/test_" .. id .. "_" .. pid
+    Good: local path = unix.mkdtemp("/tmp/test_XXXXXX")
+note: Constructing temp paths via concatenation is unsafe and can lead to race conditions. Use unix.mkdtemp() for secure temp directory creation with atomic uniqueness.
+
+rule:
+  kind: binary_expression
+  has:
+    kind: string
+    regex: '^"/tmp/'

--- a/lib/claude/test.lua
+++ b/lib/claude/test.lua
@@ -1,8 +1,11 @@
 local lu = require('luaunit')
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
 local claude = require("claude.main")
 
 function test_find_claude_binary_finds_existing()
-  local tmpfile = os.tmpname()
+  local tmpdir = unix.mkdtemp("/tmp/claude_test_XXXXXX")
+  local tmpfile = path.join(tmpdir, "testfile")
   local f = io.open(tmpfile, "w")
   f:write("test")
   f:close()
@@ -11,7 +14,8 @@ function test_find_claude_binary_finds_existing()
   local result = claude.find_claude_binary(paths)
 
   lu.assertEquals(result, tmpfile, "should find existing file")
-  os.remove(tmpfile)
+  unix.unlink(tmpfile)
+  unix.rmdir(tmpdir)
 end
 
 function test_find_claude_binary_returns_nil_when_none_exist()
@@ -22,7 +26,8 @@ function test_find_claude_binary_returns_nil_when_none_exist()
 end
 
 function test_find_claude_binary_handles_nil_in_paths()
-  local tmpfile = os.tmpname()
+  local tmpdir = unix.mkdtemp("/tmp/claude_test_XXXXXX")
+  local tmpfile = path.join(tmpdir, "testfile")
   local f = io.open(tmpfile, "w")
   f:write("test")
   f:close()
@@ -31,7 +36,8 @@ function test_find_claude_binary_handles_nil_in_paths()
   local result = claude.find_claude_binary(paths)
 
   lu.assertEquals(result, tmpfile, "should find existing file even when nil is first element")
-  os.remove(tmpfile)
+  unix.unlink(tmpfile)
+  unix.rmdir(tmpdir)
 end
 
 function test_build_argv_basic()
@@ -58,7 +64,8 @@ function test_build_argv_with_user_args()
 end
 
 function test_build_argv_with_mcp_config()
-  local tmpfile = os.tmpname()
+  local tmpdir = unix.mkdtemp("/tmp/claude_test_XXXXXX")
+  local tmpfile = path.join(tmpdir, "mcp.json")
   local f = io.open(tmpfile, "w")
   f:write("{}")
   f:close()
@@ -68,7 +75,8 @@ function test_build_argv_with_mcp_config()
   lu.assertStrContains(table.concat(argv, " "), "--mcp-config")
   lu.assertStrContains(table.concat(argv, " "), tmpfile)
 
-  os.remove(tmpfile)
+  unix.unlink(tmpfile)
+  unix.rmdir(tmpdir)
 end
 
 function test_build_argv_ignores_nonexistent_mcp()

--- a/lib/home/test_main.lua
+++ b/lib/home/test_main.lua
@@ -22,9 +22,7 @@ end
 
 -- Helper: create temp directory
 local function make_temp_dir()
-  local temp_path = "/tmp/home_test_" .. os.time() .. "_" .. math.random(10000)
-  unix.makedirs(temp_path)
-  return temp_path
+  return unix.mkdtemp("/tmp/home_test_XXXXXX")
 end
 
 -- Helper: remove directory recursively

--- a/lib/home/test_main.lua
+++ b/lib/home/test_main.lua
@@ -20,11 +20,6 @@ local function mock_writer()
   }
 end
 
--- Helper: create temp directory
-local function make_temp_dir()
-  return unix.mkdtemp("/tmp/home_test_XXXXXX")
-end
-
 -- Helper: remove directory recursively
 local function remove_dir(dir_path)
   for name in unix.opendir(dir_path) do
@@ -149,7 +144,7 @@ end
 -- Test: copy_file - Basic copy
 --------------------------------------------------------------------------------
 function test_copy_file_basic()
-  local tmp = make_temp_dir()
+  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
   local src = path.join(tmp, "source.txt")
   local dst = path.join(tmp, "dest.txt")
 
@@ -168,7 +163,7 @@ function test_copy_file_basic()
 end
 
 function test_copy_file_with_mode()
-  local tmp = make_temp_dir()
+  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
   local src = path.join(tmp, "source.txt")
   local dst = path.join(tmp, "dest.txt")
 
@@ -189,7 +184,7 @@ end
 -- Test: copy_file - Overwrite behavior
 --------------------------------------------------------------------------------
 function test_copy_file_no_overwrite_fails()
-  local tmp = make_temp_dir()
+  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
   local src = path.join(tmp, "source.txt")
   local dst = path.join(tmp, "dest.txt")
 
@@ -209,7 +204,7 @@ function test_copy_file_no_overwrite_fails()
 end
 
 function test_copy_file_overwrite_succeeds()
-  local tmp = make_temp_dir()
+  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
   local src = path.join(tmp, "source.txt")
   local dst = path.join(tmp, "dest.txt")
 
@@ -231,7 +226,7 @@ end
 -- Test: copy_file - Source doesn't exist
 --------------------------------------------------------------------------------
 function test_copy_file_source_missing()
-  local tmp = make_temp_dir()
+  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
   local ok, err = home.copy_file(path.join(tmp, "nonexistent"), path.join(tmp, "dest"))
   lu.assertFalse(ok)
   lu.assertStrContains(err, "failed to open source")
@@ -276,7 +271,7 @@ end
 -- Test: cmd_unpack silent by default
 --------------------------------------------------------------------------------
 function test_cmd_unpack_silent_by_default()
-  local tmp = make_temp_dir()
+  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -311,7 +306,7 @@ end
 -- Test: cmd_unpack verbose mode
 --------------------------------------------------------------------------------
 function test_cmd_unpack_verbose()
-  local tmp = make_temp_dir()
+  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -344,7 +339,7 @@ function test_cmd_unpack_verbose()
 end
 
 function test_cmd_unpack_verbose_force_overwrite()
-  local tmp = make_temp_dir()
+  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -380,7 +375,7 @@ end
 -- Test: cmd_unpack dry-run mode
 --------------------------------------------------------------------------------
 function test_cmd_unpack_dry_run()
-  local tmp = make_temp_dir()
+  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -410,7 +405,7 @@ function test_cmd_unpack_dry_run()
 end
 
 function test_cmd_unpack_dry_run_verbose()
-  local tmp = make_temp_dir()
+  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -448,7 +443,7 @@ end
 -- Test: cmd_unpack --only filter
 --------------------------------------------------------------------------------
 function test_cmd_unpack_only_filter()
-  local tmp = make_temp_dir()
+  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -494,7 +489,7 @@ function test_cmd_unpack_only_filter()
 end
 
 function test_cmd_unpack_only_empty_filter()
-  local tmp = make_temp_dir()
+  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -525,7 +520,7 @@ function test_cmd_unpack_only_empty_filter()
 end
 
 function test_cmd_unpack_only_null_delimited()
-  local tmp = make_temp_dir()
+  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -669,7 +664,7 @@ end
 -- Test: read_file
 --------------------------------------------------------------------------------
 function test_read_file_success()
-  local tmp = make_temp_dir()
+  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
   local file_path = path.join(tmp, "test.txt")
   write_file(file_path, "test content")
 
@@ -713,7 +708,7 @@ end
 -- Test: 3p binaries in .local/share structure
 --------------------------------------------------------------------------------
 function test_unpack_3p_binary_structure()
-  local tmp = make_temp_dir()
+  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
   local zip_root = path.join(tmp, "zip/")
 
   -- Create versioned binary structure

--- a/lib/spawn/test_spawn.lua
+++ b/lib/spawn/test_spawn.lua
@@ -36,8 +36,9 @@ function TestSpawn:test_wait_returns_exit_code()
 end
 
 function TestSpawn:test_wait_drains_stdout_to_avoid_sigpipe()
-	local tmp_file = "/tmp/spawn_test_checkfile"
-	local tmp_target = "/tmp/spawn_test_target"
+	local tmpdir = unix.mkdtemp("/tmp/spawn_test_XXXXXX")
+	local tmp_file = path.join(tmpdir, "checkfile")
+	local tmp_target = path.join(tmpdir, "target")
 
 	local f = io.open(tmp_target, "w")
 	f:write("test content\n")
@@ -72,6 +73,7 @@ function TestSpawn:test_wait_drains_stdout_to_avoid_sigpipe()
 
 	unix.unlink(tmp_file)
 	unix.unlink(tmp_target)
+	unix.rmdir(tmpdir)
 end
 
 function TestSpawn:test_stdin_string()

--- a/lib/work/test_backup.lua
+++ b/lib/work/test_backup.lua
@@ -36,8 +36,7 @@ TestBackup = {}
 
 function TestBackup:setUp()
   store.reset(test_store)
-  self.test_dir = "/tmp/work-test-backup-" .. os.time()
-  unix.makedirs(self.test_dir)
+  self.test_dir = unix.mkdtemp("/tmp/work-test-backup-XXXXXX")
 end
 
 function TestBackup:tearDown()

--- a/lib/work/test_file_locking.lua
+++ b/lib/work/test_file_locking.lua
@@ -36,8 +36,7 @@ TestFileLocking = {}
 
 function TestFileLocking:setUp()
   store.reset(test_store)
-  self.test_dir = "/tmp/work-test-" .. os.time()
-  unix.makedirs(self.test_dir)
+  self.test_dir = unix.mkdtemp("/tmp/work-test-XXXXXX")
 end
 
 function TestFileLocking:tearDown()


### PR DESCRIPTION
Add four new ast-grep rules to detect unsafe temp file/directory patterns:
- avoid-os-tmpname: catches deprecated os.tmpname() usage
- manual-temp-file: catches string.format() with .tmp patterns
- manual-temp-dir: catches unix.makedirs() with /tmp paths
- hardcoded-tmp-path: catches hardcoded /tmp path literals

These rules guide developers to use unix.mkdtemp() and unix.mkstemp() for secure temp file/directory creation instead of manual construction.