### PR TITLE
makefile: refactor build system organization and variables

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Bootstrap lua
         run: make bootstrap
 
-      - name: Build home and lua binaries
-        run: make home-all lua-all -j4
-
       - name: Run checks
         run: make check
 
       - name: Run tests
         run: make test -j4
+
+      - name: Build home and lua binaries
+        run: make home-all lua-all -j4
 
       - name: Upload home artifacts
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0

--- a/3p/argparse/cook.mk
+++ b/3p/argparse/cook.mk
@@ -3,7 +3,7 @@ lua_libs += argparse
 3p_lib_dirs += o/%/argparse/lib
 libs += o/%/argparse/lib/argparse.lua
 
-o/luatest/3p/argparse/test.lua.ok: o/$(current_platform)/argparse/lib/argparse.lua
+$(luatest_o)/3p/argparse/test.lua.ok: o/$(current_platform)/argparse/lib/argparse.lua
 
 o/%/argparse/archive.tar.gz: $(argparse_version) $(fetch)
 	$(fetch) $(argparse_version) $* $@

--- a/3p/argparse/cook.mk
+++ b/3p/argparse/cook.mk
@@ -3,7 +3,7 @@ lua_libs += argparse
 3p_lib_dirs += o/%/argparse/lib
 libs += o/%/argparse/lib/argparse.lua
 
-o/any/3p/argparse/test.lua.luatest.ok: o/$(current_platform)/argparse/lib/argparse.lua
+o/luatest/3p/argparse/test.lua.ok: o/$(current_platform)/argparse/lib/argparse.lua
 
 o/%/argparse/archive.tar.gz: $(argparse_version) $(fetch)
 	$(fetch) $(argparse_version) $* $@

--- a/3p/ast-grep/cook.mk
+++ b/3p/ast-grep/cook.mk
@@ -3,12 +3,12 @@ astgrep_rules := $(wildcard .ast-grep/rules/*.yml)
 astgrep_bin := o/$(current_platform)/ast-grep/bin/ast-grep
 bins += o/%/ast-grep/bin/ast-grep
 
-o/any/3p/ast-grep/test.lua.luatest.ok: o/$(current_platform)/ast-grep/bin/ast-grep
-o/any/3p/ast-grep/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
+o/luatest/3p/ast-grep/test.lua.ok: o/$(current_platform)/ast-grep/bin/ast-grep
+o/luatest/3p/ast-grep/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
 
-o/any/3p/ast-grep/test_rules.lua.luatest.ok: o/$(current_platform)/ast-grep/bin/ast-grep sgconfig.yml $(astgrep_rules)
-o/any/3p/ast-grep/test_rules.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
-o/any/3p/ast-grep/test_rules.lua.luatest.ok: TEST_ARGS = $(CURDIR)/sgconfig.yml $(CURDIR)/.ast-grep/rules
+o/luatest/3p/ast-grep/test_rules.lua.ok: o/$(current_platform)/ast-grep/bin/ast-grep sgconfig.yml $(astgrep_rules)
+o/luatest/3p/ast-grep/test_rules.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
+o/luatest/3p/ast-grep/test_rules.lua.ok: TEST_ARGS = $(CURDIR)/sgconfig.yml $(CURDIR)/.ast-grep/rules
 
 o/%/ast-grep/archive.zip: $(astgrep_version) $(fetch)
 	$(fetch) $(astgrep_version) $* $@

--- a/3p/ast-grep/cook.mk
+++ b/3p/ast-grep/cook.mk
@@ -1,15 +1,15 @@
 astgrep_version := 3p/ast-grep/version.lua
 astgrep_config := sgconfig.yml
 astgrep_rules := $(wildcard .ast-grep/rules/*.yml)
-astgrep_bin := o/$(current_platform)/ast-grep/bin/ast-grep
-astgrep_o := o/ast-grep
+astgrep_bin := $(o_platform)/ast-grep/bin/ast-grep
+astgrep_o := $(o)/ast-grep
 bins += o/%/ast-grep/bin/ast-grep
 
 $(luatest_o)/3p/ast-grep/test.lua.ok: $(astgrep_bin)
-$(luatest_o)/3p/ast-grep/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
+$(luatest_o)/3p/ast-grep/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/ast-grep
 
 $(luatest_o)/3p/ast-grep/test_rules.lua.ok: $(astgrep_bin) $(astgrep_config) $(astgrep_rules)
-$(luatest_o)/3p/ast-grep/test_rules.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
+$(luatest_o)/3p/ast-grep/test_rules.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/ast-grep
 $(luatest_o)/3p/ast-grep/test_rules.lua.ok: TEST_ARGS = $(CURDIR)/$(astgrep_config) $(CURDIR)/.ast-grep/rules
 
 o/%/ast-grep/archive.zip: $(astgrep_version) $(fetch)

--- a/3p/ast-grep/cook.mk
+++ b/3p/ast-grep/cook.mk
@@ -1,14 +1,16 @@
 astgrep_version := 3p/ast-grep/version.lua
+astgrep_config := sgconfig.yml
 astgrep_rules := $(wildcard .ast-grep/rules/*.yml)
 astgrep_bin := o/$(current_platform)/ast-grep/bin/ast-grep
+astgrep_o := o/ast-grep
 bins += o/%/ast-grep/bin/ast-grep
 
-o/luatest/3p/ast-grep/test.lua.ok: o/$(current_platform)/ast-grep/bin/ast-grep
-o/luatest/3p/ast-grep/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
+$(luatest_o)/3p/ast-grep/test.lua.ok: $(astgrep_bin)
+$(luatest_o)/3p/ast-grep/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
 
-o/luatest/3p/ast-grep/test_rules.lua.ok: o/$(current_platform)/ast-grep/bin/ast-grep sgconfig.yml $(astgrep_rules)
-o/luatest/3p/ast-grep/test_rules.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
-o/luatest/3p/ast-grep/test_rules.lua.ok: TEST_ARGS = $(CURDIR)/sgconfig.yml $(CURDIR)/.ast-grep/rules
+$(luatest_o)/3p/ast-grep/test_rules.lua.ok: $(astgrep_bin) $(astgrep_config) $(astgrep_rules)
+$(luatest_o)/3p/ast-grep/test_rules.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
+$(luatest_o)/3p/ast-grep/test_rules.lua.ok: TEST_ARGS = $(CURDIR)/$(astgrep_config) $(CURDIR)/.ast-grep/rules
 
 o/%/ast-grep/archive.zip: $(astgrep_version) $(fetch)
 	$(fetch) $(astgrep_version) $* $@

--- a/3p/ast-grep/cook.mk
+++ b/3p/ast-grep/cook.mk
@@ -1,5 +1,6 @@
 astgrep_version := 3p/ast-grep/version.lua
 astgrep_rules := $(wildcard .ast-grep/rules/*.yml)
+astgrep_bin := o/$(current_platform)/ast-grep/bin/ast-grep
 bins += o/%/ast-grep/bin/ast-grep
 
 o/any/3p/ast-grep/test.lua.luatest.ok: o/$(current_platform)/ast-grep/bin/ast-grep

--- a/3p/biome/cook.mk
+++ b/3p/biome/cook.mk
@@ -1,8 +1,8 @@
 biome_version := 3p/biome/version.lua
 bins += o/%/biome/bin/biome
 
-o/any/3p/biome/test.lua.luatest.ok: o/$(current_platform)/biome/bin/biome
-o/any/3p/biome/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/biome
+o/luatest/3p/biome/test.lua.ok: o/$(current_platform)/biome/bin/biome
+o/luatest/3p/biome/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/biome
 
 o/%/biome/download: $(biome_version) $(fetch)
 	$(fetch) $(biome_version) $* $@

--- a/3p/biome/cook.mk
+++ b/3p/biome/cook.mk
@@ -1,8 +1,8 @@
 biome_version := 3p/biome/version.lua
 bins += o/%/biome/bin/biome
 
-o/luatest/3p/biome/test.lua.ok: o/$(current_platform)/biome/bin/biome
-o/luatest/3p/biome/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/biome
+$(luatest_o)/3p/biome/test.lua.ok: o/$(current_platform)/biome/bin/biome
+$(luatest_o)/3p/biome/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/biome
 
 o/%/biome/download: $(biome_version) $(fetch)
 	$(fetch) $(biome_version) $* $@

--- a/3p/biome/cook.mk
+++ b/3p/biome/cook.mk
@@ -2,7 +2,7 @@ biome_version := 3p/biome/version.lua
 bins += o/%/biome/bin/biome
 
 $(luatest_o)/3p/biome/test.lua.ok: o/$(current_platform)/biome/bin/biome
-$(luatest_o)/3p/biome/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/biome
+$(luatest_o)/3p/biome/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/biome
 
 o/%/biome/download: $(biome_version) $(fetch)
 	$(fetch) $(biome_version) $* $@

--- a/3p/comrak/cook.mk
+++ b/3p/comrak/cook.mk
@@ -2,7 +2,7 @@ comrak_version := 3p/comrak/version.lua
 bins += o/%/comrak/bin/comrak
 
 $(luatest_o)/3p/comrak/test.lua.ok: o/$(current_platform)/comrak/bin/comrak
-$(luatest_o)/3p/comrak/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/comrak
+$(luatest_o)/3p/comrak/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/comrak
 
 o/%/comrak/download: $(comrak_version) $(fetch)
 	$(fetch) $(comrak_version) $* $@

--- a/3p/comrak/cook.mk
+++ b/3p/comrak/cook.mk
@@ -1,8 +1,8 @@
 comrak_version := 3p/comrak/version.lua
 bins += o/%/comrak/bin/comrak
 
-o/any/3p/comrak/test.lua.luatest.ok: o/$(current_platform)/comrak/bin/comrak
-o/any/3p/comrak/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/comrak
+o/luatest/3p/comrak/test.lua.ok: o/$(current_platform)/comrak/bin/comrak
+o/luatest/3p/comrak/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/comrak
 
 o/%/comrak/download: $(comrak_version) $(fetch)
 	$(fetch) $(comrak_version) $* $@

--- a/3p/comrak/cook.mk
+++ b/3p/comrak/cook.mk
@@ -1,8 +1,8 @@
 comrak_version := 3p/comrak/version.lua
 bins += o/%/comrak/bin/comrak
 
-o/luatest/3p/comrak/test.lua.ok: o/$(current_platform)/comrak/bin/comrak
-o/luatest/3p/comrak/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/comrak
+$(luatest_o)/3p/comrak/test.lua.ok: o/$(current_platform)/comrak/bin/comrak
+$(luatest_o)/3p/comrak/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/comrak
 
 o/%/comrak/download: $(comrak_version) $(fetch)
 	$(fetch) $(comrak_version) $* $@

--- a/3p/cook.mk
+++ b/3p/cook.mk
@@ -28,9 +28,3 @@ define platform_target
 3p-$(1): $(subst %,$(1),$(bins) $(libs))
 endef
 $(foreach p,$(platforms),$(eval $(call platform_target,$(p))))
-
-# Add 3p libs to global LUA_PATH
-null :=
-space := $(null) $(null)
-LUA_PATH_3P := $(subst $(space),,$(foreach lib,$(lua_libs),o/$(current_platform)/$(lib)/lib/?.lua;o/$(current_platform)/$(lib)/lib/?/init.lua;))
-export LUA_PATH := $(LUA_PATH);$(LUA_PATH_3P)

--- a/3p/cosmos/cook.mk
+++ b/3p/cosmos/cook.mk
@@ -3,7 +3,7 @@ cosmos_bins := o/%/cosmos/bin/lua o/%/cosmos/bin/zip o/%/cosmos/bin/unzip o/%/co
 bins += $(cosmos_bins)
 
 $(luatest_o)/3p/cosmos/test.lua.ok: $(subst %,$(current_platform),$(cosmos_bins))
-$(luatest_o)/3p/cosmos/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/cosmos
+$(luatest_o)/3p/cosmos/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/cosmos
 
 o/%/cosmos/archive.zip: $(cosmos_version) $(fetch)
 	$(fetch) $(cosmos_version) $* $@

--- a/3p/cosmos/cook.mk
+++ b/3p/cosmos/cook.mk
@@ -2,8 +2,8 @@ cosmos_version := 3p/cosmos/version.lua
 cosmos_bins := o/%/cosmos/bin/lua o/%/cosmos/bin/zip o/%/cosmos/bin/unzip o/%/cosmos/bin/make
 bins += $(cosmos_bins)
 
-o/any/3p/cosmos/test.lua.luatest.ok: $(subst %,$(current_platform),$(cosmos_bins))
-o/any/3p/cosmos/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/cosmos
+o/luatest/3p/cosmos/test.lua.ok: $(subst %,$(current_platform),$(cosmos_bins))
+o/luatest/3p/cosmos/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/cosmos
 
 o/%/cosmos/archive.zip: $(cosmos_version) $(fetch)
 	$(fetch) $(cosmos_version) $* $@

--- a/3p/cosmos/cook.mk
+++ b/3p/cosmos/cook.mk
@@ -2,8 +2,8 @@ cosmos_version := 3p/cosmos/version.lua
 cosmos_bins := o/%/cosmos/bin/lua o/%/cosmos/bin/zip o/%/cosmos/bin/unzip o/%/cosmos/bin/make
 bins += $(cosmos_bins)
 
-o/luatest/3p/cosmos/test.lua.ok: $(subst %,$(current_platform),$(cosmos_bins))
-o/luatest/3p/cosmos/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/cosmos
+$(luatest_o)/3p/cosmos/test.lua.ok: $(subst %,$(current_platform),$(cosmos_bins))
+$(luatest_o)/3p/cosmos/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/cosmos
 
 o/%/cosmos/archive.zip: $(cosmos_version) $(fetch)
 	$(fetch) $(cosmos_version) $* $@

--- a/3p/delta/cook.mk
+++ b/3p/delta/cook.mk
@@ -2,7 +2,7 @@ delta_version := 3p/delta/version.lua
 bins += o/%/delta/bin/delta
 
 $(luatest_o)/3p/delta/test.lua.ok: o/$(current_platform)/delta/bin/delta
-$(luatest_o)/3p/delta/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/delta
+$(luatest_o)/3p/delta/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/delta
 
 o/%/delta/archive.tar.gz: $(delta_version) $(fetch)
 	$(fetch) $(delta_version) $* $@

--- a/3p/delta/cook.mk
+++ b/3p/delta/cook.mk
@@ -1,8 +1,8 @@
 delta_version := 3p/delta/version.lua
 bins += o/%/delta/bin/delta
 
-o/luatest/3p/delta/test.lua.ok: o/$(current_platform)/delta/bin/delta
-o/luatest/3p/delta/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/delta
+$(luatest_o)/3p/delta/test.lua.ok: o/$(current_platform)/delta/bin/delta
+$(luatest_o)/3p/delta/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/delta
 
 o/%/delta/archive.tar.gz: $(delta_version) $(fetch)
 	$(fetch) $(delta_version) $* $@

--- a/3p/delta/cook.mk
+++ b/3p/delta/cook.mk
@@ -1,8 +1,8 @@
 delta_version := 3p/delta/version.lua
 bins += o/%/delta/bin/delta
 
-o/any/3p/delta/test.lua.luatest.ok: o/$(current_platform)/delta/bin/delta
-o/any/3p/delta/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/delta
+o/luatest/3p/delta/test.lua.ok: o/$(current_platform)/delta/bin/delta
+o/luatest/3p/delta/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/delta
 
 o/%/delta/archive.tar.gz: $(delta_version) $(fetch)
 	$(fetch) $(delta_version) $* $@

--- a/3p/duckdb/cook.mk
+++ b/3p/duckdb/cook.mk
@@ -1,8 +1,8 @@
 duckdb_version := 3p/duckdb/version.lua
 bins += o/%/duckdb/bin/duckdb
 
-o/luatest/3p/duckdb/test.lua.ok: o/$(current_platform)/duckdb/bin/duckdb
-o/luatest/3p/duckdb/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/duckdb
+$(luatest_o)/3p/duckdb/test.lua.ok: o/$(current_platform)/duckdb/bin/duckdb
+$(luatest_o)/3p/duckdb/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/duckdb
 
 o/%/duckdb/archive.zip: $(duckdb_version) $(fetch)
 	$(fetch) $(duckdb_version) $* $@

--- a/3p/duckdb/cook.mk
+++ b/3p/duckdb/cook.mk
@@ -2,7 +2,7 @@ duckdb_version := 3p/duckdb/version.lua
 bins += o/%/duckdb/bin/duckdb
 
 $(luatest_o)/3p/duckdb/test.lua.ok: o/$(current_platform)/duckdb/bin/duckdb
-$(luatest_o)/3p/duckdb/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/duckdb
+$(luatest_o)/3p/duckdb/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/duckdb
 
 o/%/duckdb/archive.zip: $(duckdb_version) $(fetch)
 	$(fetch) $(duckdb_version) $* $@

--- a/3p/duckdb/cook.mk
+++ b/3p/duckdb/cook.mk
@@ -1,8 +1,8 @@
 duckdb_version := 3p/duckdb/version.lua
 bins += o/%/duckdb/bin/duckdb
 
-o/any/3p/duckdb/test.lua.luatest.ok: o/$(current_platform)/duckdb/bin/duckdb
-o/any/3p/duckdb/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/duckdb
+o/luatest/3p/duckdb/test.lua.ok: o/$(current_platform)/duckdb/bin/duckdb
+o/luatest/3p/duckdb/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/duckdb
 
 o/%/duckdb/archive.zip: $(duckdb_version) $(fetch)
 	$(fetch) $(duckdb_version) $* $@

--- a/3p/gh/cook.mk
+++ b/3p/gh/cook.mk
@@ -1,8 +1,8 @@
 gh_version := 3p/gh/version.lua
 bins += o/%/gh/bin/gh
 
-o/luatest/3p/gh/test.lua.ok: o/$(current_platform)/gh/bin/gh
-o/luatest/3p/gh/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/gh
+$(luatest_o)/3p/gh/test.lua.ok: o/$(current_platform)/gh/bin/gh
+$(luatest_o)/3p/gh/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/gh
 
 o/%/gh/archive: $(gh_version) $(fetch)
 	$(fetch) $(gh_version) $* $@

--- a/3p/gh/cook.mk
+++ b/3p/gh/cook.mk
@@ -2,7 +2,7 @@ gh_version := 3p/gh/version.lua
 bins += o/%/gh/bin/gh
 
 $(luatest_o)/3p/gh/test.lua.ok: o/$(current_platform)/gh/bin/gh
-$(luatest_o)/3p/gh/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/gh
+$(luatest_o)/3p/gh/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/gh
 
 o/%/gh/archive: $(gh_version) $(fetch)
 	$(fetch) $(gh_version) $* $@

--- a/3p/gh/cook.mk
+++ b/3p/gh/cook.mk
@@ -1,8 +1,8 @@
 gh_version := 3p/gh/version.lua
 bins += o/%/gh/bin/gh
 
-o/any/3p/gh/test.lua.luatest.ok: o/$(current_platform)/gh/bin/gh
-o/any/3p/gh/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/gh
+o/luatest/3p/gh/test.lua.ok: o/$(current_platform)/gh/bin/gh
+o/luatest/3p/gh/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/gh
 
 o/%/gh/archive: $(gh_version) $(fetch)
 	$(fetch) $(gh_version) $* $@

--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -1,11 +1,11 @@
-lua_dist := o/$(current_platform)/lua/bin/lua.dist
+lua_dist := $(o_platform)/lua/bin/lua.dist
 bins += o/%/lua/bin/lua.dist
 
-$(luatest_o)/3p/lua/test.lua.ok: o/$(current_platform)/lua/bin/lua.dist
-$(luatest_o)/3p/lua/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/lua
+$(luatest_o)/3p/lua/test.lua.ok: $(lua_dist)
+$(luatest_o)/3p/lua/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/lua
 
-$(luatest_o)/3p/lua/test_release.lua.ok: o/$(current_platform)/lua/bin/lua.dist
-$(luatest_o)/3p/lua/test_release.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/lua
+$(luatest_o)/3p/lua/test_release.lua.ok: $(lua_dist)
+$(luatest_o)/3p/lua/test_release.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/lua
 
 o/%/lua/bin/lua.ape: o/%/cosmos/bin/lua $(lib_libs) $(libs) $(luaunit)
 	rm -rf o/$*/lua/staging

--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -1,11 +1,11 @@
 lua_dist := o/$(current_platform)/lua/bin/lua.dist
 bins += o/%/lua/bin/lua.dist
 
-o/luatest/3p/lua/test.lua.ok: o/$(current_platform)/lua/bin/lua.dist
-o/luatest/3p/lua/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/lua
+$(luatest_o)/3p/lua/test.lua.ok: o/$(current_platform)/lua/bin/lua.dist
+$(luatest_o)/3p/lua/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/lua
 
-o/luatest/3p/lua/test_release.lua.ok: o/$(current_platform)/lua/bin/lua.dist
-o/luatest/3p/lua/test_release.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/lua
+$(luatest_o)/3p/lua/test_release.lua.ok: o/$(current_platform)/lua/bin/lua.dist
+$(luatest_o)/3p/lua/test_release.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/lua
 
 o/%/lua/bin/lua.ape: o/%/cosmos/bin/lua $(lib_libs) $(libs) $(luaunit)
 	rm -rf o/$*/lua/staging

--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -12,6 +12,10 @@ o/%/lua/bin/lua.ape: o/%/cosmos/bin/lua $(lib_libs) $(libs) $(luaunit)
 	mkdir -p o/$*/lua/staging/.lua $(@D)
 	$(foreach d,$(3p_lib_dirs),cp -r $(subst %,$*,$(d))/* o/$*/lua/staging/.lua/;)
 	$(foreach d,$(lib_dirs),cp -r $(d)/* o/$*/lua/staging/.lua/;)
+	# Remove test files and check artifacts from staging
+	find o/$*/lua/staging/.lua -name 'test*.lua' -delete
+	find o/$*/lua/staging/.lua -name '*.ok' -delete
+	find o/$*/lua/staging/.lua -name 'cook.mk' -delete
 	cp o/$*/cosmos/bin/lua $@
 	chmod +x $@
 	cd o/$*/lua/staging && zip -qr $(CURDIR)/$@ .lua

--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -1,3 +1,4 @@
+lua_dist := o/$(current_platform)/lua/bin/lua.dist
 bins += o/%/lua/bin/lua.dist
 
 o/any/3p/lua/test.lua.luatest.ok: o/$(current_platform)/lua/bin/lua.dist

--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -12,9 +12,8 @@ o/%/lua/bin/lua.ape: o/%/cosmos/bin/lua $(lib_libs) $(libs) $(luaunit)
 	mkdir -p o/$*/lua/staging/.lua $(@D)
 	$(foreach d,$(3p_lib_dirs),cp -r $(subst %,$*,$(d))/* o/$*/lua/staging/.lua/;)
 	$(foreach d,$(lib_dirs),cp -r $(d)/* o/$*/lua/staging/.lua/;)
-	# Remove test files and check artifacts from staging
+	# Remove test files and build config from staging
 	find o/$*/lua/staging/.lua -name 'test*.lua' -delete
-	find o/$*/lua/staging/.lua -name '*.ok' -delete
 	find o/$*/lua/staging/.lua -name 'cook.mk' -delete
 	cp o/$*/cosmos/bin/lua $@
 	chmod +x $@

--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -1,11 +1,11 @@
 lua_dist := o/$(current_platform)/lua/bin/lua.dist
 bins += o/%/lua/bin/lua.dist
 
-o/any/3p/lua/test.lua.luatest.ok: o/$(current_platform)/lua/bin/lua.dist
-o/any/3p/lua/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/lua
+o/luatest/3p/lua/test.lua.ok: o/$(current_platform)/lua/bin/lua.dist
+o/luatest/3p/lua/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/lua
 
-o/any/3p/lua/test_release.lua.luatest.ok: o/$(current_platform)/lua/bin/lua.dist
-o/any/3p/lua/test_release.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/lua
+o/luatest/3p/lua/test_release.lua.ok: o/$(current_platform)/lua/bin/lua.dist
+o/luatest/3p/lua/test_release.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/lua
 
 o/%/lua/bin/lua.ape: o/%/cosmos/bin/lua $(lib_libs) $(libs) $(luaunit)
 	rm -rf o/$*/lua/staging

--- a/3p/luacheck/cook.mk
+++ b/3p/luacheck/cook.mk
@@ -1,8 +1,10 @@
 luacheck_version := 3p/luacheck/version.lua
+luacheck_config := .luacheckrc
 lua_libs += luacheck
 3p_lib_dirs += o/%/luacheck/lib
 libs += o/%/luacheck/lib/luacheck/main.lua
 luacheck_bin := o/$(current_platform)/luacheck/bin/luacheck
+luacheck_o := o/luacheck
 bins += o/%/luacheck/bin/luacheck
 luacheck_deps := \
 	o/%/argparse/lib/argparse.lua \
@@ -10,8 +12,8 @@ luacheck_deps := \
 	o/%/cosmos/bin/lua \
 	3p/luacheck/luacheck
 
-o/luatest/3p/luacheck/test.lua.ok: o/$(current_platform)/luacheck/bin/luacheck
-o/luatest/3p/luacheck/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/luacheck
+$(luatest_o)/3p/luacheck/test.lua.ok: o/$(current_platform)/luacheck/bin/luacheck
+$(luatest_o)/3p/luacheck/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/luacheck
 
 o/%/luacheck/archive.tar.gz: $(luacheck_version) $(fetch)
 	$(fetch) $(luacheck_version) $* $@

--- a/3p/luacheck/cook.mk
+++ b/3p/luacheck/cook.mk
@@ -2,6 +2,7 @@ luacheck_version := 3p/luacheck/version.lua
 lua_libs += luacheck
 3p_lib_dirs += o/%/luacheck/lib
 libs += o/%/luacheck/lib/luacheck/main.lua
+luacheck_bin := o/$(current_platform)/luacheck/bin/luacheck
 bins += o/%/luacheck/bin/luacheck
 luacheck_deps := \
 	o/%/argparse/lib/argparse.lua \

--- a/3p/luacheck/cook.mk
+++ b/3p/luacheck/cook.mk
@@ -10,8 +10,8 @@ luacheck_deps := \
 	o/%/cosmos/bin/lua \
 	3p/luacheck/luacheck
 
-o/any/3p/luacheck/test.lua.luatest.ok: o/$(current_platform)/luacheck/bin/luacheck
-o/any/3p/luacheck/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/luacheck
+o/luatest/3p/luacheck/test.lua.ok: o/$(current_platform)/luacheck/bin/luacheck
+o/luatest/3p/luacheck/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/luacheck
 
 o/%/luacheck/archive.tar.gz: $(luacheck_version) $(fetch)
 	$(fetch) $(luacheck_version) $* $@

--- a/3p/luacheck/cook.mk
+++ b/3p/luacheck/cook.mk
@@ -3,8 +3,8 @@ luacheck_config := .luacheckrc
 lua_libs += luacheck
 3p_lib_dirs += o/%/luacheck/lib
 libs += o/%/luacheck/lib/luacheck/main.lua
-luacheck_bin := o/$(current_platform)/luacheck/bin/luacheck
-luacheck_o := o/luacheck
+luacheck_bin := $(o_platform)/luacheck/bin/luacheck
+luacheck_o := $(o)/luacheck
 bins += o/%/luacheck/bin/luacheck
 luacheck_deps := \
 	o/%/argparse/lib/argparse.lua \
@@ -12,8 +12,8 @@ luacheck_deps := \
 	o/%/cosmos/bin/lua \
 	3p/luacheck/luacheck
 
-$(luatest_o)/3p/luacheck/test.lua.ok: o/$(current_platform)/luacheck/bin/luacheck
-$(luatest_o)/3p/luacheck/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/luacheck
+$(luatest_o)/3p/luacheck/test.lua.ok: $(luacheck_bin)
+$(luatest_o)/3p/luacheck/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/luacheck
 
 o/%/luacheck/archive.tar.gz: $(luacheck_version) $(fetch)
 	$(fetch) $(luacheck_version) $* $@

--- a/3p/luaunit/cook.mk
+++ b/3p/luaunit/cook.mk
@@ -1,7 +1,7 @@
 luaunit_version := 3p/luaunit/version.lua
 3p_lib_dirs += o/any/luaunit/lib
 
-o/luatest/3p/luaunit/test.lua.ok: o/any/luaunit/lib/luaunit.lua
+$(luatest_o)/3p/luaunit/test.lua.ok: o/any/luaunit/lib/luaunit.lua
 
 o/any/luaunit/lib/luaunit.lua: $(luaunit_version) $(fetch)
 	mkdir -p $(@D)

--- a/3p/luaunit/cook.mk
+++ b/3p/luaunit/cook.mk
@@ -1,7 +1,7 @@
 luaunit_version := 3p/luaunit/version.lua
 3p_lib_dirs += o/any/luaunit/lib
 
-o/any/3p/luaunit/test.lua.luatest.ok: o/any/luaunit/lib/luaunit.lua
+o/luatest/3p/luaunit/test.lua.ok: o/any/luaunit/lib/luaunit.lua
 
 o/any/luaunit/lib/luaunit.lua: $(luaunit_version) $(fetch)
 	mkdir -p $(@D)

--- a/3p/luaunit/cook.mk
+++ b/3p/luaunit/cook.mk
@@ -1,8 +1,9 @@
 luaunit_version := 3p/luaunit/version.lua
-3p_lib_dirs += o/any/luaunit/lib
+luaunit := $(o_any)/luaunit/lib/luaunit.lua
+3p_lib_dirs += $(o_any)/luaunit/lib
 
-$(luatest_o)/3p/luaunit/test.lua.ok: o/any/luaunit/lib/luaunit.lua
+$(luatest_o)/3p/luaunit/test.lua.ok: $(luaunit)
 
-o/any/luaunit/lib/luaunit.lua: $(luaunit_version) $(fetch)
+$(luaunit): $(luaunit_version) $(fetch)
 	mkdir -p $(@D)
 	$(fetch) $(luaunit_version) any $@

--- a/3p/marksman/cook.mk
+++ b/3p/marksman/cook.mk
@@ -2,7 +2,7 @@ marksman_version := 3p/marksman/version.lua
 bins += o/%/marksman/bin/marksman
 
 $(luatest_o)/3p/marksman/test.lua.ok: o/$(current_platform)/marksman/bin/marksman
-$(luatest_o)/3p/marksman/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/marksman
+$(luatest_o)/3p/marksman/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/marksman
 
 o/%/marksman/download: $(marksman_version) $(fetch)
 	$(fetch) $(marksman_version) $* $@

--- a/3p/marksman/cook.mk
+++ b/3p/marksman/cook.mk
@@ -1,8 +1,8 @@
 marksman_version := 3p/marksman/version.lua
 bins += o/%/marksman/bin/marksman
 
-o/luatest/3p/marksman/test.lua.ok: o/$(current_platform)/marksman/bin/marksman
-o/luatest/3p/marksman/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/marksman
+$(luatest_o)/3p/marksman/test.lua.ok: o/$(current_platform)/marksman/bin/marksman
+$(luatest_o)/3p/marksman/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/marksman
 
 o/%/marksman/download: $(marksman_version) $(fetch)
 	$(fetch) $(marksman_version) $* $@

--- a/3p/marksman/cook.mk
+++ b/3p/marksman/cook.mk
@@ -1,8 +1,8 @@
 marksman_version := 3p/marksman/version.lua
 bins += o/%/marksman/bin/marksman
 
-o/any/3p/marksman/test.lua.luatest.ok: o/$(current_platform)/marksman/bin/marksman
-o/any/3p/marksman/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/marksman
+o/luatest/3p/marksman/test.lua.ok: o/$(current_platform)/marksman/bin/marksman
+o/luatest/3p/marksman/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/marksman
 
 o/%/marksman/download: $(marksman_version) $(fetch)
 	$(fetch) $(marksman_version) $* $@

--- a/3p/nvim/cook.mk
+++ b/3p/nvim/cook.mk
@@ -6,8 +6,8 @@ nvim_bundle := 3p/nvim/bundle.lua
 bins += o/%/nvim/bin/nvim
 
 # Test uses generic luatest pattern with target-specific prereqs
-o/any/3p/nvim/test.lua.luatest.ok: o/$(current_platform)/nvim/bin/nvim
-o/any/3p/nvim/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/nvim
+o/luatest/3p/nvim/test.lua.ok: o/$(current_platform)/nvim/bin/nvim
+o/luatest/3p/nvim/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/nvim
 
 o/%/nvim/archive.tar.gz: $(nvim_version) $(fetch)
 	$(fetch) $(nvim_version) $* $@

--- a/3p/nvim/cook.mk
+++ b/3p/nvim/cook.mk
@@ -7,7 +7,7 @@ bins += o/%/nvim/bin/nvim
 
 # Test uses generic luatest pattern with target-specific prereqs
 $(luatest_o)/3p/nvim/test.lua.ok: o/$(current_platform)/nvim/bin/nvim
-$(luatest_o)/3p/nvim/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/nvim
+$(luatest_o)/3p/nvim/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/nvim
 
 o/%/nvim/archive.tar.gz: $(nvim_version) $(fetch)
 	$(fetch) $(nvim_version) $* $@

--- a/3p/nvim/cook.mk
+++ b/3p/nvim/cook.mk
@@ -6,8 +6,8 @@ nvim_bundle := 3p/nvim/bundle.lua
 bins += o/%/nvim/bin/nvim
 
 # Test uses generic luatest pattern with target-specific prereqs
-o/luatest/3p/nvim/test.lua.ok: o/$(current_platform)/nvim/bin/nvim
-o/luatest/3p/nvim/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/nvim
+$(luatest_o)/3p/nvim/test.lua.ok: o/$(current_platform)/nvim/bin/nvim
+$(luatest_o)/3p/nvim/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/nvim
 
 o/%/nvim/archive.tar.gz: $(nvim_version) $(fetch)
 	$(fetch) $(nvim_version) $* $@

--- a/3p/rg/cook.mk
+++ b/3p/rg/cook.mk
@@ -2,7 +2,7 @@ rg_version := 3p/rg/version.lua
 bins += o/%/rg/bin/rg
 
 $(luatest_o)/3p/rg/test.lua.ok: o/$(current_platform)/rg/bin/rg
-$(luatest_o)/3p/rg/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/rg
+$(luatest_o)/3p/rg/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/rg
 
 o/%/rg/archive.tar.gz: $(rg_version) $(fetch)
 	$(fetch) $(rg_version) $* $@

--- a/3p/rg/cook.mk
+++ b/3p/rg/cook.mk
@@ -1,8 +1,8 @@
 rg_version := 3p/rg/version.lua
 bins += o/%/rg/bin/rg
 
-o/luatest/3p/rg/test.lua.ok: o/$(current_platform)/rg/bin/rg
-o/luatest/3p/rg/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/rg
+$(luatest_o)/3p/rg/test.lua.ok: o/$(current_platform)/rg/bin/rg
+$(luatest_o)/3p/rg/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/rg
 
 o/%/rg/archive.tar.gz: $(rg_version) $(fetch)
 	$(fetch) $(rg_version) $* $@

--- a/3p/rg/cook.mk
+++ b/3p/rg/cook.mk
@@ -1,8 +1,8 @@
 rg_version := 3p/rg/version.lua
 bins += o/%/rg/bin/rg
 
-o/any/3p/rg/test.lua.luatest.ok: o/$(current_platform)/rg/bin/rg
-o/any/3p/rg/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/rg
+o/luatest/3p/rg/test.lua.ok: o/$(current_platform)/rg/bin/rg
+o/luatest/3p/rg/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/rg
 
 o/%/rg/archive.tar.gz: $(rg_version) $(fetch)
 	$(fetch) $(rg_version) $* $@

--- a/3p/ruff/cook.mk
+++ b/3p/ruff/cook.mk
@@ -2,7 +2,7 @@ ruff_version := 3p/ruff/version.lua
 bins += o/%/ruff/bin/ruff
 
 $(luatest_o)/3p/ruff/test.lua.ok: o/$(current_platform)/ruff/bin/ruff
-$(luatest_o)/3p/ruff/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ruff
+$(luatest_o)/3p/ruff/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/ruff
 
 o/%/ruff/archive.tar.gz: $(ruff_version) $(fetch)
 	$(fetch) $(ruff_version) $* $@

--- a/3p/ruff/cook.mk
+++ b/3p/ruff/cook.mk
@@ -1,8 +1,8 @@
 ruff_version := 3p/ruff/version.lua
 bins += o/%/ruff/bin/ruff
 
-o/luatest/3p/ruff/test.lua.ok: o/$(current_platform)/ruff/bin/ruff
-o/luatest/3p/ruff/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ruff
+$(luatest_o)/3p/ruff/test.lua.ok: o/$(current_platform)/ruff/bin/ruff
+$(luatest_o)/3p/ruff/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ruff
 
 o/%/ruff/archive.tar.gz: $(ruff_version) $(fetch)
 	$(fetch) $(ruff_version) $* $@

--- a/3p/ruff/cook.mk
+++ b/3p/ruff/cook.mk
@@ -1,8 +1,8 @@
 ruff_version := 3p/ruff/version.lua
 bins += o/%/ruff/bin/ruff
 
-o/any/3p/ruff/test.lua.luatest.ok: o/$(current_platform)/ruff/bin/ruff
-o/any/3p/ruff/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ruff
+o/luatest/3p/ruff/test.lua.ok: o/$(current_platform)/ruff/bin/ruff
+o/luatest/3p/ruff/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ruff
 
 o/%/ruff/archive.tar.gz: $(ruff_version) $(fetch)
 	$(fetch) $(ruff_version) $* $@

--- a/3p/shfmt/cook.mk
+++ b/3p/shfmt/cook.mk
@@ -1,8 +1,8 @@
 shfmt_version := 3p/shfmt/version.lua
 bins += o/%/shfmt/bin/shfmt
 
-o/luatest/3p/shfmt/test.lua.ok: o/$(current_platform)/shfmt/bin/shfmt
-o/luatest/3p/shfmt/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/shfmt
+$(luatest_o)/3p/shfmt/test.lua.ok: o/$(current_platform)/shfmt/bin/shfmt
+$(luatest_o)/3p/shfmt/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/shfmt
 
 o/%/shfmt/download: $(shfmt_version) $(fetch)
 	$(fetch) $(shfmt_version) $* $@

--- a/3p/shfmt/cook.mk
+++ b/3p/shfmt/cook.mk
@@ -2,7 +2,7 @@ shfmt_version := 3p/shfmt/version.lua
 bins += o/%/shfmt/bin/shfmt
 
 $(luatest_o)/3p/shfmt/test.lua.ok: o/$(current_platform)/shfmt/bin/shfmt
-$(luatest_o)/3p/shfmt/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/shfmt
+$(luatest_o)/3p/shfmt/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/shfmt
 
 o/%/shfmt/download: $(shfmt_version) $(fetch)
 	$(fetch) $(shfmt_version) $* $@

--- a/3p/shfmt/cook.mk
+++ b/3p/shfmt/cook.mk
@@ -1,8 +1,8 @@
 shfmt_version := 3p/shfmt/version.lua
 bins += o/%/shfmt/bin/shfmt
 
-o/any/3p/shfmt/test.lua.luatest.ok: o/$(current_platform)/shfmt/bin/shfmt
-o/any/3p/shfmt/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/shfmt
+o/luatest/3p/shfmt/test.lua.ok: o/$(current_platform)/shfmt/bin/shfmt
+o/luatest/3p/shfmt/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/shfmt
 
 o/%/shfmt/download: $(shfmt_version) $(fetch)
 	$(fetch) $(shfmt_version) $* $@

--- a/3p/sqruff/cook.mk
+++ b/3p/sqruff/cook.mk
@@ -2,7 +2,7 @@ sqruff_version := 3p/sqruff/version.lua
 bins += o/%/sqruff/bin/sqruff
 
 $(luatest_o)/3p/sqruff/test.lua.ok: o/$(current_platform)/sqruff/bin/sqruff
-$(luatest_o)/3p/sqruff/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/sqruff
+$(luatest_o)/3p/sqruff/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/sqruff
 
 o/%/sqruff/archive.tar.gz: $(sqruff_version) $(fetch)
 	$(fetch) $(sqruff_version) $* $@

--- a/3p/sqruff/cook.mk
+++ b/3p/sqruff/cook.mk
@@ -1,8 +1,8 @@
 sqruff_version := 3p/sqruff/version.lua
 bins += o/%/sqruff/bin/sqruff
 
-o/luatest/3p/sqruff/test.lua.ok: o/$(current_platform)/sqruff/bin/sqruff
-o/luatest/3p/sqruff/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/sqruff
+$(luatest_o)/3p/sqruff/test.lua.ok: o/$(current_platform)/sqruff/bin/sqruff
+$(luatest_o)/3p/sqruff/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/sqruff
 
 o/%/sqruff/archive.tar.gz: $(sqruff_version) $(fetch)
 	$(fetch) $(sqruff_version) $* $@

--- a/3p/sqruff/cook.mk
+++ b/3p/sqruff/cook.mk
@@ -1,8 +1,8 @@
 sqruff_version := 3p/sqruff/version.lua
 bins += o/%/sqruff/bin/sqruff
 
-o/any/3p/sqruff/test.lua.luatest.ok: o/$(current_platform)/sqruff/bin/sqruff
-o/any/3p/sqruff/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/sqruff
+o/luatest/3p/sqruff/test.lua.ok: o/$(current_platform)/sqruff/bin/sqruff
+o/luatest/3p/sqruff/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/sqruff
 
 o/%/sqruff/archive.tar.gz: $(sqruff_version) $(fetch)
 	$(fetch) $(sqruff_version) $* $@

--- a/3p/stylua/cook.mk
+++ b/3p/stylua/cook.mk
@@ -1,8 +1,8 @@
 stylua_version := 3p/stylua/version.lua
 bins += o/%/stylua/bin/stylua
 
-o/any/3p/stylua/test.lua.luatest.ok: o/$(current_platform)/stylua/bin/stylua
-o/any/3p/stylua/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/stylua
+o/luatest/3p/stylua/test.lua.ok: o/$(current_platform)/stylua/bin/stylua
+o/luatest/3p/stylua/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/stylua
 
 o/%/stylua/archive.zip: $(stylua_version) $(fetch)
 	$(fetch) $(stylua_version) $* $@

--- a/3p/stylua/cook.mk
+++ b/3p/stylua/cook.mk
@@ -1,8 +1,8 @@
 stylua_version := 3p/stylua/version.lua
 bins += o/%/stylua/bin/stylua
 
-o/luatest/3p/stylua/test.lua.ok: o/$(current_platform)/stylua/bin/stylua
-o/luatest/3p/stylua/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/stylua
+$(luatest_o)/3p/stylua/test.lua.ok: o/$(current_platform)/stylua/bin/stylua
+$(luatest_o)/3p/stylua/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/stylua
 
 o/%/stylua/archive.zip: $(stylua_version) $(fetch)
 	$(fetch) $(stylua_version) $* $@

--- a/3p/stylua/cook.mk
+++ b/3p/stylua/cook.mk
@@ -2,7 +2,7 @@ stylua_version := 3p/stylua/version.lua
 bins += o/%/stylua/bin/stylua
 
 $(luatest_o)/3p/stylua/test.lua.ok: o/$(current_platform)/stylua/bin/stylua
-$(luatest_o)/3p/stylua/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/stylua
+$(luatest_o)/3p/stylua/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/stylua
 
 o/%/stylua/archive.zip: $(stylua_version) $(fetch)
 	$(fetch) $(stylua_version) $* $@

--- a/3p/superhtml/cook.mk
+++ b/3p/superhtml/cook.mk
@@ -1,8 +1,8 @@
 superhtml_version := 3p/superhtml/version.lua
 bins += o/%/superhtml/bin/superhtml
 
-o/luatest/3p/superhtml/test.lua.ok: o/$(current_platform)/superhtml/bin/superhtml
-o/luatest/3p/superhtml/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/superhtml
+$(luatest_o)/3p/superhtml/test.lua.ok: o/$(current_platform)/superhtml/bin/superhtml
+$(luatest_o)/3p/superhtml/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/superhtml
 
 o/%/superhtml/archive.tar.gz: $(superhtml_version) $(fetch)
 	$(fetch) $(superhtml_version) $* $@

--- a/3p/superhtml/cook.mk
+++ b/3p/superhtml/cook.mk
@@ -2,7 +2,7 @@ superhtml_version := 3p/superhtml/version.lua
 bins += o/%/superhtml/bin/superhtml
 
 $(luatest_o)/3p/superhtml/test.lua.ok: o/$(current_platform)/superhtml/bin/superhtml
-$(luatest_o)/3p/superhtml/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/superhtml
+$(luatest_o)/3p/superhtml/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/superhtml
 
 o/%/superhtml/archive.tar.gz: $(superhtml_version) $(fetch)
 	$(fetch) $(superhtml_version) $* $@

--- a/3p/superhtml/cook.mk
+++ b/3p/superhtml/cook.mk
@@ -1,8 +1,8 @@
 superhtml_version := 3p/superhtml/version.lua
 bins += o/%/superhtml/bin/superhtml
 
-o/any/3p/superhtml/test.lua.luatest.ok: o/$(current_platform)/superhtml/bin/superhtml
-o/any/3p/superhtml/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/superhtml
+o/luatest/3p/superhtml/test.lua.ok: o/$(current_platform)/superhtml/bin/superhtml
+o/luatest/3p/superhtml/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/superhtml
 
 o/%/superhtml/archive.tar.gz: $(superhtml_version) $(fetch)
 	$(fetch) $(superhtml_version) $* $@

--- a/3p/tl/cook.mk
+++ b/3p/tl/cook.mk
@@ -3,13 +3,14 @@ lua_libs += tl
 3p_lib_dirs += o/%/tl/lib
 libs += o/%/tl/lib/tl.lua
 tl_bin := o/$(current_platform)/tl/bin/tl
+tl_o := o/teal
 bins += o/%/tl/bin/tl
 tl_deps := \
 	o/%/argparse/lib/argparse.lua \
 	o/%/cosmos/bin/lua
 
-o/luatest/3p/tl/test.lua.ok: o/$(current_platform)/tl/bin/tl
-o/luatest/3p/tl/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/tl
+$(luatest_o)/3p/tl/test.lua.ok: o/$(current_platform)/tl/bin/tl
+$(luatest_o)/3p/tl/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/tl
 
 o/%/tl/archive.tar.gz: $(tl_version) $(fetch)
 	$(fetch) $(tl_version) $* $@

--- a/3p/tl/cook.mk
+++ b/3p/tl/cook.mk
@@ -8,8 +8,8 @@ tl_deps := \
 	o/%/argparse/lib/argparse.lua \
 	o/%/cosmos/bin/lua
 
-o/any/3p/tl/test.lua.luatest.ok: o/$(current_platform)/tl/bin/tl
-o/any/3p/tl/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/tl
+o/luatest/3p/tl/test.lua.ok: o/$(current_platform)/tl/bin/tl
+o/luatest/3p/tl/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/tl
 
 o/%/tl/archive.tar.gz: $(tl_version) $(fetch)
 	$(fetch) $(tl_version) $* $@

--- a/3p/tl/cook.mk
+++ b/3p/tl/cook.mk
@@ -2,15 +2,15 @@ tl_version := 3p/tl/version.lua
 lua_libs += tl
 3p_lib_dirs += o/%/tl/lib
 libs += o/%/tl/lib/tl.lua
-tl_bin := o/$(current_platform)/tl/bin/tl
-tl_o := o/teal
+tl_bin := $(o_platform)/tl/bin/tl
+tl_o := $(o)/teal
 bins += o/%/tl/bin/tl
 tl_deps := \
 	o/%/argparse/lib/argparse.lua \
 	o/%/cosmos/bin/lua
 
-$(luatest_o)/3p/tl/test.lua.ok: o/$(current_platform)/tl/bin/tl
-$(luatest_o)/3p/tl/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/tl
+$(luatest_o)/3p/tl/test.lua.ok: $(tl_bin)
+$(luatest_o)/3p/tl/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/tl
 
 o/%/tl/archive.tar.gz: $(tl_version) $(fetch)
 	$(fetch) $(tl_version) $* $@

--- a/3p/tl/cook.mk
+++ b/3p/tl/cook.mk
@@ -2,6 +2,7 @@ tl_version := 3p/tl/version.lua
 lua_libs += tl
 3p_lib_dirs += o/%/tl/lib
 libs += o/%/tl/lib/tl.lua
+tl_bin := o/$(current_platform)/tl/bin/tl
 bins += o/%/tl/bin/tl
 tl_deps := \
 	o/%/argparse/lib/argparse.lua \

--- a/3p/tree-sitter/cook.mk
+++ b/3p/tree-sitter/cook.mk
@@ -2,7 +2,7 @@ tree_sitter_version := 3p/tree-sitter/version.lua
 bins += o/%/tree-sitter/bin/tree-sitter
 
 $(luatest_o)/3p/tree-sitter/test.lua.ok: o/$(current_platform)/tree-sitter/bin/tree-sitter
-$(luatest_o)/3p/tree-sitter/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/tree-sitter
+$(luatest_o)/3p/tree-sitter/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/tree-sitter
 
 o/%/tree-sitter/archive.gz: $(tree_sitter_version) $(fetch)
 	$(fetch) $(tree_sitter_version) $* $@

--- a/3p/tree-sitter/cook.mk
+++ b/3p/tree-sitter/cook.mk
@@ -1,8 +1,8 @@
 tree_sitter_version := 3p/tree-sitter/version.lua
 bins += o/%/tree-sitter/bin/tree-sitter
 
-o/any/3p/tree-sitter/test.lua.luatest.ok: o/$(current_platform)/tree-sitter/bin/tree-sitter
-o/any/3p/tree-sitter/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/tree-sitter
+o/luatest/3p/tree-sitter/test.lua.ok: o/$(current_platform)/tree-sitter/bin/tree-sitter
+o/luatest/3p/tree-sitter/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/tree-sitter
 
 o/%/tree-sitter/archive.gz: $(tree_sitter_version) $(fetch)
 	$(fetch) $(tree_sitter_version) $* $@

--- a/3p/tree-sitter/cook.mk
+++ b/3p/tree-sitter/cook.mk
@@ -1,8 +1,8 @@
 tree_sitter_version := 3p/tree-sitter/version.lua
 bins += o/%/tree-sitter/bin/tree-sitter
 
-o/luatest/3p/tree-sitter/test.lua.ok: o/$(current_platform)/tree-sitter/bin/tree-sitter
-o/luatest/3p/tree-sitter/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/tree-sitter
+$(luatest_o)/3p/tree-sitter/test.lua.ok: o/$(current_platform)/tree-sitter/bin/tree-sitter
+$(luatest_o)/3p/tree-sitter/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/tree-sitter
 
 o/%/tree-sitter/archive.gz: $(tree_sitter_version) $(fetch)
 	$(fetch) $(tree_sitter_version) $* $@

--- a/3p/uv/cook.mk
+++ b/3p/uv/cook.mk
@@ -2,7 +2,7 @@ uv_version := 3p/uv/version.lua
 bins += o/%/uv/bin/uv
 
 $(luatest_o)/3p/uv/test.lua.ok: o/$(current_platform)/uv/bin/uv
-$(luatest_o)/3p/uv/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/uv
+$(luatest_o)/3p/uv/test.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/uv
 
 o/%/uv/archive.tar.gz: $(uv_version) $(fetch)
 	$(fetch) $(uv_version) $* $@

--- a/3p/uv/cook.mk
+++ b/3p/uv/cook.mk
@@ -1,8 +1,8 @@
 uv_version := 3p/uv/version.lua
 bins += o/%/uv/bin/uv
 
-o/any/3p/uv/test.lua.luatest.ok: o/$(current_platform)/uv/bin/uv
-o/any/3p/uv/test.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/uv
+o/luatest/3p/uv/test.lua.ok: o/$(current_platform)/uv/bin/uv
+o/luatest/3p/uv/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/uv
 
 o/%/uv/archive.tar.gz: $(uv_version) $(fetch)
 	$(fetch) $(uv_version) $* $@

--- a/3p/uv/cook.mk
+++ b/3p/uv/cook.mk
@@ -1,8 +1,8 @@
 uv_version := 3p/uv/version.lua
 bins += o/%/uv/bin/uv
 
-o/luatest/3p/uv/test.lua.ok: o/$(current_platform)/uv/bin/uv
-o/luatest/3p/uv/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/uv
+$(luatest_o)/3p/uv/test.lua.ok: o/$(current_platform)/uv/bin/uv
+$(luatest_o)/3p/uv/test.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/uv
 
 o/%/uv/archive.tar.gz: $(uv_version) $(fetch)
 	$(fetch) $(uv_version) $* $@

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,15 @@ include 3p/cook.mk
 # Assemble script dependencies from individual library modules
 script_deps := $(spawn_lib) $(walk_lib)
 
+# Tool binaries for checkers
+ast_grep := o/$(current_platform)/ast-grep/bin/ast-grep
+lua_dist := o/$(current_platform)/lua/bin/lua.dist
+tl_bin := o/$(current_platform)/tl/bin/tl
+
+# Build scripts that require runtime dependencies
+$(extract_script): | $(spawn_lib)
+$(luatest_script) $(luacheck_script) $(ast_grep_script) $(teal_script): | $(script_deps)
+
 lua_files := $(shell git ls-files '*.lua' | grep -vE '^(\.config/(hammerspoon|nvim|voyager)|\.local/bin)/' ; git ls-files | grep -v '\.lua$$' | grep -v '^o/' | grep -vE '^(\.config/(hammerspoon|nvim|voyager)|\.local/bin)/' | xargs -r grep -l '^#!/.*lua' 2>/dev/null || true)
 test_files := $(shell git ls-files '*test.lua' 'test_*.lua' | grep -vE '(latest|luatest)\.lua$$')
 luatest_files := $(patsubst %,o/any/%.luatest.ok,$(test_files))
@@ -99,11 +108,6 @@ $(lua_bin):
 
 cosmos: o/$(current_platform)/cosmos/bin/lua
 lua: o/$(current_platform)/lua/bin/lua.dist
-
-ast_grep := o/$(current_platform)/ast-grep/bin/ast-grep
-lua_dist := o/$(current_platform)/lua/bin/lua.dist
-
-tl_bin := o/$(current_platform)/tl/bin/tl
 
 check: $(ast_grep_files) $(luacheck_files) $(teal_files) ## Run ast-grep, luacheck, and teal
 	@$(ast_grep_runner) report o/any

--- a/Makefile
+++ b/Makefile
@@ -52,45 +52,45 @@ $(luatest_script) $(luacheck_script) $(ast_grep_script) $(teal_script): | $(scri
 
 lua_files := $(shell git ls-files '*.lua' | grep -vE '^(\.config/(hammerspoon|nvim|voyager)|\.local/bin)/' ; git ls-files | grep -v '\.lua$$' | grep -v '^o/' | grep -vE '^(\.config/(hammerspoon|nvim|voyager)|\.local/bin)/' | xargs -r grep -l '^#!/.*lua' 2>/dev/null || true)
 test_files := $(shell git ls-files '*test.lua' 'test_*.lua' | grep -vE '(latest|luatest)\.lua$$')
-luatest_files := $(patsubst %,o/any/%.luatest.ok,$(test_files))
-luacheck_files := $(patsubst %,o/any/%.luacheck.ok,$(lua_files))
+luatest_files := $(patsubst %,o/luatest/%.ok,$(test_files))
+luacheck_files := $(patsubst %,o/luacheck/%.ok,$(lua_files))
 
 luatest: $(luatest_files) ## Run tests incrementally on changed files
 
-o/any/%.luatest.ok: % $(luatest_script) $(luaunit) $(script_deps)
+o/luatest/%.ok: % $(luatest_script) $(luaunit) $(script_deps)
 	$(TEST_ENV) $(luatest_runner) $< $@ $(TEST_ARGS)
 
 luatest-report: $(luatest_files) $(script_deps) ## Run tests and show summary report
-	@$(luatest_runner) report o/any
+	@$(luatest_runner) report o/luatest
 
 luacheck: $(luacheck_files) ## Run luacheck incrementally on changed files
 
-o/any/%.luacheck.ok: % .luacheckrc $(luacheck_script) $(luacheck_bin) $(script_deps)
+o/luacheck/%.ok: % .luacheckrc $(luacheck_script) $(luacheck_bin) $(script_deps)
 	$(luacheck_runner) $< $@ $(luacheck_bin)
 
 luacheck-report: $(luacheck_files) ## Run luacheck and show summary report
-	@$(luacheck_runner) report o/any
+	@$(luacheck_runner) report o/luacheck
 
-ast_grep_files := $(patsubst %,o/any/%.ast-grep.ok,$(lua_files))
+ast_grep_files := $(patsubst %,o/ast-grep/%.ok,$(lua_files))
 
 ast-grep: $(ast_grep_files) ## Run ast-grep incrementally on changed files
 
-o/any/%.ast-grep.ok: % sgconfig.yml $(ast_grep_script) $(astgrep_bin) $(script_deps)
+o/ast-grep/%.ok: % sgconfig.yml $(ast_grep_script) $(astgrep_bin) $(script_deps)
 	$(ast_grep_runner) $< $@ $(astgrep_bin)
 
 ast-grep-report: $(ast_grep_files) ## Run ast-grep and show summary report
-	@$(ast_grep_runner) report o/any
+	@$(ast_grep_runner) report o/ast-grep
 
-teal_files := $(patsubst %,o/any/%.teal.ok,$(lua_files))
+teal_files := $(patsubst %,o/teal/%.ok,$(lua_files))
 
 teal: $(teal_files) ## Run teal incrementally on changed files
 
-o/any/%.teal.ok: % $(teal_script) $(tl_bin) $(lua_dist) $(script_deps)
+o/teal/%.ok: % $(teal_script) $(tl_bin) $(lua_dist) $(script_deps)
 	$(teal_runner) $< $@ $(tl_bin) $(lua_dist) || true
 
 teal-report: $(teal_files) ## Run teal and show summary report
 	# TODO: remove || true once all files pass
-	@$(teal_runner) report o/any || true
+	@$(teal_runner) report o/teal || true
 
 bootstrap: $(lua_bin)
 	@[ -n "$$CLAUDE_ENV_FILE" ] && echo "PATH=$(dir $(lua_bin)):\$$PATH" >> "$$CLAUDE_ENV_FILE"; true
@@ -104,12 +104,12 @@ cosmos: o/$(current_platform)/cosmos/bin/lua
 lua: o/$(current_platform)/lua/bin/lua.dist
 
 check: $(ast_grep_files) $(luacheck_files) $(teal_files) ## Run ast-grep, luacheck, and teal
-	@$(ast_grep_runner) report o/any
+	@$(ast_grep_runner) report o/ast-grep
 	@echo ""
-	@$(luacheck_runner) report o/any
+	@$(luacheck_runner) report o/luacheck
 	@echo ""
 	# TODO: remove || true once all files pass teal
-	@$(teal_runner) report o/any || true
+	@$(teal_runner) report o/teal || true
 
 test: $(luatest_files)
 	@echo "All tests passed"

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ ast_grep_runner = $(lua_bin) $(ast_grep_script)
 teal_runner = $(lua_bin) $(teal_script)
 
 luaunit := o/any/luaunit/lib/luaunit.lua
-script_deps := o/any/spawn/lib/spawn/init.lua o/any/walk/lib/walk/init.lua
 
 $(fetch_script) $(extract_script) $(install_script) $(luatest_script) $(luacheck_script) $(ast_grep_script) $(teal_script): | $(lua_bin)
 cosmo := whilp/cosmopolitan
@@ -44,6 +43,9 @@ release ?= latest
 
 include lib/cook.mk
 include 3p/cook.mk
+
+# Assemble script dependencies from individual library modules
+script_deps := $(spawn_lib) $(walk_lib)
 
 lua_files := $(shell git ls-files '*.lua' | grep -vE '^(\.config/(hammerspoon|nvim|voyager)|\.local/bin)/' ; git ls-files | grep -v '\.lua$$' | grep -v '^o/' | grep -vE '^(\.config/(hammerspoon|nvim|voyager)|\.local/bin)/' | xargs -r grep -l '^#!/.*lua' 2>/dev/null || true)
 test_files := $(shell git ls-files '*test.lua' 'test_*.lua' | grep -vE '(latest|luatest)\.lua$$')

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,7 @@ else ifeq ($(uname_s),Linux)
   current_platform := linux-$(subst aarch64,arm64,$(uname_m))
 endif
 
-# LUA_PATH will be built after includes populate lib_dirs
 export PATH := $(CURDIR)/o/$(current_platform)/cosmos/bin:$(CURDIR)/o/any/lua/bin:$(PATH)
-export RIPGREP_CONFIG_PATH := $(CURDIR)/.config/ripgrep/rg.conf
 
 lua_bin := o/any/lua/bin/lua
 
@@ -59,45 +57,45 @@ $(luatest_script) $(luacheck_script) $(ast_grep_script) $(teal_script): | $(scri
 
 lua_files := $(shell git ls-files '*.lua' | grep -vE '^(\.config/(hammerspoon|nvim|voyager)|\.local/bin)/' ; git ls-files | grep -v '\.lua$$' | grep -v '^o/' | grep -vE '^(\.config/(hammerspoon|nvim|voyager)|\.local/bin)/' | xargs -r grep -l '^#!/.*lua' 2>/dev/null || true)
 test_files := $(shell git ls-files '*test.lua' 'test_*.lua' | grep -vE '(latest|luatest)\.lua$$')
-luatest_files := $(patsubst %,o/luatest/%.ok,$(test_files))
-luacheck_files := $(patsubst %,o/luacheck/%.ok,$(lua_files))
+luatest_files := $(patsubst %,$(luatest_o)/%.ok,$(test_files))
+luacheck_files := $(patsubst %,$(luacheck_o)/%.ok,$(lua_files))
 
 luatest: $(luatest_files) ## Run tests incrementally on changed files
 
-o/luatest/%.ok: % $(luatest_script) $(luaunit) $(script_deps)
+$(luatest_o)/%.ok: % $(luatest_script) $(luaunit) $(script_deps)
 	$(TEST_ENV) $(luatest_runner) $< $@ $(TEST_ARGS)
 
 luatest-report: $(luatest_files) $(script_deps) ## Run tests and show summary report
-	@$(luatest_runner) report o/luatest
+	@$(luatest_runner) report $(luatest_o)
 
 luacheck: $(luacheck_files) ## Run luacheck incrementally on changed files
 
-o/luacheck/%.ok: % .luacheckrc $(luacheck_script) $(luacheck_bin) $(script_deps)
+$(luacheck_o)/%.ok: % $(luacheck_config) $(luacheck_script) $(luacheck_bin) $(script_deps)
 	$(luacheck_runner) $< $@ $(luacheck_bin)
 
 luacheck-report: $(luacheck_files) ## Run luacheck and show summary report
-	@$(luacheck_runner) report o/luacheck
+	@$(luacheck_runner) report $(luacheck_o)
 
-ast_grep_files := $(patsubst %,o/ast-grep/%.ok,$(lua_files))
+ast_grep_files := $(patsubst %,$(astgrep_o)/%.ok,$(lua_files))
 
 ast-grep: $(ast_grep_files) ## Run ast-grep incrementally on changed files
 
-o/ast-grep/%.ok: % sgconfig.yml $(ast_grep_script) $(astgrep_bin) $(script_deps)
+$(astgrep_o)/%.ok: % $(astgrep_config) $(ast_grep_script) $(astgrep_bin) $(script_deps)
 	$(ast_grep_runner) $< $@ $(astgrep_bin)
 
 ast-grep-report: $(ast_grep_files) ## Run ast-grep and show summary report
-	@$(ast_grep_runner) report o/ast-grep
+	@$(ast_grep_runner) report $(astgrep_o)
 
-teal_files := $(patsubst %,o/teal/%.ok,$(lua_files))
+teal_files := $(patsubst %,$(tl_o)/%.ok,$(lua_files))
 
 teal: $(teal_files) ## Run teal incrementally on changed files
 
-o/teal/%.ok: % $(teal_script) $(tl_bin) $(lua_dist) $(script_deps)
+$(tl_o)/%.ok: % $(teal_script) $(tl_bin) $(lua_dist) $(script_deps)
 	$(teal_runner) $< $@ $(tl_bin) $(lua_dist) || true
 
 teal-report: $(teal_files) ## Run teal and show summary report
 	# TODO: remove || true once all files pass
-	@$(teal_runner) report o/teal || true
+	@$(teal_runner) report $(tl_o) || true
 
 bootstrap: $(lua_bin)
 	@[ -n "$$CLAUDE_ENV_FILE" ] && echo "PATH=$(dir $(lua_bin)):\$$PATH" >> "$$CLAUDE_ENV_FILE"; true

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ else ifeq ($(uname_s),Linux)
   current_platform := linux-$(subst aarch64,arm64,$(uname_m))
 endif
 
-export LUA_PATH := $(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;$(CURDIR)/o/any/spawn/lib/?.lua;$(CURDIR)/o/any/spawn/lib/?/init.lua;$(CURDIR)/o/any/walk/lib/?.lua;$(CURDIR)/o/any/walk/lib/?/init.lua;$(CURDIR)/o/any/luaunit/lib/?.lua;/zip/.lua/?.lua;/zip/.lua/?/init.lua
+# LUA_PATH will be built after includes populate lib_dirs
 export PATH := $(CURDIR)/o/$(current_platform)/cosmos/bin:$(CURDIR)/o/any/lua/bin:$(PATH)
 export RIPGREP_CONFIG_PATH := $(CURDIR)/.config/ripgrep/rg.conf
 
@@ -42,6 +42,13 @@ release ?= latest
 
 include lib/cook.mk
 include 3p/cook.mk
+
+# Build LUA_PATH from lib_dirs and 3p_lib_dirs
+null :=
+space := $(null) $(null)
+lib_paths := $(subst $(space),,$(foreach dir,$(lib_dirs),$(CURDIR)/$(dir)/?.lua;$(CURDIR)/$(dir)/?/init.lua;))
+3p_lib_paths := $(subst $(space),,$(foreach dir,$(subst %,$(current_platform),$(3p_lib_dirs)),$(CURDIR)/$(dir)/?.lua;$(CURDIR)/$(dir)/?/init.lua;))
+export LUA_PATH := $(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;$(lib_paths)$(3p_lib_paths)/zip/.lua/?.lua;/zip/.lua/?/init.lua
 
 # Assemble script dependencies from individual library modules
 script_deps := $(spawn_lib) $(walk_lib)

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,13 @@ else ifeq ($(uname_s),Linux)
   current_platform := linux-$(subst aarch64,arm64,$(uname_m))
 endif
 
-export PATH := $(CURDIR)/o/$(current_platform)/cosmos/bin:$(CURDIR)/o/any/lua/bin:$(PATH)
+o := o
+o_platform := $(o)/$(current_platform)
+o_any := $(o)/any
 
-lua_bin := o/any/lua/bin/lua
+export PATH := $(CURDIR)/$(o_platform)/cosmos/bin:$(CURDIR)/$(o_any)/lua/bin:$(PATH)
+
+lua_bin := $(o_any)/lua/bin/lua
 
 # Script paths (for dependencies)
 fetch_script := lib/build/fetch.lua
@@ -31,8 +35,6 @@ luatest_runner = $(lua_bin) $(luatest_script)
 luacheck_runner = $(lua_bin) $(luacheck_script)
 ast_grep_runner = $(lua_bin) $(ast_grep_script)
 teal_runner = $(lua_bin) $(teal_script)
-
-luaunit := o/any/luaunit/lib/luaunit.lua
 
 $(fetch_script) $(extract_script) $(install_script) $(luatest_script) $(luacheck_script) $(ast_grep_script) $(teal_script): | $(lua_bin)
 cosmo := whilp/cosmopolitan

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ else ifeq ($(uname_s),Linux)
   current_platform := linux-$(subst aarch64,arm64,$(uname_m))
 endif
 
-export LUA_PATH := $(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;$(CURDIR)/o/any/luaunit/lib/?.lua;/zip/.lua/?.lua;/zip/.lua/?/init.lua
+export LUA_PATH := $(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;$(CURDIR)/o/any/spawn/lib/?.lua;$(CURDIR)/o/any/spawn/lib/?/init.lua;$(CURDIR)/o/any/walk/lib/?.lua;$(CURDIR)/o/any/walk/lib/?/init.lua;$(CURDIR)/o/any/luaunit/lib/?.lua;/zip/.lua/?.lua;/zip/.lua/?/init.lua
 export PATH := $(CURDIR)/o/$(current_platform)/cosmos/bin:$(CURDIR)/o/any/lua/bin:$(PATH)
 export RIPGREP_CONFIG_PATH := $(CURDIR)/.config/ripgrep/rg.conf
 
@@ -59,7 +59,7 @@ luatest-report: $(luatest_files) o/any/walk/lib/walk/init.lua ## Run tests and s
 
 luacheck: $(luacheck_files) ## Run luacheck incrementally on changed files
 
-o/any/%.luacheck.ok: % .luacheckrc $(luacheck_script) $(luacheck_bin)
+o/any/%.luacheck.ok: % .luacheckrc $(luacheck_script) $(luacheck_bin) o/any/spawn/lib/spawn/init.lua o/any/walk/lib/walk/init.lua
 	$(luacheck_runner) $< $@ $(luacheck_bin)
 
 luacheck-report: $(luacheck_files) ## Run luacheck and show summary report
@@ -69,7 +69,7 @@ ast_grep_files := $(patsubst %,o/any/%.ast-grep.ok,$(lua_files))
 
 ast-grep: $(ast_grep_files) ## Run ast-grep incrementally on changed files
 
-o/any/%.ast-grep.ok: % sgconfig.yml $(ast_grep_script) $(ast_grep)
+o/any/%.ast-grep.ok: % sgconfig.yml $(ast_grep_script) $(ast_grep) o/any/spawn/lib/spawn/init.lua o/any/walk/lib/walk/init.lua
 	$(ast_grep_runner) $< $@ $(ast_grep)
 
 ast-grep-report: $(ast_grep_files) ## Run ast-grep and show summary report
@@ -79,7 +79,7 @@ teal_files := $(patsubst %,o/any/%.teal.ok,$(lua_files))
 
 teal: $(teal_files) ## Run teal incrementally on changed files
 
-o/any/%.teal.ok: % $(teal_script) $(tl_bin) $(lua_dist)
+o/any/%.teal.ok: % $(teal_script) $(tl_bin) $(lua_dist) o/any/spawn/lib/spawn/init.lua o/any/walk/lib/walk/init.lua
 	$(teal_runner) $< $@ $(tl_bin) $(lua_dist) || true
 
 teal-report: $(teal_files) ## Run teal and show summary report

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ ast_grep_runner = $(lua_bin) $(ast_grep_script)
 teal_runner = $(lua_bin) $(teal_script)
 
 luaunit := o/any/luaunit/lib/luaunit.lua
+script_deps := o/any/spawn/lib/spawn/init.lua o/any/walk/lib/walk/init.lua
 
 $(fetch_script) $(extract_script) $(install_script) $(luatest_script) $(luacheck_script) $(ast_grep_script) $(teal_script): | $(lua_bin)
 cosmo := whilp/cosmopolitan
@@ -51,15 +52,15 @@ luacheck_files := $(patsubst %,o/any/%.luacheck.ok,$(lua_files))
 
 luatest: $(luatest_files) ## Run tests incrementally on changed files
 
-o/any/%.luatest.ok: % $(luatest_script) $(luaunit) o/any/walk/lib/walk/init.lua
+o/any/%.luatest.ok: % $(luatest_script) $(luaunit) $(script_deps)
 	$(TEST_ENV) $(luatest_runner) $< $@ $(TEST_ARGS)
 
-luatest-report: $(luatest_files) o/any/walk/lib/walk/init.lua ## Run tests and show summary report
+luatest-report: $(luatest_files) $(script_deps) ## Run tests and show summary report
 	@$(luatest_runner) report o/any
 
 luacheck: $(luacheck_files) ## Run luacheck incrementally on changed files
 
-o/any/%.luacheck.ok: % .luacheckrc $(luacheck_script) $(luacheck_bin) o/any/spawn/lib/spawn/init.lua o/any/walk/lib/walk/init.lua
+o/any/%.luacheck.ok: % .luacheckrc $(luacheck_script) $(luacheck_bin) $(script_deps)
 	$(luacheck_runner) $< $@ $(luacheck_bin)
 
 luacheck-report: $(luacheck_files) ## Run luacheck and show summary report
@@ -69,7 +70,7 @@ ast_grep_files := $(patsubst %,o/any/%.ast-grep.ok,$(lua_files))
 
 ast-grep: $(ast_grep_files) ## Run ast-grep incrementally on changed files
 
-o/any/%.ast-grep.ok: % sgconfig.yml $(ast_grep_script) $(ast_grep) o/any/spawn/lib/spawn/init.lua o/any/walk/lib/walk/init.lua
+o/any/%.ast-grep.ok: % sgconfig.yml $(ast_grep_script) $(ast_grep) $(script_deps)
 	$(ast_grep_runner) $< $@ $(ast_grep)
 
 ast-grep-report: $(ast_grep_files) ## Run ast-grep and show summary report
@@ -79,7 +80,7 @@ teal_files := $(patsubst %,o/any/%.teal.ok,$(lua_files))
 
 teal: $(teal_files) ## Run teal incrementally on changed files
 
-o/any/%.teal.ok: % $(teal_script) $(tl_bin) $(lua_dist) o/any/spawn/lib/spawn/init.lua o/any/walk/lib/walk/init.lua
+o/any/%.teal.ok: % $(teal_script) $(tl_bin) $(lua_dist) $(script_deps)
 	$(teal_runner) $< $@ $(tl_bin) $(lua_dist) || true
 
 teal-report: $(teal_files) ## Run teal and show summary report

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ extract = $(lua_bin) $(extract_script)
 install = $(lua_bin) $(install_script)
 runner = $(lua_bin) $(luatest_script)
 luatest_runner = $(lua_bin) $(luatest_script)
-luacheck_bin = o/$(current_platform)/luacheck/bin/luacheck
 luacheck_runner = $(lua_bin) $(luacheck_script)
 ast_grep_runner = $(lua_bin) $(ast_grep_script)
 teal_runner = $(lua_bin) $(teal_script)
@@ -46,11 +45,6 @@ include 3p/cook.mk
 
 # Assemble script dependencies from individual library modules
 script_deps := $(spawn_lib) $(walk_lib)
-
-# Tool binaries for checkers
-ast_grep := o/$(current_platform)/ast-grep/bin/ast-grep
-lua_dist := o/$(current_platform)/lua/bin/lua.dist
-tl_bin := o/$(current_platform)/tl/bin/tl
 
 # Build scripts that require runtime dependencies
 $(extract_script): | $(spawn_lib)
@@ -81,8 +75,8 @@ ast_grep_files := $(patsubst %,o/any/%.ast-grep.ok,$(lua_files))
 
 ast-grep: $(ast_grep_files) ## Run ast-grep incrementally on changed files
 
-o/any/%.ast-grep.ok: % sgconfig.yml $(ast_grep_script) $(ast_grep) $(script_deps)
-	$(ast_grep_runner) $< $@ $(ast_grep)
+o/any/%.ast-grep.ok: % sgconfig.yml $(ast_grep_script) $(astgrep_bin) $(script_deps)
+	$(ast_grep_runner) $< $@ $(astgrep_bin)
 
 ast-grep-report: $(ast_grep_files) ## Run ast-grep and show summary report
 	@$(ast_grep_runner) report o/any

--- a/lib/build/ast-grep.lua
+++ b/lib/build/ast-grep.lua
@@ -1,18 +1,12 @@
 #!/usr/bin/env lua
--- Debug: print LUA_PATH
-io.stderr:write("DEBUG ast-grep.lua: LUA_PATH=" .. (os.getenv("LUA_PATH") or "nil") .. "\n")
-io.stderr:write("DEBUG ast-grep.lua: package.path=" .. package.path .. "\n")
 
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local cosmo = require("cosmo")
 
-io.stderr:write("DEBUG ast-grep.lua: about to require spawn\n")
 local spawn = require("spawn").spawn
-io.stderr:write("DEBUG ast-grep.lua: spawn loaded successfully\n")
 
 local walk = require("walk")
-io.stderr:write("DEBUG ast-grep.lua: walk loaded successfully\n")
 
 local function parse_json_stream(stdout)
   local issues = {}
@@ -41,25 +35,16 @@ local function check(source_file, output, ast_grep_bin)
 
   print("# ast-grep " .. source_file)
 
-  io.stderr:write("DEBUG: ast_grep_bin=" .. ast_grep_bin .. "\n")
-  io.stderr:write("DEBUG: checking if binary exists\n")
-  local stat = unix.stat(ast_grep_bin)
-  io.stderr:write("DEBUG: stat result=" .. (stat and "exists" or "nil") .. "\n")
-
   local cmd = {
     ast_grep_bin,
     "scan",
     "--json=stream",
     source_file,
   }
-  io.stderr:write("DEBUG: spawning command: " .. table.concat(cmd, " ") .. "\n")
 
   local handle = spawn(cmd)
-  io.stderr:write("DEBUG: spawn returned, calling read()\n")
 
   local _, stdout, exit_code = handle:read()
-  io.stderr:write("DEBUG: read() returned, exit_code=" .. tostring(exit_code) .. "\n")
-  io.stderr:write("DEBUG: stdout length=" .. (stdout and #stdout or 0) .. "\n")
 
   local issues = parse_json_stream(stdout)
 
@@ -84,9 +69,7 @@ local function check(source_file, output, ast_grep_bin)
     issues = issues,
   }
 
-  io.stderr:write("DEBUG: writing result to " .. output .. "\n")
   cosmo.Barf(output, "return " .. cosmo.EncodeLua(result) .. "\n")
-  io.stderr:write("DEBUG: check() returning passed=" .. tostring(passed) .. "\n")
 
   return passed
 end
@@ -152,15 +135,9 @@ local function report(output_dir)
 end
 
 local function main(args)
-  io.stderr:write("DEBUG main: received " .. #args .. " arguments\n")
-  for i, arg in ipairs(args) do
-    io.stderr:write("DEBUG main: args[" .. i .. "]=" .. arg .. "\n")
-  end
-
   local cmd = args[1]
 
   if cmd == "report" then
-    io.stderr:write("DEBUG main: entering report mode\n")
     local output_dir = args[2] or "o/any"
     return report(output_dir) and 0 or 1
   end
@@ -172,9 +149,7 @@ local function main(args)
     return 1
   end
 
-  io.stderr:write("DEBUG main: calling check()\n")
   local passed = check(source_file, output, ast_grep_bin)
-  io.stderr:write("DEBUG main: check() returned, passed=" .. tostring(passed) .. "\n")
   return passed and 0 or 1
 end
 

--- a/lib/build/ast-grep.lua
+++ b/lib/build/ast-grep.lua
@@ -98,7 +98,7 @@ local function report(output_dir)
   local total_issues = 0
   local by_rule = {}
 
-  for _, filepath in ipairs(walk.collect(output_dir, "%.ast%-grep%.ok$")) do
+  for _, filepath in ipairs(walk.collect(output_dir, "%.ok$")) do
     local chunk = loadfile(filepath)
     if chunk then
       local result = chunk()

--- a/lib/build/ast-grep.lua
+++ b/lib/build/ast-grep.lua
@@ -1,9 +1,18 @@
 #!/usr/bin/env lua
+-- Debug: print LUA_PATH
+io.stderr:write("DEBUG ast-grep.lua: LUA_PATH=" .. (os.getenv("LUA_PATH") or "nil") .. "\n")
+io.stderr:write("DEBUG ast-grep.lua: package.path=" .. package.path .. "\n")
+
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local cosmo = require("cosmo")
+
+io.stderr:write("DEBUG ast-grep.lua: about to require spawn\n")
 local spawn = require("spawn").spawn
+io.stderr:write("DEBUG ast-grep.lua: spawn loaded successfully\n")
+
 local walk = require("walk")
+io.stderr:write("DEBUG ast-grep.lua: walk loaded successfully\n")
 
 local function parse_json_stream(stdout)
   local issues = {}

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -1,23 +1,23 @@
 # lib/build - build tools (fetch, extract, install)
 
-luatest_o := o/luatest
+luatest_o := $(o)/luatest
 
-lib_dirs += o/any/build/lib
-lib_libs += o/any/build/lib/build/install.lua
-lib_libs += o/any/build/lib/build/fetch.lua
+lib_dirs += $(o_any)/build/lib
+lib_libs += $(o_any)/build/lib/build/install.lua
+lib_libs += $(o_any)/build/lib/build/fetch.lua
 
-o/any/build/lib/build/install.lua: lib/build/install.lua
+$(o_any)/build/lib/build/install.lua: lib/build/install.lua
 	mkdir -p $(@D)
 	cp $< $@
 
-o/any/build/lib/build/fetch.lua: lib/build/fetch.lua
+$(o_any)/build/lib/build/fetch.lua: lib/build/fetch.lua
 	mkdir -p $(@D)
 	cp $< $@
 
 $(luatest_o)/lib/build/test_luacheck.lua.ok: lib/build/luacheck.lua $(luacheck_bin)
-$(luatest_o)/lib/build/test_luacheck.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/luacheck
+$(luatest_o)/lib/build/test_luacheck.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/luacheck
 $(luatest_o)/lib/build/test_luacheck.lua.ok: TEST_ARGS = $(CURDIR)/$(luacheck_config)
 
 $(luatest_o)/lib/build/test_ast_grep.lua.ok: lib/build/ast-grep.lua $(astgrep_bin)
-$(luatest_o)/lib/build/test_ast_grep.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
+$(luatest_o)/lib/build/test_ast_grep.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/ast-grep
 $(luatest_o)/lib/build/test_ast_grep.lua.ok: TEST_ARGS = $(CURDIR)/$(astgrep_config) $(CURDIR)/.ast-grep

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -12,10 +12,10 @@ o/any/build/lib/build/fetch.lua: lib/build/fetch.lua
 	mkdir -p $(@D)
 	cp $< $@
 
-o/any/lib/build/test_luacheck.lua.luatest.ok: lib/build/luacheck.lua $(luacheck_bin)
-o/any/lib/build/test_luacheck.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/luacheck
-o/any/lib/build/test_luacheck.lua.luatest.ok: TEST_ARGS = $(CURDIR)/.luacheckrc
+o/luatest/lib/build/test_luacheck.lua.ok: lib/build/luacheck.lua $(luacheck_bin)
+o/luatest/lib/build/test_luacheck.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/luacheck
+o/luatest/lib/build/test_luacheck.lua.ok: TEST_ARGS = $(CURDIR)/.luacheckrc
 
-o/any/lib/build/test_ast_grep.lua.luatest.ok: lib/build/ast-grep.lua $(ast_grep)
-o/any/lib/build/test_ast_grep.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
-o/any/lib/build/test_ast_grep.lua.luatest.ok: TEST_ARGS = $(CURDIR)/sgconfig.yml $(CURDIR)/.ast-grep
+o/luatest/lib/build/test_ast_grep.lua.ok: lib/build/ast-grep.lua $(ast_grep)
+o/luatest/lib/build/test_ast_grep.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
+o/luatest/lib/build/test_ast_grep.lua.ok: TEST_ARGS = $(CURDIR)/sgconfig.yml $(CURDIR)/.ast-grep

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -1,5 +1,7 @@
 # lib/build - build tools (fetch, extract, install)
 
+luatest_o := o/luatest
+
 lib_dirs += o/any/build/lib
 lib_libs += o/any/build/lib/build/install.lua
 lib_libs += o/any/build/lib/build/fetch.lua
@@ -12,10 +14,10 @@ o/any/build/lib/build/fetch.lua: lib/build/fetch.lua
 	mkdir -p $(@D)
 	cp $< $@
 
-o/luatest/lib/build/test_luacheck.lua.ok: lib/build/luacheck.lua $(luacheck_bin)
-o/luatest/lib/build/test_luacheck.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/luacheck
-o/luatest/lib/build/test_luacheck.lua.ok: TEST_ARGS = $(CURDIR)/.luacheckrc
+$(luatest_o)/lib/build/test_luacheck.lua.ok: lib/build/luacheck.lua $(luacheck_bin)
+$(luatest_o)/lib/build/test_luacheck.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/luacheck
+$(luatest_o)/lib/build/test_luacheck.lua.ok: TEST_ARGS = $(CURDIR)/$(luacheck_config)
 
-o/luatest/lib/build/test_ast_grep.lua.ok: lib/build/ast-grep.lua $(ast_grep)
-o/luatest/lib/build/test_ast_grep.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
-o/luatest/lib/build/test_ast_grep.lua.ok: TEST_ARGS = $(CURDIR)/sgconfig.yml $(CURDIR)/.ast-grep
+$(luatest_o)/lib/build/test_ast_grep.lua.ok: lib/build/ast-grep.lua $(astgrep_bin)
+$(luatest_o)/lib/build/test_ast_grep.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/ast-grep
+$(luatest_o)/lib/build/test_ast_grep.lua.ok: TEST_ARGS = $(CURDIR)/$(astgrep_config) $(CURDIR)/.ast-grep

--- a/lib/build/luacheck.lua
+++ b/lib/build/luacheck.lua
@@ -1,18 +1,13 @@
 #!/usr/bin/env lua
 -- Debug: print LUA_PATH
-io.stderr:write("DEBUG luacheck.lua: LUA_PATH=" .. (os.getenv("LUA_PATH") or "nil") .. "\n")
-io.stderr:write("DEBUG luacheck.lua: package.path=" .. package.path .. "\n")
 
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local cosmo = require("cosmo")
 
-io.stderr:write("DEBUG luacheck.lua: about to require spawn\n")
 local spawn = require("spawn").spawn
-io.stderr:write("DEBUG luacheck.lua: spawn loaded successfully\n")
 
 local walk = require("walk")
-io.stderr:write("DEBUG luacheck.lua: walk loaded successfully\n")
 
 local function parse_plain(stdout)
   local issues = {}

--- a/lib/build/luacheck.lua
+++ b/lib/build/luacheck.lua
@@ -1,9 +1,18 @@
 #!/usr/bin/env lua
+-- Debug: print LUA_PATH
+io.stderr:write("DEBUG luacheck.lua: LUA_PATH=" .. (os.getenv("LUA_PATH") or "nil") .. "\n")
+io.stderr:write("DEBUG luacheck.lua: package.path=" .. package.path .. "\n")
+
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local cosmo = require("cosmo")
+
+io.stderr:write("DEBUG luacheck.lua: about to require spawn\n")
 local spawn = require("spawn").spawn
+io.stderr:write("DEBUG luacheck.lua: spawn loaded successfully\n")
+
 local walk = require("walk")
+io.stderr:write("DEBUG luacheck.lua: walk loaded successfully\n")
 
 local function parse_plain(stdout)
   local issues = {}

--- a/lib/build/luacheck.lua
+++ b/lib/build/luacheck.lua
@@ -81,7 +81,7 @@ local function report(output_dir)
   local total_issues = 0
   local by_code = {}
 
-  for _, filepath in ipairs(walk.collect(output_dir, "%.luacheck%.ok$")) do
+  for _, filepath in ipairs(walk.collect(output_dir, "%.ok$")) do
     local chunk = loadfile(filepath)
     if chunk then
       local result = chunk()

--- a/lib/build/luatest.lua
+++ b/lib/build/luatest.lua
@@ -102,7 +102,7 @@ local function report(output_dir)
   local total_skipped = 0
   local total_duration_ms = 0
 
-  for _, filepath in ipairs(walk.collect(output_dir, "%.luatest%.ok$")) do
+  for _, filepath in ipairs(walk.collect(output_dir, "%.ok$")) do
     local chunk = loadfile(filepath)
     if chunk then
       local result = chunk()

--- a/lib/build/teal.lua
+++ b/lib/build/teal.lua
@@ -1,18 +1,13 @@
 #!/usr/bin/env lua
 -- Debug: print LUA_PATH
-io.stderr:write("DEBUG teal.lua: LUA_PATH=" .. (os.getenv("LUA_PATH") or "nil") .. "\n")
-io.stderr:write("DEBUG teal.lua: package.path=" .. package.path .. "\n")
 
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local cosmo = require("cosmo")
 
-io.stderr:write("DEBUG teal.lua: about to require spawn\n")
 local spawn = require("spawn").spawn
-io.stderr:write("DEBUG teal.lua: spawn loaded successfully\n")
 
 local walk = require("walk")
-io.stderr:write("DEBUG teal.lua: walk loaded successfully\n")
 
 local function parse_output(stdout)
   local issues = {}

--- a/lib/build/teal.lua
+++ b/lib/build/teal.lua
@@ -83,7 +83,7 @@ local function report(output_dir)
   local total_issues = 0
   local by_severity = {}
 
-  for _, filepath in ipairs(walk.collect(output_dir, "%.teal%.ok$")) do
+  for _, filepath in ipairs(walk.collect(output_dir, "%.ok$")) do
     local chunk = loadfile(filepath)
     if chunk then
       local result = chunk()

--- a/lib/build/teal.lua
+++ b/lib/build/teal.lua
@@ -1,9 +1,18 @@
 #!/usr/bin/env lua
+-- Debug: print LUA_PATH
+io.stderr:write("DEBUG teal.lua: LUA_PATH=" .. (os.getenv("LUA_PATH") or "nil") .. "\n")
+io.stderr:write("DEBUG teal.lua: package.path=" .. package.path .. "\n")
+
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local cosmo = require("cosmo")
+
+io.stderr:write("DEBUG teal.lua: about to require spawn\n")
 local spawn = require("spawn").spawn
+io.stderr:write("DEBUG teal.lua: spawn loaded successfully\n")
+
 local walk = require("walk")
+io.stderr:write("DEBUG teal.lua: walk loaded successfully\n")
 
 local function parse_output(stdout)
   local issues = {}

--- a/lib/spawn/cook.mk
+++ b/lib/spawn/cook.mk
@@ -8,4 +8,4 @@ $(spawn_lib): lib/spawn/init.lua
 	cp $< $@
 
 $(luatest_o)/lib/spawn/test_spawn.lua.ok: $(spawn_lib) o/$(current_platform)/cosmos/bin/lua
-$(luatest_o)/lib/spawn/test_spawn.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/cosmos
+$(luatest_o)/lib/spawn/test_spawn.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/cosmos

--- a/lib/spawn/cook.mk
+++ b/lib/spawn/cook.mk
@@ -7,5 +7,5 @@ $(spawn_lib): lib/spawn/init.lua
 	mkdir -p $(@D)
 	cp $< $@
 
-o/any/lib/spawn/test_spawn.lua.luatest.ok: $(spawn_lib) o/$(current_platform)/cosmos/bin/lua
-o/any/lib/spawn/test_spawn.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/cosmos
+o/luatest/lib/spawn/test_spawn.lua.ok: $(spawn_lib) o/$(current_platform)/cosmos/bin/lua
+o/luatest/lib/spawn/test_spawn.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/cosmos

--- a/lib/spawn/cook.mk
+++ b/lib/spawn/cook.mk
@@ -1,10 +1,11 @@
 lib_lua_modules += spawn
 lib_dirs += o/any/spawn/lib
-lib_libs += o/any/spawn/lib/spawn/init.lua
+spawn_lib := o/any/spawn/lib/spawn/init.lua
+lib_libs += $(spawn_lib)
 
-o/any/spawn/lib/spawn/init.lua: lib/spawn/init.lua
+$(spawn_lib): lib/spawn/init.lua
 	mkdir -p $(@D)
 	cp $< $@
 
-o/any/lib/spawn/test_spawn.lua.luatest.ok: o/any/spawn/lib/spawn/init.lua o/$(current_platform)/cosmos/bin/lua
+o/any/lib/spawn/test_spawn.lua.luatest.ok: $(spawn_lib) o/$(current_platform)/cosmos/bin/lua
 o/any/lib/spawn/test_spawn.lua.luatest.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/cosmos

--- a/lib/spawn/cook.mk
+++ b/lib/spawn/cook.mk
@@ -7,5 +7,5 @@ $(spawn_lib): lib/spawn/init.lua
 	mkdir -p $(@D)
 	cp $< $@
 
-o/luatest/lib/spawn/test_spawn.lua.ok: $(spawn_lib) o/$(current_platform)/cosmos/bin/lua
-o/luatest/lib/spawn/test_spawn.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/cosmos
+$(luatest_o)/lib/spawn/test_spawn.lua.ok: $(spawn_lib) o/$(current_platform)/cosmos/bin/lua
+$(luatest_o)/lib/spawn/test_spawn.lua.ok: TEST_ENV = TEST_BIN_DIR=o/$(current_platform)/cosmos

--- a/lib/walk/cook.mk
+++ b/lib/walk/cook.mk
@@ -1,8 +1,9 @@
 # lib/walk - directory tree walking utilities
 
 lib_dirs += o/any/walk/lib
-lib_libs += o/any/walk/lib/walk/init.lua
+walk_lib := o/any/walk/lib/walk/init.lua
+lib_libs += $(walk_lib)
 
-o/any/walk/lib/walk/init.lua: lib/walk/init.lua
+$(walk_lib): lib/walk/init.lua
 	mkdir -p $(@D)
 	cp $< $@


### PR DESCRIPTION
## Summary

Comprehensive refactoring of the makefile build system to improve organization, maintainability, and consistency:

- **Output directory reorganization**: Checker outputs now live in tool-specific directories (`o/luatest/`, `o/ast-grep/`, `o/luacheck/`, `o/teal/`) instead of using file suffixes, creating cleaner separation of artifacts
- **Variable-based paths**: Introduced base directory variables (`o`, `o_platform`, `o_any`) and checker-specific variables (`astgrep_o`, `luacheck_o`, etc.) to replace hardcoded paths throughout
- **Dynamic LUA_PATH construction**: Build `LUA_PATH` programmatically from `lib_dirs` and `3p_lib_dirs` instead of hardcoding individual library paths
- **Modular configuration**: Move tool-specific variables and configs to their respective `cook.mk` files for better locality
- **Workflow optimization**: Reorder CI steps to run checks and tests before builds

## Key changes

- Reorganized checker output directories with cleaner naming scheme
- Standardized path handling using base directory variables
- Automated LUA_PATH construction from library directories
- Decentralized variable definitions to cook.mk files
- Cleaned up redundant file exclusions and exports
- Fixed dependency ordering issues in CI workflow

## Test plan

- [x] CI checks pass with new directory structure
- [x] All checkers (luatest, ast-grep, luacheck, teal) run successfully
- [x] Build artifacts are correctly organized
- [x] LUA_PATH includes all necessary libraries