### PR TITLE
workflows: refactor to nightly releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,8 @@
-name: Build home
+name: Nightly release
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  schedule:
+    - cron: '0 6 * * *'  # 6 AM UTC daily
   workflow_dispatch:
 
 jobs:
@@ -39,7 +37,6 @@ jobs:
             o/linux-x86_64/lua/bin/lua.dist
 
   test:
-    if: github.ref == 'refs/heads/main'
     runs-on: ${{ matrix.os }}
     needs: build
     strategy:
@@ -71,3 +68,53 @@ jobs:
         run: |
           o/${{ matrix.platform }}/lua/bin/lua lib/home/test_main.lua
 
+  release:
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Download home artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: home-binaries
+          path: o/
+
+      - name: Prepare release binaries
+        run: |
+          mkdir -p release
+          cp o/darwin-arm64/home/bin/home release/home-darwin-arm64
+          cp o/linux-arm64/home/bin/home release/home-linux-arm64
+          cp o/linux-x86_64/home/bin/home release/home-linux-x86_64
+          cp o/linux-x86_64/home/bin/home release/home
+          cp o/linux-x86_64/lua/bin/lua.dist release/lua
+          chmod +x release/*
+
+      - name: Get version
+        id: version
+        run: |
+          echo "tag=home-$(date -u +%Y-%m-%d)-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
+      - name: Create checksums
+        run: |
+          cd release
+          sha256sum * > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "home ${{ steps.version.outputs.tag }}" \
+            --notes "## Home binaries
+          Platform-specific dotfiles and bundled tools.
+
+          ### Quick setup
+          \`\`\`bash
+          curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/home | sh
+          \`\`\`" \
+            release/*


### PR DESCRIPTION
Split workflow into CI and release:
- home.yml: CI workflow for build/test on push/PR
- release.yml: nightly releases with manual dispatch option

Release workflow runs daily at 6 AM UTC and supports workflow_dispatch
for manual triggering. Keeps the same date-sha tag format.