### PR TITLE
cosmos: update to 2026.01.02-248b4d9b3

### DIFF
--- a/.github/pr/204.md
+++ b/.github/pr/204.md
@@ -1,0 +1,12 @@
+# cosmos: update to 2026.01.02-248b4d9b3
+
+Update cosmopolitan from `2025.12.31-b0b834275` to `2026.01.02-248b4d9b3`.
+
+- Updated version string to `2026.01.02-248b4d9b3`
+- Updated SHA256 checksum to `0961617e409bc09eff6b58e5b7206aea2437a527c68169695e05fdf21cdf17c3`
+- Added `tag` field to match latest version format
+
+## Validation
+
+- [x] `make o/luatest/3p/cosmos/test.lua.ok` passes (4 tests)
+- [x] Merged latest main

--- a/.github/pr/204.md
+++ b/.github/pr/204.md
@@ -10,3 +10,4 @@ Update cosmopolitan from `2025.12.31-b0b834275` to `2026.01.02-248b4d9b3`.
 
 - [x] `make o/luatest/3p/cosmos/test.lua.ok` passes (4 tests)
 - [x] Merged latest main
+

--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,6 +1,7 @@
 return {
   format="zip",
-  platforms={["*"]={sha="994a45a2a9c9e611a8edc936274f4e418a38643f688e304ae160e39609db3e2f"}},
+  platforms={["*"]={sha="0961617e409bc09eff6b58e5b7206aea2437a527c68169695e05fdf21cdf17c3"}},
+  tag="2026.01.02-248b4d9b3",
   url="https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version="2025.12.31-b0b834275"
+  version="2026.01.02-248b4d9b3"
 }

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -21,7 +21,7 @@ $(luatest_o)/lib/build/test_ast_grep.lua.ok: lib/build/ast-grep.lua $(astgrep_bi
 $(luatest_o)/lib/build/test_ast_grep.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/ast-grep
 $(luatest_o)/lib/build/test_ast_grep.lua.ok: TEST_ARGS = $(CURDIR)/$(astgrep_config) $(CURDIR)/.ast-grep
 
-update-pr: $(lua_bin) ## Update PR title/description from .github/pr.md
-	@test -f .github/pr.md && $(lua_bin) lib/build/pr.lua || true
+update-pr: $(lua_bin) ## Update PR title/description from .github/pr/<number>.md
+	@$(lua_bin) lib/build/pr.lua || true
 
 .PHONY: update-pr


### PR DESCRIPTION
Update cosmopolitan from `2025.12.31-b0b834275` to `2026.01.02-248b4d9b3`.

- Updated version string to `2026.01.02-248b4d9b3`
- Updated SHA256 checksum to `0961617e409bc09eff6b58e5b7206aea2437a527c68169695e05fdf21cdf17c3`
- Added `tag` field to match latest version format

## Validation

- [x] `make o/luatest/3p/cosmos/test.lua.ok` passes (4 tests)
- [x] Merged latest main