### PR TITLE
extract: set extracted file mtimes to current time

### DIFF
--- a/.github/pr/212.md
+++ b/.github/pr/212.md
@@ -1,13 +1,19 @@
-# extract: set extracted file mtimes to archive mtime
+# extract: set extracted file mtimes to current time
 
-Extracted files now have their modification times set to match the archive file's mtime (with nanosecond precision). This prevents make from unnecessarily rebuilding targets when running make check multiple times, as extracted files are no longer older than the archives they come from.
+Extracted files now have their modification times set to the current time when extraction completes. This prevents make from unnecessarily rebuilding targets, even when extract.lua is modified, since extracted files are always newer than all dependencies.
 
-- lib/build/extract.lua - added set_mtime_recursive function and updated extract_zip/extract_targz to set mtimes
-- lib/build/test_extract.lua - updated timestamp preservation tests to verify extracted files match archive mtime
+- lib/build/extract.lua - added set_mtime_recursive using cosmic.walk, sets all extracted files to current time
+- lib/build/test_extract.lua - updated tests to verify mtimes are set to current time
+
+## Key decisions
+
+- **Current time vs archive mtime**: Using current time ensures extracted files are newer than both the archive and extract.lua, preventing continuous rebuilds when the extraction script changes
+- **Centralized in main()**: Individual extractors (zip, tar.gz, gz) focus on extraction only; mtime setting happens once in main() for all formats
+- **cosmic.walk**: Used for clean, efficient directory traversal instead of manual recursion
 
 ## Validation
 
 - [x] tests pass
 - [x] linter passes
-- [x] verified timestamps match with nanosecond precision
+- [x] verified no rebuilds when extract.lua changes
 - [x] confirmed no unnecessary rebuilds on repeated make check

--- a/.github/pr/212.md
+++ b/.github/pr/212.md
@@ -1,0 +1,13 @@
+# extract: set extracted file mtimes to archive mtime
+
+Extracted files now have their modification times set to match the archive file's mtime (with nanosecond precision). This prevents make from unnecessarily rebuilding targets when running make check multiple times, as extracted files are no longer older than the archives they come from.
+
+- lib/build/extract.lua - added set_mtime_recursive function and updated extract_zip/extract_targz to set mtimes
+- lib/build/test_extract.lua - updated timestamp preservation tests to verify extracted files match archive mtime
+
+## Validation
+
+- [x] tests pass
+- [x] linter passes
+- [x] verified timestamps match with nanosecond precision
+- [x] confirmed no unnecessary rebuilds on repeated make check

--- a/lib/build/extract.lua
+++ b/lib/build/extract.lua
@@ -224,4 +224,5 @@ return {
   extract_targz = extract_targz,
   extract_gz = extract_gz,
   strip_components = strip_components,
+  set_mtime_recursive = set_mtime_recursive,
 }

--- a/lib/build/extract.lua
+++ b/lib/build/extract.lua
@@ -98,11 +98,12 @@ local function clear_dir(dir)
   end
 end
 
-local function set_mtime_recursive(dir, mtime_sec, mtime_nsec)
+local function set_mtime_recursive(dir)
+  local now_sec, now_nsec = unix.clock_gettime(unix.CLOCK_REALTIME)
   walk.walk(dir, function(file_path)
     local fd = unix.open(file_path, unix.O_RDONLY)
     if fd then
-      unix.futimens(fd, mtime_sec, mtime_nsec, mtime_sec, mtime_nsec)
+      unix.futimens(fd, now_sec, now_nsec, now_sec, now_nsec)
       unix.close(fd)
     end
   end)
@@ -205,11 +206,7 @@ local function main(version_file, platform, input, dest_dir)
     return nil, err
   end
 
-  local archive_stat = unix.stat(input)
-  if archive_stat then
-    local archive_mtime_sec, archive_mtime_nsec = archive_stat:mtim()
-    set_mtime_recursive(dest_dir, archive_mtime_sec, archive_mtime_nsec)
-  end
+  set_mtime_recursive(dest_dir)
 
   return true
 end

--- a/lib/build/extract.lua
+++ b/lib/build/extract.lua
@@ -152,20 +152,7 @@ local function extract_targz(archive, dest_dir, strip)
   return true
 end
 
-local function read_gz_mtime(archive)
-  local fd = unix.open(archive, unix.O_RDONLY)
-  if not fd then return nil end
-  local header = unix.read(fd, 8)
-  unix.close(fd)
-  if not header or #header < 8 then return nil end
-  -- mtime is bytes 4-7 (0-indexed) as little-endian uint32
-  local b1, b2, b3, b4 = header:byte(5, 8)
-  return b1 + b2 * 256 + b3 * 65536 + b4 * 16777216
-end
-
 local function extract_gz(archive, dest_dir, tool_name)
-  local mtime = read_gz_mtime(archive)
-
   local dest = path.join(dest_dir, tool_name)
   local handle = spawn({"gunzip", "-c", archive})
   local ok, output, exit_code = handle:read()
@@ -177,9 +164,6 @@ local function extract_gz(archive, dest_dir, tool_name)
     return nil, "failed to create " .. dest
   end
   unix.write(fd, output)
-  if mtime and mtime > 0 then
-    unix.futimens(fd, mtime, 0, mtime, 0)
-  end
   unix.close(fd)
   return true
 end
@@ -221,12 +205,10 @@ local function main(version_file, platform, input, dest_dir)
     return nil, err
   end
 
-  if format == "zip" or format == "tar.gz" then
-    local archive_stat = unix.stat(input)
-    if archive_stat then
-      local archive_mtime_sec, archive_mtime_nsec = archive_stat:mtim()
-      set_mtime_recursive(dest_dir, archive_mtime_sec, archive_mtime_nsec)
-    end
+  local archive_stat = unix.stat(input)
+  if archive_stat then
+    local archive_mtime_sec, archive_mtime_nsec = archive_stat:mtim()
+    set_mtime_recursive(dest_dir, archive_mtime_sec, archive_mtime_nsec)
   end
 
   return true

--- a/lib/build/extract.lua
+++ b/lib/build/extract.lua
@@ -97,8 +97,35 @@ local function clear_dir(dir)
   end
 end
 
+local function set_mtime_recursive(dir, mtime_sec, mtime_nsec)
+  local handle = unix.opendir(dir)
+  if not handle then return end
+  for name in handle do
+    if name ~= "." and name ~= ".." then
+      local file_path = path.join(dir, name)
+      local stat = unix.stat(file_path)
+      if stat then
+        local fd = unix.open(file_path, unix.O_RDONLY)
+        if fd then
+          unix.futimens(fd, mtime_sec, mtime_nsec, mtime_sec, mtime_nsec)
+          unix.close(fd)
+        end
+        if unix.S_ISDIR(stat:mode()) then
+          set_mtime_recursive(file_path, mtime_sec, mtime_nsec)
+        end
+      end
+    end
+  end
+end
+
 local function extract_zip(archive, dest_dir, strip)
   strip = strip or 0
+  local archive_stat = unix.stat(archive)
+  if not archive_stat then
+    return nil, "failed to stat archive: " .. archive
+  end
+  local archive_mtime_sec, archive_mtime_nsec = archive_stat:mtim()
+
   -- temp_dir must be on same filesystem as dest_dir for rename to work
   local temp_dir = unix.mkdtemp(path.join(path.dirname(dest_dir), ".extract_XXXXXX"))
   clear_dir(dest_dir)
@@ -117,11 +144,19 @@ local function extract_zip(archive, dest_dir, strip)
   if not ok then
     return nil, err
   end
+
+  set_mtime_recursive(dest_dir, archive_mtime_sec, archive_mtime_nsec)
   return true
 end
 
 local function extract_targz(archive, dest_dir, strip)
   strip = strip or 0
+  local archive_stat = unix.stat(archive)
+  if not archive_stat then
+    return nil, "failed to stat archive: " .. archive
+  end
+  local archive_mtime_sec, archive_mtime_nsec = archive_stat:mtim()
+
   -- temp_dir must be on same filesystem as dest_dir for rename to work
   local temp_dir = unix.mkdtemp(path.join(path.dirname(dest_dir), ".extract_XXXXXX"))
   clear_dir(dest_dir)
@@ -138,6 +173,8 @@ local function extract_targz(archive, dest_dir, strip)
   if not ok then
     return nil, err
   end
+
+  set_mtime_recursive(dest_dir, archive_mtime_sec, archive_mtime_nsec)
   return true
 end
 

--- a/lib/build/test_extract.lua
+++ b/lib/build/test_extract.lua
@@ -292,8 +292,12 @@ function TestTimestampPreservationTargz:test_preserves_original_mtime()
   local extracted = path.join(self.dest, "file1.txt")
   lu.assertTrue(file_exists(extracted))
 
+  local archive_stat = unix.stat(self.archive)
   local stat = unix.stat(extracted)
-  lu.assertEquals(stat:mtim(), self.known_mtime, "mtime should match original file")
+  local archive_sec, archive_nsec = archive_stat:mtim()
+  local extracted_sec, extracted_nsec = stat:mtim()
+  lu.assertEquals(extracted_sec, archive_sec, "mtime seconds should match archive file")
+  lu.assertEquals(extracted_nsec, archive_nsec, "mtime nanoseconds should match archive file")
 end
 
 TestTimestampPreservationZip = {}
@@ -336,10 +340,12 @@ function TestTimestampPreservationZip:test_preserves_original_mtime()
   local extracted = path.join(self.dest, "file1.txt")
   lu.assertTrue(file_exists(extracted))
 
+  local archive_stat = unix.stat(self.archive)
   local stat = unix.stat(extracted)
-  -- zip stores mtime with 2-second resolution
-  local diff = math.abs(stat:mtim() - self.known_mtime)
-  lu.assertTrue(diff <= 2, "mtime should match original file (within 2s)")
+  local archive_sec, archive_nsec = archive_stat:mtim()
+  local extracted_sec, extracted_nsec = stat:mtim()
+  lu.assertEquals(extracted_sec, archive_sec, "mtime seconds should match archive file")
+  lu.assertEquals(extracted_nsec, archive_nsec, "mtime nanoseconds should match archive file")
 end
 
 TestTimestampPreservationGz = {}

--- a/lib/build/test_extract.lua
+++ b/lib/build/test_extract.lua
@@ -286,9 +286,11 @@ function TestTimestampPreservationTargz:tearDown()
 end
 
 function TestTimestampPreservationTargz:test_preserves_original_mtime()
-  local before = unix.clock_gettime(unix.CLOCK_REALTIME)
   local ok, err = extract.extract_targz(self.archive, self.dest, 0)
   lu.assertTrue(ok, "extract should succeed: " .. tostring(err))
+
+  local before = unix.clock_gettime(unix.CLOCK_REALTIME)
+  extract.set_mtime_recursive(self.dest)
   local after = unix.clock_gettime(unix.CLOCK_REALTIME)
 
   local extracted = path.join(self.dest, "file1.txt")
@@ -334,9 +336,11 @@ function TestTimestampPreservationZip:tearDown()
 end
 
 function TestTimestampPreservationZip:test_preserves_original_mtime()
-  local before = unix.clock_gettime(unix.CLOCK_REALTIME)
   local ok, err = extract.extract_zip(self.archive, self.dest, 0)
   lu.assertTrue(ok, "extract should succeed: " .. tostring(err))
+
+  local before = unix.clock_gettime(unix.CLOCK_REALTIME)
+  extract.set_mtime_recursive(self.dest)
   local after = unix.clock_gettime(unix.CLOCK_REALTIME)
 
   local extracted = path.join(self.dest, "file1.txt")
@@ -384,9 +388,11 @@ function TestTimestampPreservationGz:tearDown()
 end
 
 function TestTimestampPreservationGz:test_uses_gzip_header_mtime()
-  local before = unix.clock_gettime(unix.CLOCK_REALTIME)
   local ok, err = extract.extract_gz(self.archive, self.dest, self.tool_name)
   lu.assertTrue(ok, "extract should succeed: " .. tostring(err))
+
+  local before = unix.clock_gettime(unix.CLOCK_REALTIME)
+  extract.set_mtime_recursive(self.dest)
   local after = unix.clock_gettime(unix.CLOCK_REALTIME)
 
   local extracted_file = path.join(self.dest, self.tool_name)

--- a/lib/build/test_extract.lua
+++ b/lib/build/test_extract.lua
@@ -390,6 +390,10 @@ function TestTimestampPreservationGz:test_uses_gzip_header_mtime()
   local extracted_file = path.join(self.dest, self.tool_name)
   lu.assertTrue(file_exists(extracted_file))
 
+  local archive_stat = unix.stat(self.archive)
   local extracted_stat = unix.stat(extracted_file)
-  lu.assertEquals(extracted_stat:mtim(), self.known_mtime, "mtime should match gzip header (original file)")
+  local archive_sec, archive_nsec = archive_stat:mtim()
+  local extracted_sec, extracted_nsec = extracted_stat:mtim()
+  lu.assertEquals(extracted_sec, archive_sec, "mtime seconds should match archive file")
+  lu.assertEquals(extracted_nsec, archive_nsec, "mtime nanoseconds should match archive file")
 end

--- a/lib/build/test_extract.lua
+++ b/lib/build/test_extract.lua
@@ -286,18 +286,18 @@ function TestTimestampPreservationTargz:tearDown()
 end
 
 function TestTimestampPreservationTargz:test_preserves_original_mtime()
+  local before = unix.clock_gettime(unix.CLOCK_REALTIME)
   local ok, err = extract.extract_targz(self.archive, self.dest, 0)
   lu.assertTrue(ok, "extract should succeed: " .. tostring(err))
+  local after = unix.clock_gettime(unix.CLOCK_REALTIME)
 
   local extracted = path.join(self.dest, "file1.txt")
   lu.assertTrue(file_exists(extracted))
 
-  local archive_stat = unix.stat(self.archive)
   local stat = unix.stat(extracted)
-  local archive_sec, archive_nsec = archive_stat:mtim()
-  local extracted_sec, extracted_nsec = stat:mtim()
-  lu.assertEquals(extracted_sec, archive_sec, "mtime seconds should match archive file")
-  lu.assertEquals(extracted_nsec, archive_nsec, "mtime nanoseconds should match archive file")
+  local extracted_sec = stat:mtim()
+  lu.assertTrue(extracted_sec >= before, "mtime should be >= before extraction")
+  lu.assertTrue(extracted_sec <= after, "mtime should be <= after extraction")
 end
 
 TestTimestampPreservationZip = {}
@@ -334,18 +334,18 @@ function TestTimestampPreservationZip:tearDown()
 end
 
 function TestTimestampPreservationZip:test_preserves_original_mtime()
+  local before = unix.clock_gettime(unix.CLOCK_REALTIME)
   local ok, err = extract.extract_zip(self.archive, self.dest, 0)
   lu.assertTrue(ok, "extract should succeed: " .. tostring(err))
+  local after = unix.clock_gettime(unix.CLOCK_REALTIME)
 
   local extracted = path.join(self.dest, "file1.txt")
   lu.assertTrue(file_exists(extracted))
 
-  local archive_stat = unix.stat(self.archive)
   local stat = unix.stat(extracted)
-  local archive_sec, archive_nsec = archive_stat:mtim()
-  local extracted_sec, extracted_nsec = stat:mtim()
-  lu.assertEquals(extracted_sec, archive_sec, "mtime seconds should match archive file")
-  lu.assertEquals(extracted_nsec, archive_nsec, "mtime nanoseconds should match archive file")
+  local extracted_sec = stat:mtim()
+  lu.assertTrue(extracted_sec >= before, "mtime should be >= before extraction")
+  lu.assertTrue(extracted_sec <= after, "mtime should be <= after extraction")
 end
 
 TestTimestampPreservationGz = {}
@@ -384,16 +384,16 @@ function TestTimestampPreservationGz:tearDown()
 end
 
 function TestTimestampPreservationGz:test_uses_gzip_header_mtime()
+  local before = unix.clock_gettime(unix.CLOCK_REALTIME)
   local ok, err = extract.extract_gz(self.archive, self.dest, self.tool_name)
   lu.assertTrue(ok, "extract should succeed: " .. tostring(err))
+  local after = unix.clock_gettime(unix.CLOCK_REALTIME)
 
   local extracted_file = path.join(self.dest, self.tool_name)
   lu.assertTrue(file_exists(extracted_file))
 
-  local archive_stat = unix.stat(self.archive)
   local extracted_stat = unix.stat(extracted_file)
-  local archive_sec, archive_nsec = archive_stat:mtim()
-  local extracted_sec, extracted_nsec = extracted_stat:mtim()
-  lu.assertEquals(extracted_sec, archive_sec, "mtime seconds should match archive file")
-  lu.assertEquals(extracted_nsec, archive_nsec, "mtime nanoseconds should match archive file")
+  local extracted_sec = extracted_stat:mtim()
+  lu.assertTrue(extracted_sec >= before, "mtime should be >= before extraction")
+  lu.assertTrue(extracted_sec <= after, "mtime should be <= after extraction")
 end


### PR DESCRIPTION
Extracted files now have their modification times set to the current time when extraction completes. This prevents make from unnecessarily rebuilding targets, even when extract.lua is modified, since extracted files are always newer than all dependencies.

- lib/build/extract.lua - added set_mtime_recursive using cosmic.walk, sets all extracted files to current time
- lib/build/test_extract.lua - updated tests to verify mtimes are set to current time

## Key decisions

- **Current time vs archive mtime**: Using current time ensures extracted files are newer than both the archive and extract.lua, preventing continuous rebuilds when the extraction script changes
- **Centralized in main()**: Individual extractors (zip, tar.gz, gz) focus on extraction only; mtime setting happens once in main() for all formats
- **cosmic.walk**: Used for clean, efficient directory traversal instead of manual recursion

## Validation

- [x] tests pass
- [x] linter passes
- [x] verified no rebuilds when extract.lua changes
- [x] confirmed no unnecessary rebuilds on repeated make check