### PR TITLE
Generalize and reuse walk implementations

### DIFF
--- a/lib/build/ast-grep.lua
+++ b/lib/build/ast-grep.lua
@@ -3,7 +3,7 @@ local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local cosmo = require("cosmo")
 local spawn = require("spawn").spawn
-local walk_lib = require("walk")
+local walk = require("walk")
 
 local function parse_json_stream(stdout)
   local issues = {}
@@ -74,7 +74,7 @@ local function report(output_dir)
   local total_issues = 0
   local by_rule = {}
 
-  for _, filepath in ipairs(walk_lib.collect(output_dir, "%.ast%-grep%.ok$")) do
+  for _, filepath in ipairs(walk.collect(output_dir, "%.ast%-grep%.ok$")) do
     local chunk = loadfile(filepath)
     if chunk then
       local result = chunk()

--- a/lib/build/ast-grep.lua
+++ b/lib/build/ast-grep.lua
@@ -3,30 +3,7 @@ local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local cosmo = require("cosmo")
 local spawn = require("spawn").spawn
-
-local function walk(dir, pattern, results)
-  results = results or {}
-  local handle = unix.opendir(dir)
-  if not handle then return results end
-
-  while true do
-    local entry = handle:read()
-    if not entry then break end
-    if entry ~= "." and entry ~= ".." then
-      local full_path = path.join(dir, entry)
-      local stat = unix.stat(full_path)
-      if stat then
-        if unix.S_ISDIR(stat:mode()) then
-          walk(full_path, pattern, results)
-        elseif entry:match(pattern) then
-          table.insert(results, full_path)
-        end
-      end
-    end
-  end
-  handle:close()
-  return results
-end
+local walk_lib = require("walk")
 
 local function parse_json_stream(stdout)
   local issues = {}
@@ -97,7 +74,7 @@ local function report(output_dir)
   local total_issues = 0
   local by_rule = {}
 
-  for _, filepath in ipairs(walk(output_dir, "%.ast%-grep%.ok$")) do
+  for _, filepath in ipairs(walk_lib.collect(output_dir, "%.ast%-grep%.ok$")) do
     local chunk = loadfile(filepath)
     if chunk then
       local result = chunk()

--- a/lib/build/luacheck.lua
+++ b/lib/build/luacheck.lua
@@ -3,7 +3,7 @@ local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local cosmo = require("cosmo")
 local spawn = require("spawn").spawn
-local walk_lib = require("walk")
+local walk = require("walk")
 
 local function parse_plain(stdout)
   local issues = {}
@@ -72,7 +72,7 @@ local function report(output_dir)
   local total_issues = 0
   local by_code = {}
 
-  for _, filepath in ipairs(walk_lib.collect(output_dir, "%.luacheck%.ok$")) do
+  for _, filepath in ipairs(walk.collect(output_dir, "%.luacheck%.ok$")) do
     local chunk = loadfile(filepath)
     if chunk then
       local result = chunk()

--- a/lib/build/luacheck.lua
+++ b/lib/build/luacheck.lua
@@ -3,30 +3,7 @@ local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local cosmo = require("cosmo")
 local spawn = require("spawn").spawn
-
-local function walk(dir, pattern, results)
-  results = results or {}
-  local handle = unix.opendir(dir)
-  if not handle then return results end
-
-  while true do
-    local entry = handle:read()
-    if not entry then break end
-    if entry ~= "." and entry ~= ".." then
-      local full_path = path.join(dir, entry)
-      local stat = unix.stat(full_path)
-      if stat then
-        if unix.S_ISDIR(stat:mode()) then
-          walk(full_path, pattern, results)
-        elseif entry:match(pattern) then
-          table.insert(results, full_path)
-        end
-      end
-    end
-  end
-  handle:close()
-  return results
-end
+local walk_lib = require("walk")
 
 local function parse_plain(stdout)
   local issues = {}
@@ -95,7 +72,7 @@ local function report(output_dir)
   local total_issues = 0
   local by_code = {}
 
-  for _, filepath in ipairs(walk(output_dir, "%.luacheck%.ok$")) do
+  for _, filepath in ipairs(walk_lib.collect(output_dir, "%.luacheck%.ok$")) do
     local chunk = loadfile(filepath)
     if chunk then
       local result = chunk()
@@ -171,7 +148,6 @@ if ... then
   os.exit(main({ ... }))
 else
   return {
-    walk = walk,
     parse_plain = parse_plain,
     check = check,
     report = report,

--- a/lib/build/test_luacheck.lua
+++ b/lib/build/test_luacheck.lua
@@ -98,47 +98,6 @@ end
 
 local luacheck_module = dofile(luacheck_script)
 
-TestWalk = {}
-
-function TestWalk:test_walk_finds_lua_files()
-  local test_dir = path.join(TEST_TMPDIR, "walk_test")
-  unix.makedirs(test_dir)
-  cosmo.Barf(path.join(test_dir, "file1.lua"), "")
-  cosmo.Barf(path.join(test_dir, "file2.lua"), "")
-  cosmo.Barf(path.join(test_dir, "file.txt"), "")
-
-  local results = luacheck_module.walk(test_dir, "%.lua$")
-  lu.assertEquals(#results, 2)
-end
-
-function TestWalk:test_walk_finds_nested_files()
-  local test_dir = path.join(TEST_TMPDIR, "walk_nested")
-  local sub_dir = path.join(test_dir, "subdir")
-  unix.makedirs(sub_dir)
-  cosmo.Barf(path.join(test_dir, "top.lua"), "")
-  cosmo.Barf(path.join(sub_dir, "nested.lua"), "")
-
-  local results = luacheck_module.walk(test_dir, "%.lua$")
-  lu.assertEquals(#results, 2)
-end
-
-function TestWalk:test_walk_empty_directory()
-  local test_dir = path.join(TEST_TMPDIR, "walk_empty")
-  unix.makedirs(test_dir)
-
-  local results = luacheck_module.walk(test_dir, "%.lua$")
-  lu.assertEquals(#results, 0)
-end
-
-function TestWalk:test_walk_no_matches()
-  local test_dir = path.join(TEST_TMPDIR, "walk_no_match")
-  unix.makedirs(test_dir)
-  cosmo.Barf(path.join(test_dir, "file.txt"), "")
-
-  local results = luacheck_module.walk(test_dir, "%.lua$")
-  lu.assertEquals(#results, 0)
-end
-
 TestParsePlain = {}
 
 function TestParsePlain:test_parse_with_ranges()

--- a/lib/cook.mk
+++ b/lib/cook.mk
@@ -19,6 +19,7 @@ include lib/environ/cook.mk
 include lib/spawn/cook.mk
 include lib/home/cook.mk
 include lib/nvim/cook.mk
+include lib/walk/cook.mk
 include lib/whereami/cook.mk
 include lib/work/cook.mk
 

--- a/lib/home/gen-manifest.lua
+++ b/lib/home/gen-manifest.lua
@@ -1,30 +1,6 @@
 local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
-local path = require("cosmo.path")
-
-local function walk_dir(dir, base, files)
-  files = files or {}
-  base = base or ""
-
-  for name in unix.opendir(dir) do
-    if name ~= "." and name ~= ".." then
-      local full_path = path.join(dir, name)
-      local rel_path = base == "" and name or path.join(base, name)
-      local st = unix.stat(full_path)
-
-      if st then
-        if unix.S_ISDIR(st:mode()) then
-          walk_dir(full_path, rel_path, files)
-        elseif unix.S_ISREG(st:mode()) or unix.S_ISLNK(st:mode()) then
-          local mode = st:mode() & 0x1ff
-          files[rel_path] = { mode = mode }
-        end
-      end
-    end
-  end
-
-  return files
-end
+local walk_lib = require("walk")
 
 local function cmd_help()
   io.stderr:write("usage: gen-manifest <directory> [version]\n")
@@ -48,7 +24,7 @@ local function main(args)
     return 1
   end
 
-  local files = walk_dir(dir)
+  local files = walk_lib.collect_all(dir)
   local manifest = {
     version = version,
     files = files,
@@ -58,7 +34,6 @@ local function main(args)
 end
 
 local M = {
-  walk_dir = walk_dir,
   main = main,
 }
 

--- a/lib/home/gen-manifest.lua
+++ b/lib/home/gen-manifest.lua
@@ -1,6 +1,6 @@
 local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
-local walk_lib = require("walk")
+local walk = require("walk")
 
 local function cmd_help()
   io.stderr:write("usage: gen-manifest <directory> [version]\n")
@@ -24,7 +24,7 @@ local function main(args)
     return 1
   end
 
-  local files = walk_lib.collect_all(dir)
+  local files = walk.collect_all(dir)
   local manifest = {
     version = version,
     files = files,

--- a/lib/walk/cook.mk
+++ b/lib/walk/cook.mk
@@ -1,6 +1,12 @@
 # lib/walk - directory tree walking utilities
 
+lib_dirs += o/any/walk/lib
+lib_libs += o/any/walk/lib/walk/init.lua
 lib_tests += o/any/walk/test_walk.ok
 
-o/any/walk/test_walk.ok: lib/walk/test_walk.lua lib/walk/init.lua $(runner)
+o/any/walk/lib/walk/init.lua: lib/walk/init.lua
+	mkdir -p $(@D)
+	cp $< $@
+
+o/any/walk/test_walk.ok: lib/walk/test_walk.lua o/any/walk/lib/walk/init.lua $(runner)
 	$(runner) $< $@

--- a/lib/walk/cook.mk
+++ b/lib/walk/cook.mk
@@ -1,0 +1,6 @@
+# lib/walk - directory tree walking utilities
+
+lib_tests += o/any/walk/test_walk.ok
+
+o/any/walk/test_walk.ok: lib/walk/test_walk.lua lib/walk/init.lua $(runner)
+	$(runner) $< $@

--- a/lib/walk/init.lua
+++ b/lib/walk/init.lua
@@ -1,0 +1,70 @@
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
+
+local function walk(dir, visitor, ctx)
+  ctx = ctx or {}
+  local handle = unix.opendir(dir)
+  if not handle then return ctx end
+
+  while true do
+    local entry = handle:read()
+    if not entry then break end
+    if entry ~= "." and entry ~= ".." then
+      local full_path = path.join(dir, entry)
+      local stat = unix.stat(full_path)
+      if stat then
+        local continue = visitor(full_path, entry, stat, ctx)
+        if continue ~= false and unix.S_ISDIR(stat:mode()) then
+          walk(full_path, visitor, ctx)
+        end
+      end
+    end
+  end
+  handle:close()
+  return ctx
+end
+
+local function collect(dir, pattern)
+  local results = {}
+  walk(dir, function(full_path, entry, stat, ctx)
+    if not unix.S_ISDIR(stat:mode()) and entry:match(pattern) then
+      table.insert(ctx, full_path)
+    end
+  end, results)
+  return results
+end
+
+local function collect_all(dir, base, files)
+  files = files or {}
+  base = base or ""
+
+  local handle = unix.opendir(dir)
+  if not handle then return files end
+
+  while true do
+    local entry = handle:read()
+    if not entry then break end
+    if entry ~= "." and entry ~= ".." then
+      local full_path = path.join(dir, entry)
+      local rel_path = base == "" and entry or path.join(base, entry)
+      local stat = unix.stat(full_path)
+
+      if stat then
+        if unix.S_ISDIR(stat:mode()) then
+          collect_all(full_path, rel_path, files)
+        elseif unix.S_ISREG(stat:mode()) or unix.S_ISLNK(stat:mode()) then
+          local mode = stat:mode() & 0x1ff
+          files[rel_path] = { mode = mode }
+        end
+      end
+    end
+  end
+  handle:close()
+  return files
+end
+
+return {
+  walk = walk,
+  collect = collect,
+  collect_all = collect_all,
+}

--- a/lib/walk/test_walk.lua
+++ b/lib/walk/test_walk.lua
@@ -1,0 +1,123 @@
+local walk_lib = require("walk")
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
+
+local TestWalk = {}
+
+function TestWalk:setup()
+  self.test_dir = unix.mkdtemp("/tmp/walk_test_XXXXXX")
+  unix.makedirs(path.join(self.test_dir, "subdir"))
+  unix.makedirs(path.join(self.test_dir, "subdir/nested"))
+
+  local function touch(filepath)
+    local fd = unix.open(filepath, unix.O_WRONLY | unix.O_CREAT, tonumber("644", 8))
+    unix.close(fd)
+  end
+
+  touch(path.join(self.test_dir, "file1.lua"))
+  touch(path.join(self.test_dir, "file2.txt"))
+  touch(path.join(self.test_dir, "subdir/file3.lua"))
+  touch(path.join(self.test_dir, "subdir/nested/file4.lua"))
+end
+
+function TestWalk:teardown()
+  if self.test_dir then
+    unix.rmrf(self.test_dir)
+  end
+end
+
+function TestWalk:test_collect_finds_lua_files()
+  local files = walk_lib.collect(self.test_dir, "%.lua$")
+
+  assert(#files == 3, "expected 3 lua files, got " .. #files)
+
+  local found = {}
+  for _, f in ipairs(files) do
+    local name = path.basename(f)
+    found[name] = true
+  end
+
+  assert(found["file1.lua"], "missing file1.lua")
+  assert(found["file3.lua"], "missing file3.lua")
+  assert(found["file4.lua"], "missing file4.lua")
+  assert(not found["file2.txt"], "should not find txt file")
+end
+
+function TestWalk:test_collect_finds_nested_files()
+  local files = walk_lib.collect(self.test_dir, "%.txt$")
+  assert(#files == 1, "expected 1 txt file, got " .. #files)
+  assert(path.basename(files[1]) == "file2.txt")
+end
+
+function TestWalk:test_walk_with_visitor()
+  local count = 0
+  local dirs = 0
+
+  walk_lib.walk(self.test_dir, function(full_path, entry, stat, ctx)
+    ctx.count = ctx.count + 1
+    if unix.S_ISDIR(stat:mode()) then
+      ctx.dirs = ctx.dirs + 1
+    end
+  end, { count = 0, dirs = 0 })
+
+  -- should visit 4 files + 2 directories (subdir, nested)
+  -- note: visitor is called for everything including dirs
+end
+
+function TestWalk:test_collect_all()
+  local files = walk_lib.collect_all(self.test_dir)
+
+  assert(files["file1.lua"], "missing file1.lua")
+  assert(files["file2.txt"], "missing file2.txt")
+  assert(files["subdir/file3.lua"], "missing subdir/file3.lua")
+  assert(files["subdir/nested/file4.lua"], "missing subdir/nested/file4.lua")
+
+  assert(files["file1.lua"].mode, "file1.lua should have mode")
+  assert(not files["subdir"], "directories should not be in results")
+end
+
+function TestWalk:test_walk_empty_directory()
+  local empty_dir = unix.mkdtemp("/tmp/walk_empty_XXXXXX")
+  local files = walk_lib.collect(empty_dir, "%.lua$")
+  assert(#files == 0, "empty directory should return 0 files")
+  unix.rmrf(empty_dir)
+end
+
+local function run_tests()
+  local tests = {}
+  for name, func in pairs(TestWalk) do
+    if name:match("^test_") then
+      table.insert(tests, { name = name, func = func })
+    end
+  end
+
+  table.sort(tests, function(a, b) return a.name < b.name end)
+
+  local passed = 0
+  local failed = 0
+
+  for _, test in ipairs(tests) do
+    TestWalk:setup()
+    local ok, err = pcall(test.func, TestWalk)
+    TestWalk:teardown()
+
+    if ok then
+      print("✓ " .. test.name)
+      passed = passed + 1
+    else
+      print("✗ " .. test.name)
+      print("  " .. tostring(err))
+      failed = failed + 1
+    end
+  end
+
+  print("")
+  print(string.format("passed: %d, failed: %d", passed, failed))
+  return failed == 0
+end
+
+if not pcall(debug.getlocal, 4, 1) then
+  os.exit(run_tests() and 0 or 1)
+end
+
+return TestWalk

--- a/lib/walk/test_walk.lua
+++ b/lib/walk/test_walk.lua
@@ -53,7 +53,7 @@ end
 function TestWalk:test_walk_with_visitor()
   local ctx = { count = 0, dirs = 0 }
 
-  walk.walk(self.test_dir, function(full_path, entry, stat, c)
+  walk.walk(self.test_dir, function(_full_path, _entry, stat, c)
     c.count = c.count + 1
     if unix.S_ISDIR(stat:mode()) then
       c.dirs = c.dirs + 1

--- a/lib/walk/test_walk.lua
+++ b/lib/walk/test_walk.lua
@@ -83,5 +83,3 @@ function TestWalk:test_walk_empty_directory()
   lu.assertEquals(#files, 0)
   unix.rmrf(empty_dir)
 end
-
-os.exit(lu.LuaUnit.run())


### PR DESCRIPTION
create lib/walk with reusable directory tree walking utilities:
- walk(): core recursive walk with visitor callback
- collect(): collect files matching a pattern
- collect_all(): collect all files with relative paths and metadata

refactor existing walk implementations to use the new module:
- lib/build/ast-grep.lua
- lib/build/luacheck.lua
- lib/home/gen-manifest.lua

add comprehensive tests and build integration