### PR TITLE
build: add github action parser module

### DIFF
--- a/lib/build/action.lua
+++ b/lib/build/action.lua
@@ -49,20 +49,7 @@ local function parse_workflow(workflow_content)
 	return actions
 end
 
-local function parse_workflow_file(file_path)
-	local file, err = io.open(file_path, "r")
-	if not file then
-		return nil, err
-	end
-
-	local content = file:read("*a")
-	file:close()
-
-	return parse_workflow(content)
-end
-
 return {
 	parse = parse,
 	parse_workflow = parse_workflow,
-	parse_workflow_file = parse_workflow_file,
 }

--- a/lib/build/action.lua
+++ b/lib/build/action.lua
@@ -1,6 +1,4 @@
-local M = {}
-
-function M.parse(action_string)
+local function parse(action_string)
 	if not action_string or action_string == "" then
 		return nil, "empty action string"
 	end
@@ -37,25 +35,34 @@ function M.parse(action_string)
 	return result
 end
 
-function M.parse_workflow_file(file_path)
-	local file, err = io.open(file_path, "r")
-	if not file then
-		return nil, err
-	end
-
+local function parse_workflow(workflow_content)
 	local actions = {}
-	for line in file:lines() do
+	for line in workflow_content:gmatch("[^\r\n]+") do
 		local uses = line:match("uses:%s*(.+)")
 		if uses then
-			local action, parse_err = M.parse(uses)
+			local action = parse(uses)
 			if action then
 				table.insert(actions, action)
 			end
 		end
 	end
-
-	file:close()
 	return actions
 end
 
-return M
+local function parse_workflow_file(file_path)
+	local file, err = io.open(file_path, "r")
+	if not file then
+		return nil, err
+	end
+
+	local content = file:read("*a")
+	file:close()
+
+	return parse_workflow(content)
+end
+
+return {
+	parse = parse,
+	parse_workflow = parse_workflow,
+	parse_workflow_file = parse_workflow_file,
+}

--- a/lib/build/action.lua
+++ b/lib/build/action.lua
@@ -1,0 +1,61 @@
+local M = {}
+
+function M.parse(action_string)
+	if not action_string or action_string == "" then
+		return nil, "empty action string"
+	end
+
+	local trimmed = action_string:match("^%s*(.-)%s*$")
+	local action_part, comment_part = trimmed:match("^(.-)%s*#%s*(.+)$")
+	if not action_part then
+		action_part = trimmed
+	end
+
+	local owner_repo, ref = action_part:match("^([^@]+)@(.+)$")
+	if not owner_repo or not ref then
+		return nil, "invalid action format"
+	end
+
+	local owner, repo = owner_repo:match("^([^/]+)/(.+)$")
+	if not owner or not repo then
+		return nil, "invalid owner/repo format"
+	end
+
+	local is_sha = ref:match("^%x+$") and #ref == 40
+
+	local result = {
+		owner = owner,
+		repo = repo,
+		ref = ref,
+		is_sha = is_sha or false,
+	}
+
+	if comment_part then
+		result.version = comment_part:match("^%s*(.-)%s*$")
+	end
+
+	return result
+end
+
+function M.parse_workflow_file(file_path)
+	local file, err = io.open(file_path, "r")
+	if not file then
+		return nil, err
+	end
+
+	local actions = {}
+	for line in file:lines() do
+		local uses = line:match("uses:%s*(.+)")
+		if uses then
+			local action, parse_err = M.parse(uses)
+			if action then
+				table.insert(actions, action)
+			end
+		end
+	end
+
+	file:close()
+	return actions
+end
+
+return M

--- a/lib/build/test_action.lua
+++ b/lib/build/test_action.lua
@@ -176,12 +176,4 @@ jobs:
 	lu.assertEquals(action_names["actions/download-artifact"], 1)
 end
 
-TestWorkflowFile = {}
-
-function TestWorkflowFile:test_parse_nonexistent_file()
-	local actions, err = action.parse_workflow_file("nonexistent.yml")
-	lu.assertNil(actions)
-	lu.assertNotNil(err)
-end
-
 os.exit(lu.LuaUnit.run())

--- a/lib/build/test_action.lua
+++ b/lib/build/test_action.lua
@@ -84,6 +84,51 @@ function TestActionParse:test_parse_missing_slash()
 	lu.assertEquals(err, "invalid owner/repo format")
 end
 
+TestWorkflow = {}
+
+function TestWorkflow:test_parse_workflow_string()
+	local workflow = [[
+name: Test
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4 # v4.3.0
+      - uses: actions/setup-node@v3
+]]
+	local actions = action.parse_workflow(workflow)
+	lu.assertNotNil(actions)
+	lu.assertEquals(#actions, 2)
+
+	lu.assertEquals(actions[1].owner, "actions")
+	lu.assertEquals(actions[1].repo, "checkout")
+	lu.assertEquals(actions[1].ref, "v4")
+	lu.assertEquals(actions[1].version, "v4.3.0")
+
+	lu.assertEquals(actions[2].owner, "actions")
+	lu.assertEquals(actions[2].repo, "setup-node")
+	lu.assertEquals(actions[2].ref, "v3")
+	lu.assertNil(actions[2].version)
+end
+
+function TestWorkflow:test_parse_workflow_empty_string()
+	local actions = action.parse_workflow("")
+	lu.assertNotNil(actions)
+	lu.assertEquals(#actions, 0)
+end
+
+function TestWorkflow:test_parse_workflow_no_actions()
+	local workflow = [[
+name: Test
+jobs:
+  test:
+    runs-on: ubuntu-latest
+]]
+	local actions = action.parse_workflow(workflow)
+	lu.assertNotNil(actions)
+	lu.assertEquals(#actions, 0)
+end
+
 TestWorkflowFile = {}
 
 function TestWorkflowFile:test_parse_workflow_file()

--- a/lib/build/test_action.lua
+++ b/lib/build/test_action.lua
@@ -165,15 +165,10 @@ jobs:
 	lu.assertNotNil(actions)
 	lu.assertEquals(#actions, 3)
 
-	local action_names = {}
-	for _, act in ipairs(actions) do
-		local full_name = act.owner .. "/" .. act.repo
-		action_names[full_name] = (action_names[full_name] or 0) + 1
-	end
-
-	lu.assertEquals(action_names["actions/checkout"], 1)
-	lu.assertEquals(action_names["actions/upload-artifact"], 1)
-	lu.assertEquals(action_names["actions/download-artifact"], 1)
+	lu.assertEquals(actions[1].owner, "actions")
+	lu.assertEquals(actions[1].repo, "checkout")
+	lu.assertEquals(actions[2].owner, "actions")
+	lu.assertEquals(actions[2].repo, "upload-artifact")
+	lu.assertEquals(actions[3].owner, "actions")
+	lu.assertEquals(actions[3].repo, "download-artifact")
 end
-
-os.exit(lu.LuaUnit.run())

--- a/lib/build/test_action.lua
+++ b/lib/build/test_action.lua
@@ -1,0 +1,122 @@
+local lu = require("luaunit")
+local action = require("build.action")
+
+TestActionParse = {}
+
+function TestActionParse:test_parse_with_sha_and_version()
+	local result = action.parse("actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0")
+	lu.assertNotNil(result)
+	lu.assertEquals(result.owner, "actions")
+	lu.assertEquals(result.repo, "checkout")
+	lu.assertEquals(result.ref, "08eba0b27e820071cde6df949e0beb9ba4906955")
+	lu.assertEquals(result.is_sha, true)
+	lu.assertEquals(result.version, "v4.3.0")
+end
+
+function TestActionParse:test_parse_with_different_action()
+	local result = action.parse("actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0")
+	lu.assertNotNil(result)
+	lu.assertEquals(result.owner, "actions")
+	lu.assertEquals(result.repo, "upload-artifact")
+	lu.assertEquals(result.ref, "6f51ac03b9356f520e9adb1b1b7802705f340c2b")
+	lu.assertEquals(result.is_sha, true)
+	lu.assertEquals(result.version, "v4.5.0")
+end
+
+function TestActionParse:test_parse_with_version_tag()
+	local result = action.parse("actions/checkout@v4")
+	lu.assertNotNil(result)
+	lu.assertEquals(result.owner, "actions")
+	lu.assertEquals(result.repo, "checkout")
+	lu.assertEquals(result.ref, "v4")
+	lu.assertEquals(result.is_sha, false)
+	lu.assertNil(result.version)
+end
+
+function TestActionParse:test_parse_with_short_sha()
+	local result = action.parse("actions/checkout@abc123")
+	lu.assertNotNil(result)
+	lu.assertEquals(result.owner, "actions")
+	lu.assertEquals(result.repo, "checkout")
+	lu.assertEquals(result.ref, "abc123")
+	lu.assertEquals(result.is_sha, false)
+end
+
+function TestActionParse:test_parse_third_party_action()
+	local result = action.parse("docker/build-push-action@v5")
+	lu.assertNotNil(result)
+	lu.assertEquals(result.owner, "docker")
+	lu.assertEquals(result.repo, "build-push-action")
+	lu.assertEquals(result.ref, "v5")
+	lu.assertEquals(result.is_sha, false)
+end
+
+function TestActionParse:test_parse_with_whitespace()
+	local result = action.parse("  actions/checkout@v4  #  v4.3.0  ")
+	lu.assertNotNil(result)
+	lu.assertEquals(result.owner, "actions")
+	lu.assertEquals(result.repo, "checkout")
+	lu.assertEquals(result.ref, "v4")
+	lu.assertEquals(result.version, "v4.3.0")
+end
+
+function TestActionParse:test_parse_empty_string()
+	local result, err = action.parse("")
+	lu.assertNil(result)
+	lu.assertEquals(err, "empty action string")
+end
+
+function TestActionParse:test_parse_nil()
+	local result, err = action.parse(nil)
+	lu.assertNil(result)
+	lu.assertEquals(err, "empty action string")
+end
+
+function TestActionParse:test_parse_missing_at()
+	local result, err = action.parse("actions/checkout")
+	lu.assertNil(result)
+	lu.assertEquals(err, "invalid action format")
+end
+
+function TestActionParse:test_parse_missing_slash()
+	local result, err = action.parse("checkout@v4")
+	lu.assertNil(result)
+	lu.assertEquals(err, "invalid owner/repo format")
+end
+
+TestWorkflowFile = {}
+
+function TestWorkflowFile:test_parse_workflow_file()
+	local actions = action.parse_workflow_file(".github/workflows/home.yml")
+	lu.assertNotNil(actions)
+	lu.assertTrue(#actions > 0)
+
+	lu.assertEquals(actions[1].owner, "actions")
+	lu.assertEquals(actions[1].repo, "checkout")
+	lu.assertEquals(actions[1].ref, "08eba0b27e820071cde6df949e0beb9ba4906955")
+	lu.assertEquals(actions[1].is_sha, true)
+	lu.assertEquals(actions[1].version, "v4.3.0")
+end
+
+function TestWorkflowFile:test_parse_workflow_finds_all_actions()
+	local actions = action.parse_workflow_file(".github/workflows/home.yml")
+	lu.assertNotNil(actions)
+
+	local action_names = {}
+	for _, act in ipairs(actions) do
+		local full_name = act.owner .. "/" .. act.repo
+		action_names[full_name] = (action_names[full_name] or 0) + 1
+	end
+
+	lu.assertTrue(action_names["actions/checkout"] > 0)
+	lu.assertTrue(action_names["actions/upload-artifact"] > 0)
+	lu.assertTrue(action_names["actions/download-artifact"] > 0)
+end
+
+function TestWorkflowFile:test_parse_nonexistent_file()
+	local actions, err = action.parse_workflow_file("nonexistent.yml")
+	lu.assertNil(actions)
+	lu.assertNotNil(err)
+end
+
+os.exit(lu.LuaUnit.run())


### PR DESCRIPTION
Add module to parse GitHub action versions and SHAs from workflow files.
Includes comprehensive tests demonstrating functionality on the repo's
workflow file.