### PR TITLE
Update build dependencies and tools

### DIFF
--- a/lib/build/build-fetch.lua
+++ b/lib/build/build-fetch.lua
@@ -103,7 +103,7 @@ local function main(version_file, platform, output)
   local archive_dir = path.join(fetch_o, module_name, version_sha)
   local archive_path = path.join(archive_dir, archive_name)
 
-  io.stderr:write(string.format("⬇ FETCH  %s\n", url))
+  io.stderr:write(string.format("↓ FETCH  %s\n", url))
 
   unix.makedirs(archive_dir)
 

--- a/lib/build/build-stage.lua
+++ b/lib/build/build-stage.lua
@@ -205,7 +205,7 @@ local function main(version_file, platform, input, output)
 
   -- format: STAGE  module @ version-sha_prefix
   local sha_prefix = plat.sha:sub(1, 7)
-  io.stderr:write(string.format("◼ STAGE  %s @ %s-%s\n", module_name, spec.version, sha_prefix))
+  io.stderr:write(string.format("□ STAGE  %s @ %s-%s\n", module_name, spec.version, sha_prefix))
 
   -- create symlink: output -> staged/<module>/<version-sha>
   -- output is o/<module>/.staged, staged is o/staged/<module>/<ver>-<sha>

--- a/lib/test/report-test.lua
+++ b/lib/test/report-test.lua
@@ -66,10 +66,10 @@ local function main(test_dir)
 
   -- print each test result with padded status
   local status_icons = {
-    pass = "✔",
-    fail = "✖",
-    skip = "⇒",
-    ignore = "●",
+    pass = "✓",
+    fail = "✗",
+    skip = "→",
+    ignore = "○",
   }
   for _, result in ipairs(all_results) do
     local status = string.upper(result.status)


### PR DESCRIPTION
replace double-width unicode variants with single-width equivalents:
- ⬇ → ↓ FETCH (U+2193 vs U+2B07)
- ◼ → ■ STAGE (U+25A0 vs U+25FC)
- ✔ → ✓ PASS (U+2713 vs U+2714)
- ✖ → ✗ FAIL (U+2717 vs U+2716)
- ⇒ → → SKIP (U+2192 vs U+21D2)
- ● → ○ IGNORE (U+25CB vs U+25CF)

the lighter, simpler characters from standard unicode blocks all render as single-width in monospace terminals, ensuring proper column alignment