### PR TITLE
ast-grep: add test-exit-pattern rule

### DIFF
--- a/.ast-grep/rules/test-exit-pattern.yml
+++ b/.ast-grep/rules/test-exit-pattern.yml
@@ -19,8 +19,13 @@ note: |
 
 rule:
   any:
-    - pattern: os.exit($$$)
+    - pattern: os.exit($LU.$METHOD.run($$$))
     - pattern: $LU.$METHOD.run($$$)
+      not:
+        inside:
+          any:
+            - kind: function_definition
+            - kind: function_declaration
 
 constraints:
   LU:

--- a/.ast-grep/rules/test-exit-pattern.yml
+++ b/.ast-grep/rules/test-exit-pattern.yml
@@ -1,0 +1,27 @@
+id: test-exit-pattern
+language: lua
+severity: error
+message: |
+  Test files should never call os.exit() or lu.*.run() - these are only called by the test runner.
+
+  Test files should define test functions and let the test runner handle execution:
+    Bad:  os.exit(lu.LuaUnit.run())
+    Bad:  lu.LuaUnit.run()
+    Good: Define test functions and let the test runner call them
+
+note: |
+  The test runner is responsible for:
+  1. Loading test modules
+  2. Running lu.LuaUnit.run()
+  3. Calling os.exit() with the appropriate status
+
+  Test files should only define test functions.
+
+rule:
+  any:
+    - pattern: os.exit($$$)
+    - pattern: $LU.$METHOD.run($$$)
+
+constraints:
+  LU:
+    regex: "^lu$"

--- a/lib/aerosnap/test.lua
+++ b/lib/aerosnap/test.lua
@@ -71,4 +71,3 @@ function TestLookupWorkspace:test_returns_nil_for_unknown_bundle()
   lu.assertNil(match_type, "match_type should be nil")
 end
 
-os.exit(lu.LuaUnit.run())

--- a/lib/claude/test.lua
+++ b/lib/claude/test.lua
@@ -95,4 +95,3 @@ function test_scan_for_atomic_install()
   lu.assertTrue(result == nil or type(result) == "string", "should return nil or string")
 end
 
-os.exit(lu.LuaUnit.run())

--- a/lib/daemonize/test.lua
+++ b/lib/daemonize/test.lua
@@ -53,4 +53,3 @@ function test_acquire_lock_requires_path()
   lu.assertStrContains(err, "required", "error should mention path is required")
 end
 
-os.exit(lu.LuaUnit.run())

--- a/lib/environ/test.lua
+++ b/lib/environ/test.lua
@@ -139,4 +139,3 @@ function test_roundtrip()
   lu.assertEquals(env2.NUM, "123")
 end
 
-os.exit(lu.LuaUnit.run())

--- a/lib/home/test_main.lua
+++ b/lib/home/test_main.lua
@@ -772,4 +772,3 @@ function test_detect_platform_returns_string()
   )
 end
 
-os.exit(lu.LuaUnit.run())

--- a/lib/nvim/test.lua
+++ b/lib/nvim/test.lua
@@ -93,4 +93,3 @@ function test_resolve_nvim_bin_returns_error_when_missing()
   end
 end
 
-os.exit(lu.LuaUnit.run())

--- a/lib/whereami/test.lua
+++ b/lib/whereami/test.lua
@@ -26,4 +26,3 @@ function test_whereami_codespaces_format()
   lu.assertStrMatches(result, '^repo | .+')
 end
 
-os.exit(lu.LuaUnit.run())

--- a/lib/work/test.lua
+++ b/lib/work/test.lua
@@ -11,4 +11,3 @@ require("work.test_file_locking")
 require("work.test_string_sanitization")
 require("work.test_backup")
 
-os.exit(lu.LuaUnit.run())

--- a/lib/work/test.lua
+++ b/lib/work/test.lua
@@ -1,7 +1,5 @@
 #!/usr/bin/env lua
 
-local lu = require("luaunit")
-
 require("work.test_command_blocked")
 require("work.test_blockers")
 require("work.test_blocked_on_display")

--- a/lib/work/test_backup.lua
+++ b/lib/work/test_backup.lua
@@ -6,7 +6,7 @@ if not has_posix then
   function test_backup_skipped()
     lu.skip("requires luaposix")
   end
-  os.exit(lu.LuaUnit.run())
+  return
 end
 
 local unix = require("cosmo.unix")
@@ -208,4 +208,3 @@ function TestBackup:test_backup_content_matches_original()
   lu.assertNotStrContains(backup_content, "updated content")
 end
 
-os.exit(lu.LuaUnit.run())

--- a/lib/work/test_blocked_on_display.lua
+++ b/lib/work/test_blocked_on_display.lua
@@ -6,7 +6,7 @@ if not has_posix then
   function test_blocked_on_display_skipped()
     lu.skip("requires luaposix")
   end
-  os.exit(lu.LuaUnit.run())
+  return
 end
 
 local data = require("work.data")
@@ -51,4 +51,3 @@ function TestBlockedOnDisplay:test_unresolved_blocks_display()
   lu.assertTrue(#unresolved > 0, "blocked item should show what items are blocking it, got: " .. #unresolved)
 end
 
-os.exit(lu.LuaUnit.run())

--- a/lib/work/test_blockers.lua
+++ b/lib/work/test_blockers.lua
@@ -6,7 +6,7 @@ if not has_posix then
   function test_blockers_skipped()
     lu.skip("requires luaposix")
   end
-  os.exit(lu.LuaUnit.run())
+  return
 end
 
 local data = require("work.data")
@@ -43,4 +43,3 @@ function TestBlockers:test_item_blocking_relationship()
   lu.assertFalse(process.is_item_blocked(test_store, blocker))
 end
 
-os.exit(lu.LuaUnit.run())

--- a/lib/work/test_command_blocked.lua
+++ b/lib/work/test_command_blocked.lua
@@ -6,7 +6,7 @@ if not has_posix then
   function test_command_blocked_skipped()
     lu.skip("requires luaposix")
   end
-  os.exit(lu.LuaUnit.run())
+  return
 end
 
 local data = require("work.data")
@@ -42,4 +42,3 @@ function TestCommandBlocked:test_blocked_items_list()
   lu.assertEquals(blocked_items[1].id, item1.id)
 end
 
-os.exit(lu.LuaUnit.run())

--- a/lib/work/test_file_locking.lua
+++ b/lib/work/test_file_locking.lua
@@ -6,7 +6,7 @@ if not has_posix then
   function test_file_locking_skipped()
     lu.skip("requires luaposix")
   end
-  os.exit(lu.LuaUnit.run())
+  return
 end
 
 local unix = require("cosmo.unix")
@@ -124,5 +124,3 @@ function TestFileLocking:test_delete_with_locking()
   local f = io.open(file_path, "r")
   lu.assertNil(f, "work item file should not exist after delete")
 end
-
-os.exit(lu.LuaUnit.run())

--- a/lib/work/test_orphaned_blocks.lua
+++ b/lib/work/test_orphaned_blocks.lua
@@ -6,7 +6,7 @@ if not has_posix then
   function test_orphaned_blocks_skipped()
     lu.skip("requires luaposix")
   end
-  os.exit(lu.LuaUnit.run())
+  return
 end
 
 local process = require("work.process")
@@ -111,4 +111,3 @@ function TestOrphanedBlocks:test_find_items_blocking_on_multiple_blocks()
   lu.assertEquals(referencing_b[1].id, "01TEST0000000000000000003")
 end
 
-os.exit(lu.LuaUnit.run())

--- a/lib/work/test_string_sanitization.lua
+++ b/lib/work/test_string_sanitization.lua
@@ -6,7 +6,7 @@ if not has_posix then
   function test_string_sanitization_skipped()
     lu.skip("requires luaposix")
   end
-  os.exit(lu.LuaUnit.run())
+  return
 end
 
 local data = require("work.data")
@@ -123,4 +123,3 @@ function TestStringSanitization:test_error_message_includes_field_name()
   lu.assertStrContains(err, "title")
 end
 
-os.exit(lu.LuaUnit.run())

--- a/lib/work/test_validate_blocks.lua
+++ b/lib/work/test_validate_blocks.lua
@@ -6,7 +6,7 @@ if not has_posix then
   function test_validate_blocks_skipped()
     lu.skip("requires luaposix")
   end
-  os.exit(lu.LuaUnit.run())
+  return
 end
 
 local process = require("work.process")
@@ -99,4 +99,3 @@ function TestValidateBlocks:test_validate_blocks_self_reference()
   lu.assertStrContains(err, "cannot block on itself")
 end
 
-os.exit(lu.LuaUnit.run())


### PR DESCRIPTION
Adds an ast-grep rule to prevent test files from calling `os.exit()` or `lu.LuaUnit.run()` directly. The test runner is responsible for loading test modules, running tests, and handling exit status.

## Changes

- Add `.ast-grep/rules/test-exit-pattern.yml` rule
- Remove `os.exit(lu.LuaUnit.run())` calls from all test files

## Rule details

The rule catches:
- `os.exit(lu.LuaUnit.run())` - full runner pattern
- Top-level `lu.*.run()` calls (not inside functions)