### PR TITLE
test: capture stdout and stderr in test output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ $(o)/%/.staged: $(o)/%/.fetched
 all_tests := $(foreach x,$(modules),$($(x)_tests))
 all_tested := $(patsubst %,o/%.tested,$(all_tests))
 test: $(all_tested)
+	@$(test_reporter) $(o)
 
 $(o)/test-results.txt: $(all_tested)
 	@for f in $^; do echo "$${f%.tested}: $$(cat $$f)"; done > $@

--- a/lib/test/cook.mk
+++ b/lib/test/cook.mk
@@ -1,8 +1,10 @@
 modules += test
 test_run := $(o)/bin/run-test.lua
-test_files := $(test_run)
+test_report := $(o)/bin/report-test.lua
+test_files := $(test_run) $(test_report)
 test_tests := $(wildcard lib/test/test_*.lua)
 
-.PRECIOUS: $(test_run)
+.PRECIOUS: $(test_run) $(test_report)
 test_runner := $(bootstrap_cosmic) $(test_run)
+test_reporter := $(bootstrap_cosmic) $(test_report)
 

--- a/lib/test/report-test.lua
+++ b/lib/test/report-test.lua
@@ -35,9 +35,11 @@ local function main(test_dir)
     skip = {},
     ignore = {},
   }
+  local all_results = {}
 
   -- find all .tested files
   local tested_files = walk.collect(test_dir, "%.tested$")
+  table.sort(tested_files)
   for _, file in ipairs(tested_files) do
     local content = cosmo.Slurp(file)
     if content then
@@ -46,6 +48,7 @@ local function main(test_dir)
         local test_name = file:gsub("^o/", ""):gsub("%.tested$", "")
         result.name = test_name
         result.file = file
+        table.insert(all_results, result)
 
         local status = result.status
         if status == "pass" then
@@ -59,6 +62,13 @@ local function main(test_dir)
         end
       end
     end
+  end
+
+  -- print each test result with padded status
+  for _, result in ipairs(all_results) do
+    local status = string.upper(result.status)
+    local padded = string.format("%-6s", status)
+    print(padded .. " " .. result.name)
   end
 
   -- print summary

--- a/lib/test/report-test.lua
+++ b/lib/test/report-test.lua
@@ -1,0 +1,103 @@
+#!/usr/bin/env lua
+
+local cosmo = require("cosmo")
+local walk = require("cosmic.walk")
+local path = require("cosmo.path")
+
+local function parse_test_result(content)
+  local result = {}
+
+  -- first line is result: optional message
+  local first_line = content:match("^([^\n]+)")
+  if not first_line then
+    return nil
+  end
+
+  local status, message = first_line:match("^(%w+):?%s*(.*)")
+  result.status = status or first_line
+  result.message = message ~= "" and message or nil
+
+  -- extract stdout section
+  result.stdout = content:match("## stdout\n\n(.-)\n## stderr") or ""
+
+  -- extract stderr section
+  result.stderr = content:match("## stderr\n\n(.*)$") or ""
+
+  return result
+end
+
+local function main(test_dir)
+  test_dir = test_dir or "o"
+
+  local results = {
+    pass = {},
+    fail = {},
+    skip = {},
+    ignore = {},
+  }
+
+  -- find all .tested files
+  local tested_files = walk.collect(test_dir, "%.tested$")
+  for _, file in ipairs(tested_files) do
+    local content = cosmo.Slurp(file)
+    if content then
+      local result = parse_test_result(content)
+      if result then
+        local test_name = file:gsub("^o/", ""):gsub("%.tested$", "")
+        result.name = test_name
+        result.file = file
+
+        local status = result.status
+        if status == "pass" then
+          table.insert(results.pass, result)
+        elseif status == "fail" then
+          table.insert(results.fail, result)
+        elseif status == "skip" then
+          table.insert(results.skip, result)
+        elseif status == "ignore" then
+          table.insert(results.ignore, result)
+        end
+      end
+    end
+  end
+
+  -- print summary
+  local total = #results.pass + #results.fail + #results.skip + #results.ignore
+  print(string.format(
+    "%d tests: %d passed, %d failed, %d skipped, %d ignored",
+    total,
+    #results.pass,
+    #results.fail,
+    #results.skip,
+    #results.ignore
+  ))
+
+  -- print failed tests with output
+  if #results.fail > 0 then
+    print("")
+    print("FAILURES:")
+    for _, result in ipairs(results.fail) do
+      print("")
+      print(string.format("--- %s ---", result.name))
+      if result.message then
+        print(result.message)
+      end
+      if result.stdout and result.stdout ~= "" then
+        print("")
+        print("stdout:")
+        print(result.stdout)
+      end
+      if result.stderr and result.stderr ~= "" then
+        print("")
+        print("stderr:")
+        print(result.stderr)
+      end
+    end
+  end
+
+  return #results.fail > 0 and 1 or 0
+end
+
+if cosmo.is_main() then
+  os.exit(main(...))
+end

--- a/lib/test/run-test.lua
+++ b/lib/test/run-test.lua
@@ -4,36 +4,108 @@ local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 
+local function run_test(test)
+  TEST_TMPDIR = unix.mkdtemp("/tmp/test_XXXXXX")
+  TEST_DIR = os.getenv("TEST_DIR")
+
+  -- create temp files for capturing output
+  local stdout_file = path.join(TEST_TMPDIR, "stdout")
+  local stderr_file = path.join(TEST_TMPDIR, "stderr")
+
+  -- save original fds (dup returns lowest available fd, so these go to 3+)
+  local orig_stdout = unix.dup(1)
+  local orig_stderr = unix.dup(2)
+
+  -- open capture files
+  local stdout_fd = unix.open(stdout_file, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("644", 8))
+  local stderr_fd = unix.open(stderr_file, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("644", 8))
+
+  -- redirect stdout: close fd 1, then dup stdout_fd (becomes 1)
+  unix.close(1)
+  unix.dup(stdout_fd)
+  unix.close(stdout_fd)
+
+  -- redirect stderr: close fd 2, then dup stderr_fd (becomes 2)
+  unix.close(2)
+  unix.dup(stderr_fd)
+  unix.close(stderr_fd)
+
+  -- run the test
+  local ok, err = pcall(dofile, test)
+
+  -- flush lua's io buffers before restoring fds
+  io.stdout:flush()
+  io.stderr:flush()
+
+  -- restore stdout: close fd 1, dup orig_stdout (becomes 1)
+  unix.close(1)
+  unix.dup(orig_stdout)
+  unix.close(orig_stdout)
+
+  -- restore stderr: close fd 2, dup orig_stderr (becomes 2)
+  unix.close(2)
+  unix.dup(orig_stderr)
+  unix.close(orig_stderr)
+
+  -- read captured output
+  local stdout = cosmo.Slurp(stdout_file) or ""
+  local stderr = cosmo.Slurp(stderr_file) or ""
+
+  unix.rmrf(TEST_TMPDIR)
+
+  return ok, err, stdout, stderr
+end
+
+local function format_output(result, message, stdout, stderr)
+  local lines = {}
+  if message and message ~= "" then
+    table.insert(lines, result .. ": " .. message)
+  else
+    table.insert(lines, result)
+  end
+  table.insert(lines, "")
+  table.insert(lines, "## stdout")
+  table.insert(lines, "")
+  table.insert(lines, stdout)
+  table.insert(lines, "## stderr")
+  table.insert(lines, "")
+  table.insert(lines, stderr)
+  return table.concat(lines, "\n")
+end
+
 local function main(test, out)
   if not test or not out then
-    return 1, "usage: run-test.lua <test> <out.ok>"
+    return 1, "usage: run-test.lua <test> <out>"
   end
 
   unix.makedirs(path.dirname(out))
 
-  TEST_TMPDIR = unix.mkdtemp("/tmp/test_XXXXXX")
-  TEST_DIR = os.getenv("TEST_DIR")
+  local ok, err, stdout, stderr = run_test(test)
 
-  local ok, err = pcall(dofile, test)
-  unix.rmrf(TEST_TMPDIR)
-
-  if not ok then
-    local msg = tostring(err)
-    -- check for SKIP prefix in assertion message
-    local skip_reason = msg:match("SKIP%s+(.+)")
+  local result, message
+  if ok then
+    result = "pass"
+    io.stderr:write("PASS " .. test .. "\n")
+  else
+    local err_str = tostring(err)
+    -- check for SKIP in error message
+    local skip_reason = err_str:match("SKIP%s+(.+)")
     if skip_reason then
-      cosmo.Barf(out, "skip: " .. skip_reason .. "\n")
+      result = "skip"
+      message = skip_reason
       io.stderr:write("SKIP " .. test .. " (" .. skip_reason .. ")\n")
-      return 0
+    else
+      result = "fail"
+      -- strip path prefix to show just filename:line: message
+      message = err_str:gsub("^.-/([^/]+:%d+:)", "%1")
+      io.stderr:write("FAIL " .. test .. "\n")
+      io.stderr:write("     " .. message .. "\n")
+      cosmo.Barf(out, format_output(result, message, stdout, stderr))
+      return 1
     end
-    -- strip path prefix to show just filename:line: message
-    local short = msg:gsub("^.-/([^/]+:%d+:)", "%1")
-    return 1, "FAIL " .. test .. "\n     " .. short
   end
 
-  cosmo.Barf(out, "ok\n")
-  io.stderr:write("PASS " .. test .. "\n")
-
+  cosmo.Barf(out, format_output(result, message, stdout, stderr))
   return 0
 end
 

--- a/lib/test/run-test.lua
+++ b/lib/test/run-test.lua
@@ -85,7 +85,6 @@ local function main(test, out)
   local result, message
   if ok then
     result = "pass"
-    io.stderr:write("PASS " .. test .. "\n")
   else
     local err_str = tostring(err)
     -- check for SKIP in error message
@@ -93,13 +92,10 @@ local function main(test, out)
     if skip_reason then
       result = "skip"
       message = skip_reason
-      io.stderr:write("SKIP " .. test .. " (" .. skip_reason .. ")\n")
     else
       result = "fail"
       -- strip path prefix to show just filename:line: message
       message = err_str:gsub("^.-/([^/]+:%d+:)", "%1")
-      io.stderr:write("FAIL " .. test .. "\n")
-      io.stderr:write("     " .. message .. "\n")
       cosmo.Barf(out, format_output(result, message, stdout, stderr))
       return 1
     end


### PR DESCRIPTION
- Modified run-test.lua to spawn tests as subprocesses and capture their
  stdout/stderr output
- Test result files now include structured output:
  (result): optional message
  ## stdout
  ## stderr
- Added report-test.lua script that summarizes test results and prints
  detailed output for failures
- Updated Makefile to run report-test.lua at the end of make test