### PR TITLE
luacheck: fix 3 warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,7 @@ o/any/%.luacheck.ok: % .luacheckrc $(luacheck_script) $(luacheck_bin)
 	$(luacheck_runner) $< $@ $(luacheck_bin)
 
 luacheck-report: $(luacheck_files) ## Run luacheck and show summary report
-	# TODO: remove || true once all files pass
-	@$(luacheck_runner) report o/any || true
+	@$(luacheck_runner) report o/any
 
 ast_grep_files := $(patsubst %,o/any/%.ast-grep.ok,$(lua_files))
 
@@ -74,7 +73,7 @@ o/any/%.ast-grep.ok: % sgconfig.yml $(ast_grep_script) $(ast_grep)
 	$(ast_grep_runner) $< $@ $(ast_grep)
 
 ast-grep-report: $(ast_grep_files) ## Run ast-grep and show summary report
-	@$(ast_grep_runner) report o/any || true
+	@$(ast_grep_runner) report o/any
 
 teal_files := $(patsubst %,o/any/%.teal.ok,$(lua_files))
 
@@ -104,10 +103,11 @@ lua_dist := o/$(current_platform)/lua/bin/lua.dist
 tl_bin := o/$(current_platform)/tl/bin/tl
 
 check: $(ast_grep_files) $(luacheck_files) $(teal_files) ## Run ast-grep, luacheck, and teal
-	@$(ast_grep_runner) report o/any || true
+	@$(ast_grep_runner) report o/any
 	@echo ""
-	@$(luacheck_runner) report o/any || true
+	@$(luacheck_runner) report o/any
 	@echo ""
+	# TODO: remove || true once all files pass teal
 	@$(teal_runner) report o/any || true
 
 test: $(filter o/any/lib/%,$(luatest_files)) $(subst %,$(current_platform),$(tests))

--- a/lib/build/luatest.lua
+++ b/lib/build/luatest.lua
@@ -5,7 +5,7 @@ local cosmo = require("cosmo")
 local walk = require("walk")
 
 local function run_tests(test_file, output, extra_args)
-  arg = {}
+  _G.arg = {}
   TEST_ARGS = extra_args or {}
   TEST_TMPDIR = nil
 

--- a/lib/build/teal.lua
+++ b/lib/build/teal.lua
@@ -14,9 +14,7 @@ local function parse_output(stdout)
       current_severity = "warning"
     elseif line:match("^%d+ errors?:$") then
       current_severity = "error"
-    elseif line:match("^=+$") or line:match("^%-+$") then
-      -- separator lines, skip
-    elseif current_severity then
+    elseif current_severity and not (line:match("^=+$") or line:match("^%-+$")) then
       local file, ln, col, msg = line:match("^(.+):(%d+):(%d+): (.+)$")
       if ln then
         table.insert(issues, {

--- a/lib/build/test_extract.lua
+++ b/lib/build/test_extract.lua
@@ -363,7 +363,7 @@ function TestTimestampPreservationGz:setUp()
   unix.close(fd)
 
   local handle = spawn({"gzip", "-c", src_file})
-  local ok, output, exit_code = handle:read()
+  local _, output, exit_code = handle:read()
   lu.assertEquals(exit_code, 0, "failed to create test gz")
 
   fd = unix.open(self.archive, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("644", 8))


### PR DESCRIPTION
- luatest.lua: use _G.arg to explicitly set global (W121)
- teal.lua: remove empty if branch by combining conditions (W542)
- test_extract.lua: mark unused variable with underscore (W211)