### PR TITLE
nvim: use generic luatest pattern for tests

### DIFF
--- a/3p/argparse/cook.mk
+++ b/3p/argparse/cook.mk
@@ -2,7 +2,8 @@ argparse_version := 3p/argparse/version.lua
 lua_libs += argparse
 3p_lib_dirs += o/%/argparse/lib
 libs += o/%/argparse/lib/argparse.lua
-tests += o/%/argparse/test.ok
+
+o/any/3p/argparse/test.lua.luatest.ok: o/$(current_platform)/argparse/lib/argparse.lua
 
 o/%/argparse/archive.tar.gz: $(argparse_version) $(fetch)
 	$(fetch) $(argparse_version) $* $@
@@ -12,6 +13,3 @@ o/%/argparse/staging/src/argparse.lua: $(argparse_version) $(extract) o/%/argpar
 
 o/%/argparse/lib/argparse.lua: $(argparse_version) $(install) o/%/argparse/staging/src/argparse.lua
 	$(install) $(argparse_version) $* o/$*/argparse lib o/$*/argparse/staging/src/argparse.lua
-
-o/%/argparse/test.ok: 3p/argparse/test.lua o/%/argparse/lib/argparse.lua $(runner)
-	$(runner) $< $@

--- a/3p/ast-grep/cook.mk
+++ b/3p/ast-grep/cook.mk
@@ -1,8 +1,13 @@
 astgrep_version := 3p/ast-grep/version.lua
 astgrep_rules := $(wildcard .ast-grep/rules/*.yml)
 bins += o/%/ast-grep/bin/ast-grep
-tests += o/%/ast-grep/test.ok
-tests += o/%/ast-grep/test_rules.ok
+
+o/any/3p/ast-grep/test.lua.luatest.ok: o/$(current_platform)/ast-grep/bin/ast-grep
+o/any/3p/ast-grep/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
+
+o/any/3p/ast-grep/test_rules.lua.luatest.ok: o/$(current_platform)/ast-grep/bin/ast-grep sgconfig.yml $(astgrep_rules)
+o/any/3p/ast-grep/test_rules.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
+o/any/3p/ast-grep/test_rules.lua.luatest.ok: TEST_ARGS = $(CURDIR)/sgconfig.yml $(CURDIR)/.ast-grep/rules
 
 o/%/ast-grep/archive.zip: $(astgrep_version) $(fetch)
 	$(fetch) $(astgrep_version) $* $@
@@ -12,9 +17,3 @@ o/%/ast-grep/staging/ast-grep: $(astgrep_version) $(extract) o/%/ast-grep/archiv
 
 o/%/ast-grep/bin/ast-grep: $(astgrep_version) $(install) o/%/ast-grep/staging/ast-grep
 	$(install) $(astgrep_version) $* o/$*/ast-grep bin o/$*/ast-grep/staging/ast-grep
-
-o/%/ast-grep/test.ok: 3p/ast-grep/test.lua o/%/ast-grep/bin/ast-grep $(runner)
-	TEST_BIN_DIR=o/$*/ast-grep $(runner) $< $@
-
-o/%/ast-grep/test_rules.ok: 3p/ast-grep/test_rules.lua o/%/ast-grep/bin/ast-grep sgconfig.yml $(astgrep_rules) $(runner)
-	TEST_BIN_DIR=o/$*/ast-grep $(runner) $< $@ $(CURDIR)/sgconfig.yml $(CURDIR)/.ast-grep/rules

--- a/3p/biome/cook.mk
+++ b/3p/biome/cook.mk
@@ -1,12 +1,11 @@
 biome_version := 3p/biome/version.lua
 bins += o/%/biome/bin/biome
-tests += o/%/biome/test.ok
+
+o/any/3p/biome/test.lua.luatest.ok: o/$(current_platform)/biome/bin/biome
+o/any/3p/biome/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/biome
 
 o/%/biome/download: $(biome_version) $(fetch)
 	$(fetch) $(biome_version) $* $@
 
 o/%/biome/bin/biome: $(biome_version) $(install) o/%/biome/download
 	$(install) $(biome_version) $* o/$*/biome bin o/$*/biome/download
-
-o/%/biome/test.ok: 3p/biome/test.lua o/%/biome/bin/biome $(runner)
-	TEST_BIN_DIR=o/$*/biome $(runner) $< $@

--- a/3p/comrak/cook.mk
+++ b/3p/comrak/cook.mk
@@ -1,12 +1,11 @@
 comrak_version := 3p/comrak/version.lua
 bins += o/%/comrak/bin/comrak
-tests += o/%/comrak/test.ok
+
+o/any/3p/comrak/test.lua.luatest.ok: o/$(current_platform)/comrak/bin/comrak
+o/any/3p/comrak/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/comrak
 
 o/%/comrak/download: $(comrak_version) $(fetch)
 	$(fetch) $(comrak_version) $* $@
 
 o/%/comrak/bin/comrak: $(comrak_version) $(install) o/%/comrak/download
 	$(install) $(comrak_version) $* o/$*/comrak bin o/$*/comrak/download
-
-o/%/comrak/test.ok: 3p/comrak/test.lua o/%/comrak/bin/comrak $(runner)
-	TEST_BIN_DIR=o/$*/comrak $(runner) $< $@

--- a/3p/cook.mk
+++ b/3p/cook.mk
@@ -26,7 +26,6 @@ include 3p/lua/cook.mk
 
 define platform_target
 3p-$(1): $(subst %,$(1),$(bins) $(libs))
-test-$(1): $(subst %,$(1),$(tests))
 endef
 $(foreach p,$(platforms),$(eval $(call platform_target,$(p))))
 

--- a/3p/cosmos/cook.mk
+++ b/3p/cosmos/cook.mk
@@ -1,7 +1,9 @@
 cosmos_version := 3p/cosmos/version.lua
 cosmos_bins := o/%/cosmos/bin/lua o/%/cosmos/bin/zip o/%/cosmos/bin/unzip o/%/cosmos/bin/make
 bins += $(cosmos_bins)
-tests += o/%/cosmos/test.ok
+
+o/any/3p/cosmos/test.lua.luatest.ok: $(subst %,$(current_platform),$(cosmos_bins))
+o/any/3p/cosmos/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/cosmos
 
 o/%/cosmos/archive.zip: $(cosmos_version) $(fetch)
 	$(fetch) $(cosmos_version) $* $@
@@ -22,9 +24,6 @@ o/%/cosmos/bin/unzip: $(cosmos_version) $(install) o/%/cosmos/.extracted
 
 o/%/cosmos/bin/make: $(cosmos_version) $(install) o/%/cosmos/.extracted
 	$(install) $(cosmos_version) $* o/$*/cosmos bin o/$*/cosmos/staging/make
-
-o/%/cosmos/test.ok: 3p/cosmos/test.lua $(cosmos_bins) $(runner)
-	TEST_BIN_DIR=o/$*/cosmos $(runner) $< $@
 
 cosmos-latest: | $(lua_bin)
 	3p/cosmos/latest.lua > $(cosmos_version)

--- a/3p/delta/cook.mk
+++ b/3p/delta/cook.mk
@@ -1,6 +1,8 @@
 delta_version := 3p/delta/version.lua
 bins += o/%/delta/bin/delta
-tests += o/%/delta/test.ok
+
+o/any/3p/delta/test.lua.luatest.ok: o/$(current_platform)/delta/bin/delta
+o/any/3p/delta/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/delta
 
 o/%/delta/archive.tar.gz: $(delta_version) $(fetch)
 	$(fetch) $(delta_version) $* $@
@@ -10,6 +12,3 @@ o/%/delta/staging/delta: $(delta_version) $(extract) o/%/delta/archive.tar.gz
 
 o/%/delta/bin/delta: $(delta_version) $(install) o/%/delta/staging/delta
 	$(install) $(delta_version) $* o/$*/delta bin o/$*/delta/staging/delta
-
-o/%/delta/test.ok: 3p/delta/test.lua o/%/delta/bin/delta $(runner)
-	TEST_BIN_DIR=o/$*/delta $(runner) $< $@

--- a/3p/duckdb/cook.mk
+++ b/3p/duckdb/cook.mk
@@ -1,6 +1,8 @@
 duckdb_version := 3p/duckdb/version.lua
 bins += o/%/duckdb/bin/duckdb
-tests += o/%/duckdb/test.ok
+
+o/any/3p/duckdb/test.lua.luatest.ok: o/$(current_platform)/duckdb/bin/duckdb
+o/any/3p/duckdb/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/duckdb
 
 o/%/duckdb/archive.zip: $(duckdb_version) $(fetch)
 	$(fetch) $(duckdb_version) $* $@
@@ -10,6 +12,3 @@ o/%/duckdb/staging/duckdb: $(duckdb_version) $(extract) o/%/duckdb/archive.zip
 
 o/%/duckdb/bin/duckdb: $(duckdb_version) $(install) o/%/duckdb/staging/duckdb
 	$(install) $(duckdb_version) $* o/$*/duckdb bin o/$*/duckdb/staging/duckdb
-
-o/%/duckdb/test.ok: 3p/duckdb/test.lua o/%/duckdb/bin/duckdb $(runner)
-	TEST_BIN_DIR=o/$*/duckdb $(runner) $< $@

--- a/3p/gh/cook.mk
+++ b/3p/gh/cook.mk
@@ -1,6 +1,8 @@
 gh_version := 3p/gh/version.lua
 bins += o/%/gh/bin/gh
-tests += o/%/gh/test.ok
+
+o/any/3p/gh/test.lua.luatest.ok: o/$(current_platform)/gh/bin/gh
+o/any/3p/gh/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/gh
 
 o/%/gh/archive: $(gh_version) $(fetch)
 	$(fetch) $(gh_version) $* $@
@@ -10,6 +12,3 @@ o/%/gh/staging/bin/gh: $(gh_version) $(extract) o/%/gh/archive
 
 o/%/gh/bin/gh: $(gh_version) $(install) o/%/gh/staging/bin/gh
 	$(install) $(gh_version) $* o/$*/gh bin o/$*/gh/staging/bin/gh
-
-o/%/gh/test.ok: 3p/gh/test.lua o/%/gh/bin/gh $(runner)
-	TEST_BIN_DIR=o/$*/gh $(runner) $< $@

--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -1,6 +1,10 @@
 bins += o/%/lua/bin/lua.dist
-tests += o/%/lua/test.ok
-tests += o/%/lua/test_release.ok
+
+o/any/3p/lua/test.lua.luatest.ok: o/$(current_platform)/lua/bin/lua.dist
+o/any/3p/lua/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/lua
+
+o/any/3p/lua/test_release.lua.luatest.ok: o/$(current_platform)/lua/bin/lua.dist
+o/any/3p/lua/test_release.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/lua
 
 o/%/lua/bin/lua.ape: o/%/cosmos/bin/lua $(lib_libs) $(libs) $(luaunit)
 	rm -rf o/$*/lua/staging
@@ -13,12 +17,6 @@ o/%/lua/bin/lua.ape: o/%/cosmos/bin/lua $(lib_libs) $(libs) $(luaunit)
 
 o/%/lua/bin/lua.dist: o/%/lua/bin/lua.ape
 	cp $< $@
-
-o/%/lua/test.ok: 3p/lua/test.lua o/%/lua/bin/lua.dist $(runner)
-	TEST_BIN_DIR=o/$*/lua $(runner) $< $@
-
-o/%/lua/test_release.ok: 3p/lua/test_release.lua o/%/lua/bin/lua.dist $(runner)
-	TEST_BIN_DIR=o/$*/lua $(runner) $< $@
 
 lua-all: $(foreach p,$(platforms),o/$(p)/lua/bin/lua.dist) ## Build lua.dist for all platforms
 

--- a/3p/luacheck/cook.mk
+++ b/3p/luacheck/cook.mk
@@ -3,12 +3,14 @@ lua_libs += luacheck
 3p_lib_dirs += o/%/luacheck/lib
 libs += o/%/luacheck/lib/luacheck/main.lua
 bins += o/%/luacheck/bin/luacheck
-tests += o/%/luacheck/test.ok
 luacheck_deps := \
 	o/%/argparse/lib/argparse.lua \
 	o/%/lfs/lib/lfs.lua \
 	o/%/cosmos/bin/lua \
 	3p/luacheck/luacheck
+
+o/any/3p/luacheck/test.lua.luatest.ok: o/$(current_platform)/luacheck/bin/luacheck
+o/any/3p/luacheck/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/luacheck
 
 o/%/luacheck/archive.tar.gz: $(luacheck_version) $(fetch)
 	$(fetch) $(luacheck_version) $* $@
@@ -22,6 +24,3 @@ o/%/luacheck/lib/luacheck/main.lua: $(luacheck_version) $(install) o/%/luacheck/
 o/%/luacheck/bin/luacheck: $(luacheck_version) $(install) o/%/luacheck/lib/luacheck/main.lua $(luacheck_deps)
 	$(install) $(luacheck_version) $* o/$*/luacheck bin 3p/luacheck/luacheck
 	chmod +x o/$*/luacheck/bin/luacheck
-
-o/%/luacheck/test.ok: 3p/luacheck/test.lua o/%/luacheck/bin/luacheck $(runner)
-	TEST_BIN_DIR=o/$*/luacheck $(runner) $< $@

--- a/3p/luaunit/cook.mk
+++ b/3p/luaunit/cook.mk
@@ -1,10 +1,8 @@
 luaunit_version := 3p/luaunit/version.lua
 3p_lib_dirs += o/any/luaunit/lib
-tests += o/any/luaunit/test.ok
+
+o/any/3p/luaunit/test.lua.luatest.ok: o/any/luaunit/lib/luaunit.lua
 
 o/any/luaunit/lib/luaunit.lua: $(luaunit_version) $(fetch)
 	mkdir -p $(@D)
 	$(fetch) $(luaunit_version) any $@
-
-o/any/luaunit/test.ok: 3p/luaunit/test.lua o/any/luaunit/lib/luaunit.lua $(runner)
-	$(runner) $< $@

--- a/3p/marksman/cook.mk
+++ b/3p/marksman/cook.mk
@@ -1,12 +1,11 @@
 marksman_version := 3p/marksman/version.lua
 bins += o/%/marksman/bin/marksman
-tests += o/%/marksman/test.ok
+
+o/any/3p/marksman/test.lua.luatest.ok: o/$(current_platform)/marksman/bin/marksman
+o/any/3p/marksman/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/marksman
 
 o/%/marksman/download: $(marksman_version) $(fetch)
 	$(fetch) $(marksman_version) $* $@
 
 o/%/marksman/bin/marksman: $(marksman_version) $(install) o/%/marksman/download
 	$(install) $(marksman_version) $* o/$*/marksman bin o/$*/marksman/download
-
-o/%/marksman/test.ok: 3p/marksman/test.lua o/%/marksman/bin/marksman $(runner)
-	TEST_BIN_DIR=o/$*/marksman $(runner) $< $@

--- a/3p/nvim/cook.mk
+++ b/3p/nvim/cook.mk
@@ -4,7 +4,10 @@ nvim_plugins := conform.nvim mini.nvim nvim-lspconfig nvim-treesitter
 nvim_fetch_plugin := 3p/nvim/fetch-plugin.lua
 nvim_bundle := 3p/nvim/bundle.lua
 bins += o/%/nvim/bin/nvim
-tests += o/%/nvim/test.ok
+
+# Test uses generic luatest pattern with target-specific prereqs
+o/any/3p/nvim/test.lua.luatest.ok: o/$(current_platform)/nvim/bin/nvim
+o/any/3p/nvim/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/nvim
 
 o/%/nvim/archive.tar.gz: $(nvim_version) $(fetch)
 	$(fetch) $(nvim_version) $* $@
@@ -28,9 +31,6 @@ o/%/nvim/bin/nvim: $(nvim_version) $(install) o/%/nvim/staging/bin/nvim o/any/nv
 	$(install) $(nvim_version) $* o/$*/nvim bin o/$*/nvim/staging/bin/nvim
 	$(install) $(nvim_version) $* o/$*/nvim share o/$*/nvim/staging/share
 	$(nvim_bundle) $* o/$*/nvim o/any/nvim/plugins
-
-o/%/nvim/test.ok: 3p/nvim/test.lua o/%/nvim/bin/nvim $(runner)
-	TEST_BIN_DIR=o/$*/nvim $(runner) $< $@
 
 nvim-latest: | $(lua_bin)
 	3p/nvim/latest.lua > 3p/nvim/version.lua

--- a/3p/rg/cook.mk
+++ b/3p/rg/cook.mk
@@ -1,6 +1,8 @@
 rg_version := 3p/rg/version.lua
 bins += o/%/rg/bin/rg
-tests += o/%/rg/test.ok
+
+o/any/3p/rg/test.lua.luatest.ok: o/$(current_platform)/rg/bin/rg
+o/any/3p/rg/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/rg
 
 o/%/rg/archive.tar.gz: $(rg_version) $(fetch)
 	$(fetch) $(rg_version) $* $@
@@ -10,6 +12,3 @@ o/%/rg/staging/rg: $(rg_version) $(extract) o/%/rg/archive.tar.gz
 
 o/%/rg/bin/rg: $(rg_version) $(install) o/%/rg/staging/rg
 	$(install) $(rg_version) $* o/$*/rg bin o/$*/rg/staging/rg
-
-o/%/rg/test.ok: 3p/rg/test.lua o/%/rg/bin/rg $(runner)
-	TEST_BIN_DIR=o/$*/rg $(runner) $< $@

--- a/3p/ruff/cook.mk
+++ b/3p/ruff/cook.mk
@@ -1,6 +1,8 @@
 ruff_version := 3p/ruff/version.lua
 bins += o/%/ruff/bin/ruff
-tests += o/%/ruff/test.ok
+
+o/any/3p/ruff/test.lua.luatest.ok: o/$(current_platform)/ruff/bin/ruff
+o/any/3p/ruff/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ruff
 
 o/%/ruff/archive.tar.gz: $(ruff_version) $(fetch)
 	$(fetch) $(ruff_version) $* $@
@@ -10,6 +12,3 @@ o/%/ruff/staging/ruff: $(ruff_version) $(extract) o/%/ruff/archive.tar.gz
 
 o/%/ruff/bin/ruff: $(ruff_version) $(install) o/%/ruff/staging/ruff
 	$(install) $(ruff_version) $* o/$*/ruff bin o/$*/ruff/staging/ruff
-
-o/%/ruff/test.ok: 3p/ruff/test.lua o/%/ruff/bin/ruff $(runner)
-	TEST_BIN_DIR=o/$*/ruff $(runner) $< $@

--- a/3p/shfmt/cook.mk
+++ b/3p/shfmt/cook.mk
@@ -1,12 +1,11 @@
 shfmt_version := 3p/shfmt/version.lua
 bins += o/%/shfmt/bin/shfmt
-tests += o/%/shfmt/test.ok
+
+o/any/3p/shfmt/test.lua.luatest.ok: o/$(current_platform)/shfmt/bin/shfmt
+o/any/3p/shfmt/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/shfmt
 
 o/%/shfmt/download: $(shfmt_version) $(fetch)
 	$(fetch) $(shfmt_version) $* $@
 
 o/%/shfmt/bin/shfmt: $(shfmt_version) $(install) o/%/shfmt/download
 	$(install) $(shfmt_version) $* o/$*/shfmt bin o/$*/shfmt/download
-
-o/%/shfmt/test.ok: 3p/shfmt/test.lua o/%/shfmt/bin/shfmt $(runner)
-	TEST_BIN_DIR=o/$*/shfmt $(runner) $< $@

--- a/3p/sqruff/cook.mk
+++ b/3p/sqruff/cook.mk
@@ -1,6 +1,8 @@
 sqruff_version := 3p/sqruff/version.lua
 bins += o/%/sqruff/bin/sqruff
-tests += o/%/sqruff/test.ok
+
+o/any/3p/sqruff/test.lua.luatest.ok: o/$(current_platform)/sqruff/bin/sqruff
+o/any/3p/sqruff/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/sqruff
 
 o/%/sqruff/archive.tar.gz: $(sqruff_version) $(fetch)
 	$(fetch) $(sqruff_version) $* $@
@@ -10,6 +12,3 @@ o/%/sqruff/staging/sqruff: $(sqruff_version) $(extract) o/%/sqruff/archive.tar.g
 
 o/%/sqruff/bin/sqruff: $(sqruff_version) $(install) o/%/sqruff/staging/sqruff
 	$(install) $(sqruff_version) $* o/$*/sqruff bin o/$*/sqruff/staging/sqruff
-
-o/%/sqruff/test.ok: 3p/sqruff/test.lua o/%/sqruff/bin/sqruff $(runner)
-	TEST_BIN_DIR=o/$*/sqruff $(runner) $< $@

--- a/3p/stylua/cook.mk
+++ b/3p/stylua/cook.mk
@@ -1,6 +1,8 @@
 stylua_version := 3p/stylua/version.lua
 bins += o/%/stylua/bin/stylua
-tests += o/%/stylua/test.ok
+
+o/any/3p/stylua/test.lua.luatest.ok: o/$(current_platform)/stylua/bin/stylua
+o/any/3p/stylua/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/stylua
 
 o/%/stylua/archive.zip: $(stylua_version) $(fetch)
 	$(fetch) $(stylua_version) $* $@
@@ -10,6 +12,3 @@ o/%/stylua/staging/stylua: $(stylua_version) $(extract) o/%/stylua/archive.zip
 
 o/%/stylua/bin/stylua: $(stylua_version) $(install) o/%/stylua/staging/stylua
 	$(install) $(stylua_version) $* o/$*/stylua bin o/$*/stylua/staging/stylua
-
-o/%/stylua/test.ok: 3p/stylua/test.lua o/%/stylua/bin/stylua $(runner)
-	TEST_BIN_DIR=o/$*/stylua $(runner) $< $@

--- a/3p/superhtml/cook.mk
+++ b/3p/superhtml/cook.mk
@@ -1,6 +1,8 @@
 superhtml_version := 3p/superhtml/version.lua
 bins += o/%/superhtml/bin/superhtml
-tests += o/%/superhtml/test.ok
+
+o/any/3p/superhtml/test.lua.luatest.ok: o/$(current_platform)/superhtml/bin/superhtml
+o/any/3p/superhtml/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/superhtml
 
 o/%/superhtml/archive.tar.gz: $(superhtml_version) $(fetch)
 	$(fetch) $(superhtml_version) $* $@
@@ -10,6 +12,3 @@ o/%/superhtml/staging/superhtml: $(superhtml_version) $(extract) o/%/superhtml/a
 
 o/%/superhtml/bin/superhtml: $(superhtml_version) $(install) o/%/superhtml/staging/superhtml
 	$(install) $(superhtml_version) $* o/$*/superhtml bin o/$*/superhtml/staging/superhtml
-
-o/%/superhtml/test.ok: 3p/superhtml/test.lua o/%/superhtml/bin/superhtml $(runner)
-	TEST_BIN_DIR=o/$*/superhtml $(runner) $< $@

--- a/3p/tl/cook.mk
+++ b/3p/tl/cook.mk
@@ -3,10 +3,12 @@ lua_libs += tl
 3p_lib_dirs += o/%/tl/lib
 libs += o/%/tl/lib/tl.lua
 bins += o/%/tl/bin/tl
-tests += o/%/tl/test.ok
 tl_deps := \
 	o/%/argparse/lib/argparse.lua \
 	o/%/cosmos/bin/lua
+
+o/any/3p/tl/test.lua.luatest.ok: o/$(current_platform)/tl/bin/tl
+o/any/3p/tl/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/tl
 
 o/%/tl/archive.tar.gz: $(tl_version) $(fetch)
 	$(fetch) $(tl_version) $* $@
@@ -21,6 +23,3 @@ o/%/tl/bin/tl: $(tl_version) $(install) o/%/tl/staging/tl.lua $(tl_deps)
 	$(install) $(tl_version) $* o/$*/tl bin o/$*/tl/staging/tl
 	cp o/$*/tl/staging/tl.lua o/$*/tl/bin/tl.lua
 	chmod +x o/$*/tl/bin/tl
-
-o/%/tl/test.ok: 3p/tl/test.lua o/%/tl/bin/tl $(runner)
-	TEST_BIN_DIR=o/$*/tl $(runner) $< $@

--- a/3p/tree-sitter/cook.mk
+++ b/3p/tree-sitter/cook.mk
@@ -1,6 +1,8 @@
 tree_sitter_version := 3p/tree-sitter/version.lua
 bins += o/%/tree-sitter/bin/tree-sitter
-tests += o/%/tree-sitter/test.ok
+
+o/any/3p/tree-sitter/test.lua.luatest.ok: o/$(current_platform)/tree-sitter/bin/tree-sitter
+o/any/3p/tree-sitter/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/tree-sitter
 
 o/%/tree-sitter/archive.gz: $(tree_sitter_version) $(fetch)
 	$(fetch) $(tree_sitter_version) $* $@
@@ -10,6 +12,3 @@ o/%/tree-sitter/staging/tree-sitter: $(tree_sitter_version) $(extract) o/%/tree-
 
 o/%/tree-sitter/bin/tree-sitter: $(tree_sitter_version) $(install) o/%/tree-sitter/staging/tree-sitter
 	$(install) $(tree_sitter_version) $* o/$*/tree-sitter bin o/$*/tree-sitter/staging/tree-sitter
-
-o/%/tree-sitter/test.ok: 3p/tree-sitter/test.lua o/%/tree-sitter/bin/tree-sitter $(runner)
-	TEST_BIN_DIR=o/$*/tree-sitter $(runner) $< $@

--- a/3p/uv/cook.mk
+++ b/3p/uv/cook.mk
@@ -1,6 +1,8 @@
 uv_version := 3p/uv/version.lua
 bins += o/%/uv/bin/uv
-tests += o/%/uv/test.ok
+
+o/any/3p/uv/test.lua.luatest.ok: o/$(current_platform)/uv/bin/uv
+o/any/3p/uv/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/uv
 
 o/%/uv/archive.tar.gz: $(uv_version) $(fetch)
 	$(fetch) $(uv_version) $* $@
@@ -10,6 +12,3 @@ o/%/uv/staging/uv: $(uv_version) $(extract) o/%/uv/archive.tar.gz
 
 o/%/uv/bin/uv: $(uv_version) $(install) o/%/uv/staging/uv
 	$(install) $(uv_version) $* o/$*/uv bin o/$*/uv/staging/uv
-
-o/%/uv/test.ok: 3p/uv/test.lua o/%/uv/bin/uv $(runner)
-	TEST_BIN_DIR=o/$*/uv $(runner) $< $@

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ check: $(ast_grep_files) $(luacheck_files) $(teal_files) ## Run ast-grep, luache
 	# TODO: remove || true once all files pass teal
 	@$(teal_runner) report o/any || true
 
-test: $(filter o/any/lib/%,$(luatest_files)) $(subst %,$(current_platform),$(tests))
+test: $(filter o/any/lib/% o/any/3p/nvim/%,$(luatest_files)) $(subst %,$(current_platform),$(tests))
 	@echo "All tests passed"
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ check: $(ast_grep_files) $(luacheck_files) $(teal_files) ## Run ast-grep, luache
 	# TODO: remove || true once all files pass teal
 	@$(teal_runner) report o/any || true
 
-test: $(filter o/any/lib/% o/any/3p/nvim/%,$(luatest_files)) $(subst %,$(current_platform),$(tests))
+test: $(luatest_files)
 	@echo "All tests passed"
 
 clean:


### PR DESCRIPTION
Replace explicit platform-parameterized recipe with target-specific
prerequisites. Since tests only run on current_platform (CI matrix
handles cross-platform), the % pattern was unnecessary complexity.