### PR TITLE
Implement Teal checking for Lua files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ install_script := lib/build/install.lua
 runner_script := lib/build/test.lua
 luacheck_script := lib/build/luacheck.lua
 ast_grep_script := lib/build/ast-grep.lua
+teal_script := lib/build/teal.lua
 
 # Commands (invoke lua explicitly to avoid APE "Text file busy" errors)
 fetch = $(lua_bin) $(fetch_script)
@@ -31,10 +32,11 @@ runner = $(lua_bin) $(runner_script)
 luacheck_bin = o/$(current_platform)/luacheck/bin/luacheck
 luacheck_runner = $(lua_bin) $(luacheck_script)
 ast_grep_runner = $(lua_bin) $(ast_grep_script)
+teal_runner = $(lua_bin) $(teal_script)
 
 luaunit := o/any/luaunit/lib/luaunit.lua
 
-$(fetch_script) $(extract_script) $(install_script) $(runner_script) $(luacheck_script) $(ast_grep_script): | $(lua_bin)
+$(fetch_script) $(extract_script) $(install_script) $(runner_script) $(luacheck_script) $(ast_grep_script) $(teal_script): | $(lua_bin)
 cosmo := whilp/cosmopolitan
 release ?= latest
 
@@ -63,6 +65,17 @@ o/any/%.ast-grep.ok: % sgconfig.yml $(ast_grep_script) $(ast_grep)
 ast-grep-report: $(ast_grep_files) ## Run ast-grep and show summary report
 	@$(ast_grep_runner) report o/any || true
 
+teal_files := $(patsubst %,o/any/%.teal.ok,$(lua_files))
+
+teal: $(teal_files) ## Run teal incrementally on changed files
+
+o/any/%.teal.ok: % $(teal_script) $(tl_bin) $(lua_dist)
+	$(teal_runner) $< $@ $(tl_bin) $(lua_dist)
+
+teal-report: $(teal_files) ## Run teal and show summary report
+	# TODO: remove || true once all files pass
+	@$(teal_runner) report o/any || true
+
 bootstrap: $(lua_bin)
 	@[ -n "$$CLAUDE_ENV_FILE" ] && echo "PATH=$(dir $(lua_bin)):\$$PATH" >> "$$CLAUDE_ENV_FILE"; true
 
@@ -79,14 +92,12 @@ lua_dist := o/$(current_platform)/lua/bin/lua.dist
 
 tl_bin := o/$(current_platform)/tl/bin/tl
 
-check: $(ast_grep_files) $(luacheck_files) $(tl_bin) ## Run ast-grep, luacheck, and teal
+check: $(ast_grep_files) $(luacheck_files) $(teal_files) ## Run ast-grep, luacheck, and teal
 	@$(ast_grep_runner) report o/any || true
 	@echo ""
 	@$(luacheck_runner) report o/any || true
 	@echo ""
-	@echo "Running teal type checker (lax mode)..."
-	# TODO: add .d.tl declarations for cosmo to reduce noise
-	-@$(lua_dist) $(tl_bin) check lib/*.lua lib/**/*.lua 3p/*/*.lua 2>&1
+	@$(teal_runner) report o/any || true
 
 test: lib-test $(subst %,$(current_platform),$(tests))
 	@echo "All tests passed"
@@ -94,4 +105,4 @@ test: lib-test $(subst %,$(current_platform),$(tests))
 clean:
 	rm -rf o
 
-.PHONY: bootstrap clean cosmos lua check luacheck luacheck-report ast-grep ast-grep-report test home
+.PHONY: bootstrap clean cosmos lua check luacheck luacheck-report ast-grep ast-grep-report teal teal-report test home

--- a/lib/build/teal.lua
+++ b/lib/build/teal.lua
@@ -1,0 +1,182 @@
+#!/usr/bin/env lua
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
+local cosmo = require("cosmo")
+local spawn = require("spawn").spawn
+
+local function walk(dir, pattern, results)
+  results = results or {}
+  local handle = unix.opendir(dir)
+  if not handle then return results end
+
+  while true do
+    local entry = handle:read()
+    if not entry then break end
+    if entry ~= "." and entry ~= ".." then
+      local full_path = path.join(dir, entry)
+      local stat = unix.stat(full_path)
+      if stat then
+        if unix.S_ISDIR(stat:mode()) then
+          walk(full_path, pattern, results)
+        elseif entry:match(pattern) then
+          table.insert(results, full_path)
+        end
+      end
+    end
+  end
+  handle:close()
+  return results
+end
+
+local function parse_output(stdout)
+  local issues = {}
+  local current_severity = nil
+
+  for line in (stdout or ""):gmatch("[^\n]+") do
+    if line:match("^%d+ warnings?:$") then
+      current_severity = "warning"
+    elseif line:match("^%d+ errors?:$") then
+      current_severity = "error"
+    elseif line:match("^=+$") or line:match("^%-+$") then
+      -- separator lines, skip
+    elseif current_severity then
+      local file, ln, col, msg = line:match("^(.+):(%d+):(%d+): (.+)$")
+      if ln then
+        table.insert(issues, {
+          file = file,
+          line = tonumber(ln),
+          column = tonumber(col),
+          severity = current_severity,
+          message = msg,
+        })
+      end
+    end
+  end
+  return issues
+end
+
+local function check(source_file, output, tl_bin, lua_dist)
+  local output_dir = path.dirname(output)
+  unix.makedirs(output_dir)
+
+  print("# teal " .. source_file)
+
+  local handle = spawn({
+    lua_dist,
+    tl_bin,
+    "check",
+    source_file,
+  })
+
+  if handle.stdin then handle.stdin:close() end
+  local stderr_output = handle.stderr:read()
+  local exit_code = handle:wait()
+
+  if stderr_output and #stderr_output > 0 then
+    io.write(stderr_output)
+  end
+
+  local issues = parse_output(stderr_output)
+  local passed = (exit_code == 0)
+
+  local result = {
+    file = source_file,
+    checker = "teal",
+    passed = passed,
+    exit_code = exit_code,
+    issues = issues,
+  }
+
+  cosmo.Barf(output, "return " .. cosmo.EncodeLua(result) .. "\n")
+end
+
+local function report(output_dir)
+  local files = {}
+  local passed = 0
+  local failed = 0
+  local total_issues = 0
+  local by_severity = {}
+
+  for _, filepath in ipairs(walk(output_dir, "%.teal%.ok$")) do
+    local chunk = loadfile(filepath)
+    if chunk then
+      local result = chunk()
+      if result then
+        table.insert(files, result)
+        if result.passed then
+          passed = passed + 1
+        else
+          failed = failed + 1
+        end
+        for _, issue in ipairs(result.issues or {}) do
+          total_issues = total_issues + 1
+          by_severity[issue.severity] = (by_severity[issue.severity] or 0) + 1
+        end
+      end
+    end
+  end
+
+  local total = passed + failed
+
+  print("teal report")
+  print("───────────────────────────────")
+  print(string.format("  files checked:  %d", total))
+  print(string.format("  passed:         %d", passed))
+  print(string.format("  failed:         %d", failed))
+  print(string.format("  total issues:   %d", total_issues))
+  print("")
+
+  if total_issues > 0 then
+    print("issues by severity:")
+    local severities = {}
+    for severity in pairs(by_severity) do table.insert(severities, severity) end
+    table.sort(severities, function(a, b) return by_severity[b] < by_severity[a] end)
+    for _, severity in ipairs(severities) do
+      print(string.format("  %s: %d", severity, by_severity[severity]))
+    end
+    print("")
+  end
+
+  if failed > 0 then
+    print("files with issues:")
+    table.sort(files, function(a, b) return a.file < b.file end)
+    for _, f in ipairs(files) do
+      if not f.passed then
+        print(string.format("  %s (%d)", f.file, #(f.issues or {})))
+      end
+    end
+  end
+
+  return failed == 0
+end
+
+local function main(args)
+  local cmd = args[1]
+
+  if cmd == "report" then
+    local output_dir = args[2] or "o/any"
+    return report(output_dir) and 0 or 1
+  end
+
+  local source_file, output, tl_bin, lua_dist = args[1], args[2], args[3], args[4]
+  if not source_file or not output or not tl_bin or not lua_dist then
+    io.stderr:write("usage: teal.lua <source_file> <output> <tl_bin> <lua_dist>\n")
+    io.stderr:write("       teal.lua report [output_dir]\n")
+    return 1
+  end
+
+  check(source_file, output, tl_bin, lua_dist)
+  return 0
+end
+
+if ... then
+  os.exit(main({ ... }))
+else
+  return {
+    walk = walk,
+    parse_output = parse_output,
+    check = check,
+    report = report,
+    main = main,
+  }
+end


### PR DESCRIPTION
Following the pattern of luacheck and ast-grep implementations, add incremental teal type checking for all lua files:

1. Add lib/build/teal.lua checker script
   - Parses teal output from stderr (not stdout)
   - Captures both warnings and errors with file/line/column info
   - Generates .teal.ok result files for incremental checking
   - Provides summary report aggregating all check results

2. Update Makefile to integrate teal checking
   - Add teal_script and teal_runner variables
   - Generate teal_files from lua_files pattern
   - Add teal and teal-report targets
   - Update check target to use teal-report instead of manual tl invocation
   - Add teal targets to .PHONY declaration

Benefits:
- Incremental: only rechecks files that changed
- Parallel: make can check multiple files concurrently
- Consistent: same pattern as luacheck and ast-grep
- Informative: detailed reports with issue counts by severity