### PR TITLE
ast-grep: incremental per-file linting with auto-discovery and reporting

### DIFF
--- a/lib/build/ast-grep.lua
+++ b/lib/build/ast-grep.lua
@@ -1,0 +1,172 @@
+#!/usr/bin/env lua
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
+local cosmo = require("cosmo")
+local spawn = require("spawn").spawn
+
+local function walk(dir, pattern, results)
+  results = results or {}
+  local handle = unix.opendir(dir)
+  if not handle then return results end
+
+  while true do
+    local entry = handle:read()
+    if not entry then break end
+    if entry ~= "." and entry ~= ".." then
+      local full_path = path.join(dir, entry)
+      local stat = unix.stat(full_path)
+      if stat then
+        if unix.S_ISDIR(stat:mode()) then
+          walk(full_path, pattern, results)
+        elseif entry:match(pattern) then
+          table.insert(results, full_path)
+        end
+      end
+    end
+  end
+  handle:close()
+  return results
+end
+
+local function parse_json_stream(stdout)
+  local issues = {}
+  for line in (stdout or ""):gmatch("[^\n]+") do
+    local ok, obj = pcall(cosmo.DecodeJson, line)
+    if ok and obj and obj.ruleId then
+      table.insert(issues, {
+        line = (obj.range and obj.range.start and obj.range.start.line or 0) + 1,
+        column = (obj.range and obj.range.start and obj.range.start.column or 0) + 1,
+        end_line = (obj.range and obj.range["end"] and obj.range["end"].line or 0) + 1,
+        end_column = (obj.range and obj.range["end"] and obj.range["end"].column or 0) + 1,
+        rule_id = obj.ruleId,
+        severity = obj.severity,
+        message = obj.message,
+        note = obj.note,
+        text = obj.text,
+      })
+    end
+  end
+  return issues
+end
+
+local function check(source_file, output, ast_grep_bin)
+  local output_dir = path.dirname(output)
+  unix.makedirs(output_dir)
+
+  print("# ast-grep " .. source_file)
+
+  local handle = spawn({
+    ast_grep_bin,
+    "scan",
+    "--json=stream",
+    source_file,
+  })
+
+  local _, stdout, exit_code = handle:read()
+
+  local issues = parse_json_stream(stdout)
+
+  if #issues > 0 then
+    for _, issue in ipairs(issues) do
+      io.write(string.format("%s:%d:%d: [%s] %s\n",
+        source_file,
+        issue.line,
+        issue.column,
+        issue.rule_id,
+        issue.note or issue.message:match("^[^\n]+")))
+    end
+  end
+
+  local passed = (#issues == 0)
+
+  local result = {
+    file = source_file,
+    checker = "ast-grep",
+    passed = passed,
+    exit_code = exit_code,
+    issues = issues,
+  }
+
+  cosmo.Barf(output, "return " .. cosmo.EncodeLua(result) .. "\n")
+end
+
+local function report(output_dir)
+  local files = {}
+  local passed = 0
+  local failed = 0
+  local total_issues = 0
+  local by_rule = {}
+
+  for _, filepath in ipairs(walk(output_dir, "%.ast%-grep%.ok$")) do
+    local chunk = loadfile(filepath)
+    if chunk then
+      local result = chunk()
+      if result then
+        table.insert(files, result)
+        if result.passed then
+          passed = passed + 1
+        else
+          failed = failed + 1
+        end
+        for _, issue in ipairs(result.issues or {}) do
+          total_issues = total_issues + 1
+          by_rule[issue.rule_id] = (by_rule[issue.rule_id] or 0) + 1
+        end
+      end
+    end
+  end
+
+  local total = passed + failed
+
+  print("ast-grep report")
+  print("───────────────────────────────")
+  print(string.format("  files checked:  %d", total))
+  print(string.format("  passed:         %d", passed))
+  print(string.format("  failed:         %d", failed))
+  print(string.format("  total issues:   %d", total_issues))
+  print("")
+
+  if total_issues > 0 then
+    print("issues by rule:")
+    local rules = {}
+    for rule in pairs(by_rule) do table.insert(rules, rule) end
+    table.sort(rules, function(a, b) return by_rule[b] < by_rule[a] end)
+    for _, rule in ipairs(rules) do
+      print(string.format("  %s: %d", rule, by_rule[rule]))
+    end
+    print("")
+  end
+
+  if failed > 0 then
+    print("files with issues:")
+    table.sort(files, function(a, b) return a.file < b.file end)
+    for _, f in ipairs(files) do
+      if not f.passed then
+        print(string.format("  %s (%d)", f.file, #(f.issues or {})))
+      end
+    end
+  end
+
+  return failed == 0
+end
+
+local function main(args)
+  local cmd = args[1]
+
+  if cmd == "report" then
+    local output_dir = args[2] or "o/any"
+    return report(output_dir) and 0 or 1
+  end
+
+  local source_file, output, ast_grep_bin = args[1], args[2], args[3]
+  if not source_file or not output or not ast_grep_bin then
+    io.stderr:write("usage: ast-grep.lua <source_file> <output> <ast_grep_bin>\n")
+    io.stderr:write("       ast-grep.lua report [output_dir]\n")
+    return 1
+  end
+
+  check(source_file, output, ast_grep_bin)
+  return 0
+end
+
+os.exit(main({ ... }))

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -7,6 +7,7 @@ lib_tests += o/any/build/test_install.ok
 lib_tests += o/any/build/test_fetch.ok
 lib_tests += o/any/build/test_extract.ok
 lib_tests += o/any/build/test_luacheck.ok
+lib_tests += o/any/build/test_ast_grep.ok
 
 o/any/build/lib/build/install.lua: lib/build/install.lua
 	mkdir -p $(@D)
@@ -27,3 +28,6 @@ o/any/build/test_extract.ok: lib/build/test_extract.lua lib/build/extract.lua $(
 
 o/any/build/test_luacheck.ok: lib/build/test_luacheck.lua lib/build/luacheck.lua $(luacheck_bin) $(runner)
 	TEST_BIN_DIR=o/$(current_platform)/luacheck $(runner) $< $@ $(CURDIR)/.luacheckrc
+
+o/any/build/test_ast_grep.ok: lib/build/test_ast_grep.lua lib/build/ast-grep.lua $(ast_grep) $(runner)
+	TEST_BIN_DIR=o/$(current_platform)/ast-grep $(runner) $< $@ $(CURDIR)/sgconfig.yml $(CURDIR)/.ast-grep

--- a/lib/build/test_ast_grep.lua
+++ b/lib/build/test_ast_grep.lua
@@ -1,0 +1,92 @@
+local lu = require("luaunit")
+local cosmo = require("cosmo")
+local path = require("cosmo.path")
+local spawn = require("spawn").spawn
+
+local ast_grep_bin = path.join(os.getenv("TEST_BIN_DIR"), "bin", "ast-grep")
+local ast_grep_script = "lib/build/ast-grep.lua"
+local lua_bin = "o/any/lua/bin/lua"
+
+local function run_check(code, filename)
+  local filepath = path.join(TEST_TMPDIR, filename)
+  local output_path = path.join(TEST_TMPDIR, filename .. ".ast-grep.ok")
+  cosmo.Barf(filepath, code)
+
+  local handle = spawn({ lua_bin, ast_grep_script, filepath, output_path, ast_grep_bin })
+  handle:wait()
+
+  local chunk = loadfile(output_path)
+  if not chunk then
+    return nil, "failed to load output"
+  end
+  return chunk()
+end
+
+TestAstGrepCheck = {}
+
+function TestAstGrepCheck:test_clean_code_passes()
+  local result = run_check([[
+local spawn = require("spawn").spawn
+spawn({"ls"}):wait()
+]], "clean.lua")
+  lu.assertNotNil(result)
+  lu.assertTrue(result.passed)
+  lu.assertEquals(#result.issues, 0)
+end
+
+function TestAstGrepCheck:test_os_execute_detected()
+  local result = run_check([[
+os.execute("ls")
+]], "os_exec.lua")
+  lu.assertNotNil(result)
+  lu.assertFalse(result.passed)
+  lu.assertTrue(#result.issues > 0)
+  lu.assertEquals(result.issues[1].rule_id, "avoid-os-execute")
+end
+
+function TestAstGrepCheck:test_io_popen_detected()
+  local result = run_check([[
+local handle = io.popen("ls")
+handle:close()
+]], "io_popen.lua")
+  lu.assertNotNil(result)
+  lu.assertFalse(result.passed)
+  lu.assertTrue(#result.issues > 0)
+  lu.assertEquals(result.issues[1].rule_id, "avoid-io-popen")
+end
+
+function TestAstGrepCheck:test_package_path_detected()
+  local result = run_check([[
+package.path = package.path .. ";/foo/?.lua"
+]], "pkg_path.lua")
+  lu.assertNotNil(result)
+  lu.assertFalse(result.passed)
+  lu.assertTrue(#result.issues > 0)
+  lu.assertEquals(result.issues[1].rule_id, "avoid-package-path")
+end
+
+function TestAstGrepCheck:test_issues_have_location()
+  local result = run_check([[
+os.execute("ls")
+]], "location.lua")
+  lu.assertNotNil(result)
+  lu.assertTrue(#result.issues > 0)
+  local issue = result.issues[1]
+  lu.assertNotNil(issue.line)
+  lu.assertNotNil(issue.column)
+  lu.assertNotNil(issue.rule_id)
+  lu.assertNotNil(issue.severity)
+end
+
+function TestAstGrepCheck:test_result_structure()
+  local result = run_check([[
+local x = 1
+return x
+]], "structure.lua")
+  lu.assertNotNil(result)
+  lu.assertNotNil(result.file)
+  lu.assertEquals(result.checker, "ast-grep")
+  lu.assertIsBoolean(result.passed)
+  lu.assertNotNil(result.exit_code)
+  lu.assertIsTable(result.issues)
+end


### PR DESCRIPTION
## Summary

- Add `lib/build/ast-grep.lua` runner that checks a single file and writes structured results to `.ast-grep.ok` files
- Enable make-based incremental linting where only changed files are rechecked
- Add `ast-grep` and `ast-grep-report` targets matching the luacheck pattern
- Update `check` target to use incremental ast-grep instead of full scan

## Test plan

- [x] `make ast-grep` runs incrementally (only checks changed files)
- [x] `make ast-grep` is no-op on second run
- [x] `make ast-grep-report` shows summary with issue counts by rule
- [x] `make check` uses incremental ast-grep
- [x] `make o/any/build/test_ast_grep.ok` passes all tests