### PR TITLE
luacheck: fail build when checks fail

### DIFF
--- a/lib/build/ast-grep.lua
+++ b/lib/build/ast-grep.lua
@@ -65,6 +65,8 @@ local function check(source_file, output, ast_grep_bin)
   }
 
   cosmo.Barf(output, "return " .. cosmo.EncodeLua(result) .. "\n")
+
+  return passed
 end
 
 local function report(output_dir)
@@ -142,8 +144,17 @@ local function main(args)
     return 1
   end
 
-  check(source_file, output, ast_grep_bin)
-  return 0
+  local passed = check(source_file, output, ast_grep_bin)
+  return passed and 0 or 1
 end
 
-os.exit(main({ ... }))
+if ... then
+  os.exit(main({ ... }))
+else
+  return {
+    parse_json_stream = parse_json_stream,
+    check = check,
+    report = report,
+    main = main,
+  }
+end

--- a/lib/build/luacheck.lua
+++ b/lib/build/luacheck.lua
@@ -62,7 +62,7 @@ local function check(source_file, output, luacheck_bin)
 
   cosmo.Barf(output, "return " .. cosmo.EncodeLua(result) .. "\n")
 
-  -- TODO: fail build once all files pass
+  return passed
 end
 
 local function report(output_dir)
@@ -140,8 +140,8 @@ local function main(args)
     return 1
   end
 
-  check(source_file, output, luacheck_bin)
-  return 0
+  local passed = check(source_file, output, luacheck_bin)
+  return passed and 0 or 1
 end
 
 if ... then

--- a/lib/build/test_ast_grep.lua
+++ b/lib/build/test_ast_grep.lua
@@ -90,3 +90,25 @@ return x
   lu.assertNotNil(result.exit_code)
   lu.assertIsTable(result.issues)
 end
+
+local ast_grep_module = dofile(ast_grep_script)
+
+TestExitCode = {}
+
+function TestExitCode:test_main_returns_0_on_pass()
+  local test_file = path.join(TEST_TMPDIR, "pass.lua")
+  local output_file = path.join(TEST_TMPDIR, "pass.lua.ast-grep.ok")
+  cosmo.Barf(test_file, 'local spawn = require("spawn").spawn\nspawn({"ls"}):wait()\n')
+
+  local exit_code = ast_grep_module.main({ test_file, output_file, ast_grep_bin })
+  lu.assertEquals(exit_code, 0)
+end
+
+function TestExitCode:test_main_returns_1_on_fail()
+  local test_file = path.join(TEST_TMPDIR, "fail.lua")
+  local output_file = path.join(TEST_TMPDIR, "fail.lua.ast-grep.ok")
+  cosmo.Barf(test_file, 'os.execute("ls")\n')
+
+  local exit_code = ast_grep_module.main({ test_file, output_file, ast_grep_bin })
+  lu.assertEquals(exit_code, 1)
+end

--- a/lib/build/test_ast_grep.lua
+++ b/lib/build/test_ast_grep.lua
@@ -112,3 +112,47 @@ function TestExitCode:test_main_returns_1_on_fail()
   local exit_code = ast_grep_module.main({ test_file, output_file, ast_grep_bin })
   lu.assertEquals(exit_code, 1)
 end
+
+function TestExitCode:test_main_report_returns_0_when_all_pass()
+  local unix = require("cosmo.unix")
+  local test_dir = path.join(TEST_TMPDIR, "report_pass")
+  unix.makedirs(test_dir)
+
+  local result = {
+    file = "test.lua",
+    checker = "ast-grep",
+    passed = true,
+    exit_code = 0,
+    issues = {}
+  }
+  cosmo.Barf(path.join(test_dir, "test.ast-grep.ok"), "return " .. cosmo.EncodeLua(result) .. "\n")
+
+  local exit_code = ast_grep_module.main({ "report", test_dir })
+  lu.assertEquals(exit_code, 0)
+end
+
+function TestExitCode:test_main_report_returns_1_when_any_fail()
+  local unix = require("cosmo.unix")
+  local test_dir = path.join(TEST_TMPDIR, "report_fail")
+  unix.makedirs(test_dir)
+
+  local result = {
+    file = "test.lua",
+    checker = "ast-grep",
+    passed = false,
+    exit_code = 0,
+    issues = {
+      {
+        line = 1,
+        column = 1,
+        rule_id = "avoid-os-execute",
+        severity = "error",
+        message = "Avoid os.execute"
+      }
+    }
+  }
+  cosmo.Barf(path.join(test_dir, "test.ast-grep.ok"), "return " .. cosmo.EncodeLua(result) .. "\n")
+
+  local exit_code = ast_grep_module.main({ "report", test_dir })
+  lu.assertEquals(exit_code, 1)
+end


### PR DESCRIPTION
Remove TODO and implement build failure on luacheck errors.
All files currently pass luacheck, so this change enforces
that new code must also pass checks.