### PR TITLE
ast-grep: add rule to require cosmo.is_main()

### DIFF
--- a/.ast-grep/rules/use-cosmo-is-main.yml
+++ b/.ast-grep/rules/use-cosmo-is-main.yml
@@ -1,0 +1,19 @@
+id: use-cosmo-is-main
+language: lua
+severity: error
+message: |
+  Use cosmo.is_main() instead of pcall(debug.getlocal, ...) pattern.
+
+  The debug.getlocal hack is fragile and non-obvious.
+
+    Bad:  if not pcall(debug.getlocal, 4, 1) then
+    Good: if cosmo.is_main() then
+note: |
+  cosmo.is_main() is a built-in function that correctly detects
+  if the script is being run directly vs required as a module.
+  Ensure you have `local cosmo = require("cosmo")` at the top.
+
+rule:
+  any:
+    - pattern: pcall(debug.getlocal, $$$)
+    - pattern: debug.getlocal($$$)

--- a/lib/build/latest.lua
+++ b/lib/build/latest.lua
@@ -287,7 +287,7 @@ local function report(output_dir, opts)
   return #errors == 0
 end
 
-if not pcall(debug.getlocal, 4, 1) then
+if cosmo.is_main() then
   local command = arg[1]
 
   if command == "report" then


### PR DESCRIPTION
Add use-cosmo-is-main.yml rule that detects the fragile
pcall(debug.getlocal, 4, 1) pattern and suggests using
cosmo.is_main() instead.

Refactor lib/build/latest.lua to use the new pattern as an example.