### PR TITLE
cosmic: add main() entry point helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ export LUA_PATH := $(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;$(lib_paths)$(3p
 script_deps := $(cosmic_lib)/cosmic/spawn.lua $(cosmic_lib)/cosmic/walk.lua
 
 lua_files := $(shell git ls-files '*.lua' | grep -vE '^(\.config/(hammerspoon|nvim|voyager)|\.local/bin)/' ; git ls-files | grep -v '\.lua$$' | grep -v '^o/' | grep -vE '^(\.config/(hammerspoon|nvim|voyager)|\.local/bin)/' | xargs -r grep -l '^#!/.*lua' 2>/dev/null || true)
-test_files := $(shell git ls-files '*test.lua' 'test_*.lua' | grep -vE '(latest|luatest)\.lua$$')
+test_files := $(shell git ls-files '*test.lua' '**/test_*.lua' | grep -vE '(latest|luatest)\.lua$$')
 version_files := $(shell git ls-files '**/version.lua' | grep -v '^lib/version\.lua$$')
 luatest_files := $(patsubst %,$(luatest_o)/%.ok,$(test_files))
 luacheck_files := $(patsubst %,$(luacheck_o)/%.ok,$(lua_files))

--- a/lib/cosmic/init.lua
+++ b/lib/cosmic/init.lua
@@ -1,7 +1,18 @@
 -- cosmic: cosmopolitan lua utilities
 -- require individual modules via require("cosmic.spawn"), require("cosmic.walk"), etc.
 
+local cosmo = require("cosmo")
+
+local function main(fn)
+  if not cosmo.is_main() then return end
+  local env = {stderr = io.stderr, stdout = io.stdout}
+  local code, err = fn(arg, env)
+  if err then env.stderr:write(err .. "\n") end
+  os.exit(code or 0)
+end
+
 return {
   _VERSION = "0.1.0",
   _DESCRIPTION = "Cosmopolitan Lua utilities",
+  main = main,
 }

--- a/lib/cosmic/test_cosmic.lua
+++ b/lib/cosmic/test_cosmic.lua
@@ -29,3 +29,21 @@ function TestCosmic:test_require_cosmic_help()
   lu.assertNotNil(help.modules)
   lu.assertNotNil(help.print_help)
 end
+
+function TestCosmic:test_cosmic_main_exists()
+  local cosmic = require("cosmic")
+  lu.assertNotNil(cosmic.main)
+  lu.assertEquals(type(cosmic.main), "function")
+end
+
+function TestCosmic:test_cosmic_main_returns_when_not_main()
+  local cosmic = require("cosmic")
+  local called = false
+  local function app()
+    called = true
+    return 0
+  end
+  -- when required (not main), cosmic.main should return without calling fn
+  cosmic.main(app)
+  lu.assertFalse(called)
+end


### PR DESCRIPTION
## Summary

- Add `cosmic.main(fn)` helper for script entry points that handles the common pattern of checking `cosmo.is_main()`, passing args/env, writing errors to stderr, and calling `os.exit()`
- Fix `test_files` pattern in Makefile to include `**/test_*.lua` so tests in subdirectories are discovered

## Test plan

- [x] `cosmic.main` tests pass via `make luatest`
- [x] Tests in `lib/cosmic/` are now included in test runs