### PR TITLE
test: add TEST_TMPDIR global for test temporary directories

### DIFF
--- a/.ast-grep/rules/test-use-tmpdir-global.yml
+++ b/.ast-grep/rules/test-use-tmpdir-global.yml
@@ -13,6 +13,9 @@ files:
   - "**/test*.lua"
   - "**/test.lua"
 
+ignores:
+  - "lib/build/test.lua"
+
 rule:
   any:
     - pattern: unix.mkdtemp($$$)

--- a/.ast-grep/rules/test-use-tmpdir-global.yml
+++ b/.ast-grep/rules/test-use-tmpdir-global.yml
@@ -1,0 +1,19 @@
+id: test-use-tmpdir-global
+language: lua
+severity: warning
+message: |
+  Tests should use TEST_TMPDIR global instead of calling unix.mkdtemp() directly.
+
+  Example:
+    Bad:  local tmpdir = unix.mkdtemp("/tmp/test_XXXXXX")
+    Good: local tmpdir = TEST_TMPDIR
+note: The test runner provides TEST_TMPDIR which is automatically created and cleaned up.
+
+files:
+  - "**/test*.lua"
+  - "**/test.lua"
+
+rule:
+  any:
+    - pattern: unix.mkdtemp($$$)
+    - pattern: $X.mkdtemp($$$)

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -48,15 +48,15 @@ ignore = {
   "111/Test.*",   -- setting test class globals
   "111/test_.*",  -- setting test function globals
   "112/Test.*",   -- mutating test class globals
+  "111/TEST_.*",  -- setting test runner globals (TEST_ARGS, TEST_TMPDIR, etc)
+  "112/TEST_.*",  -- mutating test runner globals
+  "113/TEST_.*",  -- accessing test runner globals
   "212/self",     -- unused self in test methods
 }
 
 files = {
   ["lib/build/test.lua"] = {
-    globals = { "arg", "TEST_ARGS", "TEST_TMPDIR" },
-  },
-  ["**/test*.lua"] = {
-    globals = { "TEST_ARGS", "TEST_TMPDIR" },
+    globals = { "arg" },
   },
   ["lib/claude/version.lua"] = {
     -- Generated file with long URLs

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -54,6 +54,7 @@ ignore = {
 files = {
   ["lib/build/test.lua"] = {
     globals = { "arg", "TEST_ARGS" },
+    ignore = { "122" }, -- overriding os.getenv for TEST_TMPDIR
   },
   ["**/test*.lua"] = {
     globals = { "TEST_ARGS" },

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -53,11 +53,10 @@ ignore = {
 
 files = {
   ["lib/build/test.lua"] = {
-    globals = { "arg", "TEST_ARGS" },
-    ignore = { "122" }, -- overriding os.getenv for TEST_TMPDIR
+    globals = { "arg", "TEST_ARGS", "TEST_TMPDIR" },
   },
   ["**/test*.lua"] = {
-    globals = { "TEST_ARGS" },
+    globals = { "TEST_ARGS", "TEST_TMPDIR" },
   },
   ["lib/claude/version.lua"] = {
     -- Generated file with long URLs

--- a/lib/build/test.lua
+++ b/lib/build/test.lua
@@ -3,6 +3,7 @@ local args = { ... }
 local test_file, output = args[1], args[2]
 arg = {}
 TEST_ARGS = {}
+TEST_TMPDIR = nil -- set after mkdtemp
 for i = 3, #args do
   TEST_ARGS[#TEST_ARGS + 1] = args[i]
 end
@@ -39,8 +40,8 @@ if home then
   end
 end
 -- setup TEST_TMPDIR for tests to use
-local test_tmpdir = unix.mkdtemp("/tmp/test_XXXXXX")
-unix.unveil(test_tmpdir, "rwc")
+TEST_TMPDIR = unix.mkdtemp("/tmp/test_XXXXXX")
+unix.unveil(TEST_TMPDIR, "rwc")
 -- Unveil additional paths passed as arguments (available to test via TEST_ARGS)
 for _, p in ipairs(TEST_ARGS) do
   unix.unveil(p, "r")
@@ -50,13 +51,13 @@ unix.unveil(nil, nil)
 local lu = require("luaunit")
 local cosmo = require("cosmo")
 
--- override os.getenv to provide TEST_TMPDIR as environment variable
-local real_getenv = os.getenv
-local extra_env = {
-  TEST_TMPDIR = test_tmpdir,
-}
-os.getenv = function(key)
-  return extra_env[key] or real_getenv(key)
+-- exclude TEST_* globals from test discovery (reserved for test runner)
+local original_isTestName = lu.LuaUnit.isTestName
+lu.LuaUnit.isTestName = function(s)
+  if s:match("^TEST_") then
+    return false
+  end
+  return original_isTestName(s)
 end
 
 print("# " .. test_file)
@@ -69,6 +70,9 @@ end
 local runner = lu.LuaUnit.new()
 runner:setOutputType("tap")
 local code = runner:runSuite()
+
+-- cleanup TEST_TMPDIR
+unix.rmrf(TEST_TMPDIR)
 
 if runner.result.runCount == 0 and runner.result.skippedCount == 0 then
   io.stderr:write("error: no tests found in " .. test_file .. "\n")
@@ -87,8 +91,5 @@ local result = {
 local f = io.open(output, "w")
 f:write("return " .. cosmo.EncodeLua(result) .. "\n")
 f:close()
-
--- cleanup TEST_TMPDIR
-unix.rmrf(test_tmpdir)
 
 os.exit(code)

--- a/lib/build/test_extract.lua
+++ b/lib/build/test_extract.lua
@@ -6,7 +6,7 @@ local cosmo = require("cosmo")
 
 local extract = dofile("lib/build/extract.lua")
 
-local tmp_dir = unix.mkdtemp("/tmp/test_extract_XXXXXX")
+local tmp_dir = path.join(TEST_TMPDIR, "test_extract")
 
 local function file_exists(filepath)
   return unix.stat(filepath) ~= nil

--- a/lib/build/test_extract.lua
+++ b/lib/build/test_extract.lua
@@ -6,8 +6,6 @@ local cosmo = require("cosmo")
 
 local extract = dofile("lib/build/extract.lua")
 
-local tmp_dir = path.join(TEST_TMPDIR, "test_extract")
-
 local function file_exists(filepath)
   return unix.stat(filepath) ~= nil
 end
@@ -18,8 +16,8 @@ local function write_file(filepath, content)
 end
 
 local function create_test_zip_with_wrapper(name)
-  local archive_dir = path.join(tmp_dir, "archive_src")
-  local archive_path = path.join(tmp_dir, name)
+  local archive_dir = path.join(TEST_TMPDIR, "archive_src")
+  local archive_path = path.join(TEST_TMPDIR, name)
 
   unix.rmrf(archive_dir)
   unix.makedirs(archive_dir)
@@ -41,8 +39,8 @@ local function create_test_zip_with_wrapper(name)
 end
 
 local function create_test_zip_no_wrapper(name)
-  local archive_dir = path.join(tmp_dir, "archive_src")
-  local archive_path = path.join(tmp_dir, name)
+  local archive_dir = path.join(TEST_TMPDIR, "archive_src")
+  local archive_path = path.join(TEST_TMPDIR, name)
 
   unix.rmrf(archive_dir)
   unix.makedirs(archive_dir)
@@ -62,8 +60,8 @@ local function create_test_zip_no_wrapper(name)
 end
 
 local function create_test_targz_with_wrapper(name)
-  local archive_dir = path.join(tmp_dir, "archive_src")
-  local archive_path = path.join(tmp_dir, name)
+  local archive_dir = path.join(TEST_TMPDIR, "archive_src")
+  local archive_path = path.join(TEST_TMPDIR, name)
 
   unix.rmrf(archive_dir)
   unix.makedirs(archive_dir)
@@ -85,8 +83,8 @@ local function create_test_targz_with_wrapper(name)
 end
 
 local function create_test_targz_no_wrapper(name)
-  local archive_dir = path.join(tmp_dir, "archive_src")
-  local archive_path = path.join(tmp_dir, name)
+  local archive_dir = path.join(TEST_TMPDIR, "archive_src")
+  local archive_path = path.join(TEST_TMPDIR, name)
 
   unix.rmrf(archive_dir)
   unix.makedirs(archive_dir)
@@ -109,7 +107,7 @@ TestZipExtractNoStrip = {}
 
 function TestZipExtractNoStrip:setUp()
   self.archive = create_test_zip_no_wrapper("test_no_strip.zip")
-  self.dest = path.join(tmp_dir, "dest_no_strip")
+  self.dest = path.join(TEST_TMPDIR, "dest_no_strip")
   unix.rmrf(self.dest)
   unix.makedirs(self.dest)
 end
@@ -131,7 +129,7 @@ TestZipExtractWithStrip = {}
 
 function TestZipExtractWithStrip:setUp()
   self.archive = create_test_zip_with_wrapper("test_with_strip.zip")
-  self.dest = path.join(tmp_dir, "dest_with_strip")
+  self.dest = path.join(TEST_TMPDIR, "dest_with_strip")
   unix.rmrf(self.dest)
   unix.makedirs(self.dest)
 end
@@ -154,7 +152,7 @@ TestTarGzExtractNoStrip = {}
 
 function TestTarGzExtractNoStrip:setUp()
   self.archive = create_test_targz_no_wrapper("test_no_strip.tar.gz")
-  self.dest = path.join(tmp_dir, "dest_targz_no_strip")
+  self.dest = path.join(TEST_TMPDIR, "dest_targz_no_strip")
   unix.rmrf(self.dest)
   unix.makedirs(self.dest)
 end
@@ -176,7 +174,7 @@ TestTarGzExtractWithStrip = {}
 
 function TestTarGzExtractWithStrip:setUp()
   self.archive = create_test_targz_with_wrapper("test_with_strip.tar.gz")
-  self.dest = path.join(tmp_dir, "dest_targz_with_strip")
+  self.dest = path.join(TEST_TMPDIR, "dest_targz_with_strip")
   unix.rmrf(self.dest)
   unix.makedirs(self.dest)
 end
@@ -199,7 +197,7 @@ TestStripComponentsErrors = {}
 
 function TestStripComponentsErrors:setUp()
   self.archive = create_test_zip_with_wrapper("test_error.zip")
-  self.dest = path.join(tmp_dir, "dest_error")
+  self.dest = path.join(TEST_TMPDIR, "dest_error")
   unix.rmrf(self.dest)
   unix.makedirs(self.dest)
 end
@@ -220,9 +218,9 @@ TestStripComponentsDeepFile = {}
 
 function TestStripComponentsDeepFile:setUp()
   -- create archive with structure: wrapper/subdir/binary
-  local archive_dir = path.join(tmp_dir, "archive_deep")
-  self.archive = path.join(tmp_dir, "test_deep.tar.gz")
-  self.dest = path.join(tmp_dir, "dest_deep")
+  local archive_dir = path.join(TEST_TMPDIR, "archive_deep")
+  self.archive = path.join(TEST_TMPDIR, "test_deep.tar.gz")
+  self.dest = path.join(TEST_TMPDIR, "dest_deep")
 
   unix.rmrf(archive_dir)
   unix.rmrf(self.dest)

--- a/lib/build/test_install.lua
+++ b/lib/build/test_install.lua
@@ -4,8 +4,6 @@ local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local install = require("build.install")
 
-local tmp_dir = path.join(TEST_TMPDIR, "test_install")
-
 local function write_file(filepath, content)
   unix.makedirs(path.dirname(filepath))
   cosmo.Barf(filepath, content or "test", tonumber("755", 8))
@@ -18,17 +16,15 @@ end
 TestCopyFile = {}
 
 function TestCopyFile:setUp()
-  unix.makedirs(path.join(tmp_dir, "target"))
-end
-
-function TestCopyFile:tearDown()
-  unix.rmrf(tmp_dir)
+  local target = path.join(TEST_TMPDIR, "target")
+  unix.rmrf(target)
+  unix.makedirs(target)
 end
 
 -- generic names like "download" should be renamed to tool name
 function TestCopyFile:test_generic_name_renamed()
-  local source = path.join(tmp_dir, "download")
-  local target_dir = path.join(tmp_dir, "target")
+  local source = path.join(TEST_TMPDIR, "download")
+  local target_dir = path.join(TEST_TMPDIR, "target")
 
   write_file(source)
 
@@ -41,8 +37,8 @@ end
 
 -- specific names like "lua" should be preserved
 function TestCopyFile:test_specific_name_preserved()
-  local source = path.join(tmp_dir, "lua")
-  local target_dir = path.join(tmp_dir, "target")
+  local source = path.join(TEST_TMPDIR, "lua")
+  local target_dir = path.join(TEST_TMPDIR, "target")
 
   write_file(source)
 
@@ -55,8 +51,8 @@ end
 
 -- lib files should never be renamed
 function TestCopyFile:test_lib_never_renamed()
-  local source = path.join(tmp_dir, "download")
-  local target_dir = path.join(tmp_dir, "target")
+  local source = path.join(TEST_TMPDIR, "download")
+  local target_dir = path.join(TEST_TMPDIR, "target")
 
   write_file(source)
 
@@ -69,8 +65,8 @@ end
 
 -- "binary" is also a generic name
 function TestCopyFile:test_binary_name_renamed()
-  local source = path.join(tmp_dir, "binary")
-  local target_dir = path.join(tmp_dir, "target")
+  local source = path.join(TEST_TMPDIR, "binary")
+  local target_dir = path.join(TEST_TMPDIR, "target")
 
   write_file(source)
 
@@ -82,8 +78,8 @@ end
 
 -- real tool names should be preserved
 function TestCopyFile:test_zip_name_preserved()
-  local source = path.join(tmp_dir, "zip")
-  local target_dir = path.join(tmp_dir, "target")
+  local source = path.join(TEST_TMPDIR, "zip")
+  local target_dir = path.join(TEST_TMPDIR, "target")
 
   write_file(source)
 

--- a/lib/build/test_install.lua
+++ b/lib/build/test_install.lua
@@ -4,7 +4,7 @@ local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local install = require("build.install")
 
-local tmp_dir = unix.mkdtemp("/tmp/test_install_XXXXXX")
+local tmp_dir = path.join(TEST_TMPDIR, "test_install")
 
 local function write_file(filepath, content)
   unix.makedirs(path.dirname(filepath))

--- a/lib/claude/test.lua
+++ b/lib/claude/test.lua
@@ -3,8 +3,10 @@ local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local claude = require("claude.main")
 
+local tmpdir = path.join(TEST_TMPDIR, "claude_test")
+unix.makedirs(tmpdir)
+
 function test_find_claude_binary_finds_existing()
-  local tmpdir = unix.mkdtemp("/tmp/claude_test_XXXXXX")
   local tmpfile = path.join(tmpdir, "testfile")
   local f = io.open(tmpfile, "w")
   f:write("test")
@@ -15,7 +17,6 @@ function test_find_claude_binary_finds_existing()
 
   lu.assertEquals(result, tmpfile, "should find existing file")
   unix.unlink(tmpfile)
-  unix.rmdir(tmpdir)
 end
 
 function test_find_claude_binary_returns_nil_when_none_exist()
@@ -26,8 +27,7 @@ function test_find_claude_binary_returns_nil_when_none_exist()
 end
 
 function test_find_claude_binary_handles_nil_in_paths()
-  local tmpdir = unix.mkdtemp("/tmp/claude_test_XXXXXX")
-  local tmpfile = path.join(tmpdir, "testfile")
+  local tmpfile = path.join(tmpdir, "testfile2")
   local f = io.open(tmpfile, "w")
   f:write("test")
   f:close()
@@ -37,7 +37,6 @@ function test_find_claude_binary_handles_nil_in_paths()
 
   lu.assertEquals(result, tmpfile, "should find existing file even when nil is first element")
   unix.unlink(tmpfile)
-  unix.rmdir(tmpdir)
 end
 
 function test_build_argv_basic()
@@ -64,7 +63,6 @@ function test_build_argv_with_user_args()
 end
 
 function test_build_argv_with_mcp_config()
-  local tmpdir = unix.mkdtemp("/tmp/claude_test_XXXXXX")
   local tmpfile = path.join(tmpdir, "mcp.json")
   local f = io.open(tmpfile, "w")
   f:write("{}")
@@ -76,7 +74,6 @@ function test_build_argv_with_mcp_config()
   lu.assertStrContains(table.concat(argv, " "), tmpfile)
 
   unix.unlink(tmpfile)
-  unix.rmdir(tmpdir)
 end
 
 function test_build_argv_ignores_nonexistent_mcp()

--- a/lib/claude/test.lua
+++ b/lib/claude/test.lua
@@ -3,11 +3,8 @@ local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local claude = require("claude.main")
 
-local tmpdir = path.join(TEST_TMPDIR, "claude_test")
-unix.makedirs(tmpdir)
-
 function test_find_claude_binary_finds_existing()
-  local tmpfile = path.join(tmpdir, "testfile")
+  local tmpfile = path.join(TEST_TMPDIR, "testfile")
   local f = io.open(tmpfile, "w")
   f:write("test")
   f:close()
@@ -27,7 +24,7 @@ function test_find_claude_binary_returns_nil_when_none_exist()
 end
 
 function test_find_claude_binary_handles_nil_in_paths()
-  local tmpfile = path.join(tmpdir, "testfile2")
+  local tmpfile = path.join(TEST_TMPDIR, "testfile2")
   local f = io.open(tmpfile, "w")
   f:write("test")
   f:close()
@@ -63,7 +60,7 @@ function test_build_argv_with_user_args()
 end
 
 function test_build_argv_with_mcp_config()
-  local tmpfile = path.join(tmpdir, "mcp.json")
+  local tmpfile = path.join(TEST_TMPDIR, "mcp.json")
   local f = io.open(tmpfile, "w")
   f:write("{}")
   f:close()

--- a/lib/daemonize/test.lua
+++ b/lib/daemonize/test.lua
@@ -4,8 +4,10 @@ local path = require("cosmo.path")
 
 local daemonize = require('daemonize')
 
+local tmpdir = path.join(TEST_TMPDIR, "daemonize_test")
+unix.makedirs(tmpdir)
+
 function test_acquire_lock()
-  local tmpdir = unix.mkdtemp("/tmp/daemonize_test_XXXXXX")
   local lock_path = path.join(tmpdir, "lock")
 
   local fd, err = daemonize.acquire_lock(lock_path)
@@ -16,11 +18,9 @@ function test_acquire_lock()
   end
 
   unix.unlink(lock_path)
-  unix.rmdir(tmpdir)
 end
 
 function test_write_pidfile()
-  local tmpdir = unix.mkdtemp("/tmp/daemonize_test_XXXXXX")
   local pid_path = path.join(tmpdir, "pidfile")
 
   local ok, err = daemonize.write_pidfile(pid_path)
@@ -36,7 +36,6 @@ function test_write_pidfile()
   lu.assertEquals(pid, unix.getpid(), "pidfile should contain current process pid")
 
   unix.unlink(pid_path)
-  unix.rmdir(tmpdir)
 end
 
 function test_write_pidfile_requires_path()

--- a/lib/daemonize/test.lua
+++ b/lib/daemonize/test.lua
@@ -4,11 +4,8 @@ local path = require("cosmo.path")
 
 local daemonize = require('daemonize')
 
-local tmpdir = path.join(TEST_TMPDIR, "daemonize_test")
-unix.makedirs(tmpdir)
-
 function test_acquire_lock()
-  local lock_path = path.join(tmpdir, "lock")
+  local lock_path = path.join(TEST_TMPDIR, "lock")
 
   local fd, err = daemonize.acquire_lock(lock_path)
   lu.assertNotNil(fd, "acquire_lock should return a file descriptor: " .. tostring(err))
@@ -21,7 +18,7 @@ function test_acquire_lock()
 end
 
 function test_write_pidfile()
-  local pid_path = path.join(tmpdir, "pidfile")
+  local pid_path = path.join(TEST_TMPDIR, "pidfile")
 
   local ok, err = daemonize.write_pidfile(pid_path)
   lu.assertNotNil(ok, "write_pidfile should succeed: " .. tostring(err))

--- a/lib/home/test_main.lua
+++ b/lib/home/test_main.lua
@@ -5,6 +5,15 @@ local path = require("cosmo.path")
 
 local home = require("home.main")
 
+-- Helper: create a test subdirectory in TEST_TMPDIR
+local test_counter = 0
+local function make_test_dir()
+  test_counter = test_counter + 1
+  local dir = path.join(TEST_TMPDIR, "home_test_" .. test_counter)
+  unix.makedirs(dir)
+  return dir
+end
+
 -- Helper: create a mock writer that captures output
 local function mock_writer()
   local output = {}
@@ -118,7 +127,7 @@ end
 -- Test: copy_file - Basic copy
 --------------------------------------------------------------------------------
 function test_copy_file_basic()
-  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
+  local tmp = make_test_dir()
   local src = path.join(tmp, "source.txt")
   local dst = path.join(tmp, "dest.txt")
 
@@ -137,7 +146,7 @@ function test_copy_file_basic()
 end
 
 function test_copy_file_with_mode()
-  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
+  local tmp = make_test_dir()
   local src = path.join(tmp, "source.txt")
   local dst = path.join(tmp, "dest.txt")
 
@@ -158,7 +167,7 @@ end
 -- Test: copy_file - Overwrite behavior
 --------------------------------------------------------------------------------
 function test_copy_file_no_overwrite_fails()
-  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
+  local tmp = make_test_dir()
   local src = path.join(tmp, "source.txt")
   local dst = path.join(tmp, "dest.txt")
 
@@ -178,7 +187,7 @@ function test_copy_file_no_overwrite_fails()
 end
 
 function test_copy_file_overwrite_succeeds()
-  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
+  local tmp = make_test_dir()
   local src = path.join(tmp, "source.txt")
   local dst = path.join(tmp, "dest.txt")
 
@@ -200,7 +209,7 @@ end
 -- Test: copy_file - Source doesn't exist
 --------------------------------------------------------------------------------
 function test_copy_file_source_missing()
-  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
+  local tmp = make_test_dir()
   local ok, err = home.copy_file(path.join(tmp, "nonexistent"), path.join(tmp, "dest"))
   lu.assertFalse(ok)
   lu.assertStrContains(err, "failed to open source")
@@ -245,7 +254,7 @@ end
 -- Test: cmd_unpack silent by default
 --------------------------------------------------------------------------------
 function test_cmd_unpack_silent_by_default()
-  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
+  local tmp = make_test_dir()
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -280,7 +289,7 @@ end
 -- Test: cmd_unpack verbose mode
 --------------------------------------------------------------------------------
 function test_cmd_unpack_verbose()
-  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
+  local tmp = make_test_dir()
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -313,7 +322,7 @@ function test_cmd_unpack_verbose()
 end
 
 function test_cmd_unpack_verbose_force_overwrite()
-  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
+  local tmp = make_test_dir()
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -349,7 +358,7 @@ end
 -- Test: cmd_unpack dry-run mode
 --------------------------------------------------------------------------------
 function test_cmd_unpack_dry_run()
-  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
+  local tmp = make_test_dir()
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -379,7 +388,7 @@ function test_cmd_unpack_dry_run()
 end
 
 function test_cmd_unpack_dry_run_verbose()
-  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
+  local tmp = make_test_dir()
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -417,7 +426,7 @@ end
 -- Test: cmd_unpack --only filter
 --------------------------------------------------------------------------------
 function test_cmd_unpack_only_filter()
-  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
+  local tmp = make_test_dir()
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -463,7 +472,7 @@ function test_cmd_unpack_only_filter()
 end
 
 function test_cmd_unpack_only_empty_filter()
-  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
+  local tmp = make_test_dir()
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -494,7 +503,7 @@ function test_cmd_unpack_only_empty_filter()
 end
 
 function test_cmd_unpack_only_null_delimited()
-  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
+  local tmp = make_test_dir()
   local zip_root = path.join(tmp, "zip/")
   unix.makedirs(zip_root)
 
@@ -638,7 +647,7 @@ end
 -- Test: read_file
 --------------------------------------------------------------------------------
 function test_read_file_success()
-  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
+  local tmp = make_test_dir()
   local file_path = path.join(tmp, "test.txt")
   cosmo.Barf(file_path, "test content")
 
@@ -682,7 +691,7 @@ end
 -- Test: 3p binaries in .local/share structure
 --------------------------------------------------------------------------------
 function test_unpack_3p_binary_structure()
-  local tmp = unix.mkdtemp("/tmp/home_test_XXXXXX")
+  local tmp = make_test_dir()
   local zip_root = path.join(tmp, "zip/")
 
   -- Create versioned binary structure

--- a/lib/spawn/test_spawn.lua
+++ b/lib/spawn/test_spawn.lua
@@ -1,5 +1,4 @@
 local lu = require("luaunit")
-local unix = require("cosmo.unix")
 local cosmo = require("cosmo")
 local path = require("cosmo.path")
 local spawn = require("spawn")
@@ -36,10 +35,8 @@ function TestSpawn:test_wait_returns_exit_code()
 end
 
 function TestSpawn:test_wait_drains_stdout_to_avoid_sigpipe()
-	local tmpdir = path.join(TEST_TMPDIR, "spawn_test")
-	unix.makedirs(tmpdir)
-	local tmp_file = path.join(tmpdir, "checkfile")
-	local tmp_target = path.join(tmpdir, "target")
+	local tmp_file = path.join(TEST_TMPDIR, "checkfile")
+	local tmp_target = path.join(TEST_TMPDIR, "target")
 
 	local f = io.open(tmp_target, "w")
 	f:write("test content\n")
@@ -71,10 +68,6 @@ function TestSpawn:test_wait_drains_stdout_to_avoid_sigpipe()
 
 	local exit_code, err = handle:wait()
 	lu.assertEquals(exit_code, 0, "sha check should exit 0, got: " .. tostring(err))
-
-	unix.unlink(tmp_file)
-	unix.unlink(tmp_target)
-	unix.rmdir(tmpdir)
 end
 
 function TestSpawn:test_stdin_string()

--- a/lib/spawn/test_spawn.lua
+++ b/lib/spawn/test_spawn.lua
@@ -36,7 +36,8 @@ function TestSpawn:test_wait_returns_exit_code()
 end
 
 function TestSpawn:test_wait_drains_stdout_to_avoid_sigpipe()
-	local tmpdir = unix.mkdtemp("/tmp/spawn_test_XXXXXX")
+	local tmpdir = path.join(TEST_TMPDIR, "spawn_test")
+	unix.makedirs(tmpdir)
 	local tmp_file = path.join(tmpdir, "checkfile")
 	local tmp_target = path.join(tmpdir, "target")
 

--- a/lib/work/test_backup.lua
+++ b/lib/work/test_backup.lua
@@ -10,6 +10,7 @@ if not has_posix then
 end
 
 local unix = require("cosmo.unix")
+local path = require("cosmo.path")
 
 local data = require("work.data")
 local store = require("work.store")
@@ -20,7 +21,8 @@ TestBackup = {}
 
 function TestBackup:setUp()
   store.reset(test_store)
-  self.test_dir = unix.mkdtemp("/tmp/work-test-backup-XXXXXX")
+  self.test_dir = path.join(TEST_TMPDIR, "work-test-backup")
+  unix.makedirs(self.test_dir)
 end
 
 function TestBackup:tearDown()

--- a/lib/work/test_backup.lua
+++ b/lib/work/test_backup.lua
@@ -9,9 +9,6 @@ if not has_posix then
   os.exit(lu.LuaUnit.run())
 end
 
-local unix = require("cosmo.unix")
-local path = require("cosmo.path")
-
 local data = require("work.data")
 local store = require("work.store")
 local Work = require("work.test_lib")
@@ -21,13 +18,11 @@ TestBackup = {}
 
 function TestBackup:setUp()
   store.reset(test_store)
-  self.test_dir = path.join(TEST_TMPDIR, "work-test-backup")
-  unix.makedirs(self.test_dir)
+  self.test_dir = TEST_TMPDIR
 end
 
 function TestBackup:tearDown()
   data.release_lock()
-  unix.rmrf(self.test_dir)
   data._lock_handle = nil
   data._lock_path = nil
 end

--- a/lib/work/test_file_locking.lua
+++ b/lib/work/test_file_locking.lua
@@ -9,9 +9,6 @@ if not has_posix then
   os.exit(lu.LuaUnit.run())
 end
 
-local unix = require("cosmo.unix")
-local path = require("cosmo.path")
-
 local data = require("work.data")
 local store = require("work.store")
 local Work = require("work.test_lib")
@@ -21,13 +18,11 @@ TestFileLocking = {}
 
 function TestFileLocking:setUp()
   store.reset(test_store)
-  self.test_dir = path.join(TEST_TMPDIR, "work-test-locking")
-  unix.makedirs(self.test_dir)
+  self.test_dir = TEST_TMPDIR
 end
 
 function TestFileLocking:tearDown()
   data.release_lock()
-  unix.rmrf(self.test_dir)
   data._lock_handle = nil
   data._lock_path = nil
 end

--- a/lib/work/test_file_locking.lua
+++ b/lib/work/test_file_locking.lua
@@ -10,6 +10,7 @@ if not has_posix then
 end
 
 local unix = require("cosmo.unix")
+local path = require("cosmo.path")
 
 local data = require("work.data")
 local store = require("work.store")
@@ -20,7 +21,8 @@ TestFileLocking = {}
 
 function TestFileLocking:setUp()
   store.reset(test_store)
-  self.test_dir = unix.mkdtemp("/tmp/work-test-XXXXXX")
+  self.test_dir = path.join(TEST_TMPDIR, "work-test-locking")
+  unix.makedirs(self.test_dir)
 end
 
 function TestFileLocking:tearDown()


### PR DESCRIPTION
Add TEST_TMPDIR global variable for tests to use instead of creating their own temporary directories. The test runner now:
- Creates a temporary directory with unix.mkdtemp in /tmp
- Makes it available via the TEST_TMPDIR global
- Excludes TEST_* globals from luaunit test discovery
- Cleans it up after test execution

Tests can use TEST_TMPDIR directly without creating subdirectories - it's their own isolated space per test run.

Also adds an ast-grep warning rule to detect tests calling mkdtemp directly.

## Changes
- `lib/build/test.lua`: Add TEST_TMPDIR setup and cleanup
- `.luacheckrc`: Add TEST_* pattern ignores for test runner globals
- `.ast-grep/rules/test-use-tmpdir-global.yml`: Warning rule for mkdtemp in tests
- `3p/ast-grep/test_rules.lua`: Tests for the new rule
- Migrated 8 test files to use TEST_TMPDIR directly