### PR TITLE
build: fix make test and check idempotency

### DIFF
--- a/.github/pr/231.md
+++ b/.github/pr/231.md
@@ -1,0 +1,33 @@
+# build: fix make test and check idempotency
+
+Fixed `make test` and `make check` to be truly idempotent - second runs now do no work and produce no output.
+
+## Changes
+
+- **Makefile**: Removed `.PHONY` from test/check/astgrep/luacheck/teal targets, made them depend on concrete summary files
+- **3p/tl/cook.mk**: Removed unbuildable files (o/bin/tl, o/lib/tl.lua) from tl_files that were causing constant rebuilds
+
+## Details
+
+The test and check targets were marked as `.PHONY`, causing their reporters to always run and print all results even when no tests/checks needed to re-run. While the actual tests/checks weren't re-running (their .tested/.checked files were up-to-date), the reporters always executed because the targets were phony.
+
+The `tl` module was defining `tl_files` to include `$(o)/bin/tl` and `$(o)/lib/tl.lua` without build rules, causing all .checked files that depended on these (via `$(tl_files)`) to always rebuild.
+
+## Results
+
+Before:
+- `make test; make test` → 38s, then 0.18s (printed all test results both times)
+- `make check; make check` → 40s, then 3.2s (printed all check results both times)
+
+After:
+- `make test; make test` → 38s, then 0.18s (no output on second run)
+- `make check; make check` → 40s, then 0.2s (no output on second run)
+
+## Validation
+
+- [x] `make test; make test` produces no output second run
+- [x] `make check; make check` produces no output second run
+- [x] Tests re-run when test file touched
+- [x] Checks re-run when source file touched
+- [x] All tests pass
+- [x] All checks pass

--- a/3p/tl/cook.mk
+++ b/3p/tl/cook.mk
@@ -2,7 +2,7 @@ modules += tl
 tl_version := 3p/tl/version.lua
 tl_run := $(o)/bin/run-teal.lua
 tl_report := $(o)/bin/report-teal.lua
-tl_files := $(o)/bin/tl $(o)/lib/tl.lua $(tl_run) $(tl_report)
+tl_files := $(tl_run) $(tl_report)
 tl_tests := $(wildcard 3p/tl/test_*.lua)
 tl_deps := argparse cosmos
 

--- a/Makefile
+++ b/Makefile
@@ -103,15 +103,17 @@ staged: $(all_staged)
 $(o)/%/.staged: $(o)/%/.fetched
 	@$(build_stage) $$(readlink $(o)/$*/.versioned) $(platform) $< $@
 
-.PHONY: test
 all_tests := $(foreach x,$(modules),$($(x)_tests))
 ifdef TEST
   # filter tests by pattern (substring match)
   all_tests := $(foreach t,$(all_tests),$(if $(findstring $(TEST),$(t)),$(t)))
 endif
 all_tested := $(patsubst %,o/%.tested,$(all_tests))
-test: $(all_tested)
-	@$(test_reporter) $(o)
+
+test: $(o)/test-summary.txt
+
+$(o)/test-summary.txt: $(all_tested)
+	@$(test_reporter) $(o) | tee $@
 
 $(o)/test-results.txt: $(all_tested)
 	@for f in $^; do echo "$${f%.tested}: $$(cat $$f)"; done > $@

--- a/Makefile
+++ b/Makefile
@@ -139,27 +139,33 @@ $(foreach m,$(filter-out bootstrap,$(modules)),\
       $(eval $(patsubst %,$(o)/%.tested,$($(m)_tests)): $($(d)_staged))\
       $(eval $(patsubst %,$(o)/%.tested,$($(m)_tests)): TEST_DEPS += $($(d)_staged)))))
 
-.PHONY: astgrep
 all_built_files := $(foreach x,$(modules),$($(x)_files))
 all_astgreps := $(patsubst %,%.astgrep.checked,$(all_built_files))
-astgrep: $(all_astgreps)
-	@$(astgrep_reporter) $(o)
+
+astgrep: $(o)/astgrep-summary.txt
+
+$(o)/astgrep-summary.txt: $(all_astgreps)
+	@$(astgrep_reporter) $(o) | tee $@
 
 $(o)/%.astgrep.checked: $(o)/% $(ast-grep_files) | $(bootstrap_files) $(ast-grep_staged)
 	@ASTGREP_BIN=$(ast-grep_staged) $(astgrep_runner) $< $@
 
-.PHONY: luacheck
 all_luachecks := $(patsubst %,%.luacheck.checked,$(all_built_files))
-luacheck: $(all_luachecks)
-	@$(luacheck_reporter) $(o)
+
+luacheck: $(o)/luacheck-summary.txt
+
+$(o)/luacheck-summary.txt: $(all_luachecks)
+	@$(luacheck_reporter) $(o) | tee $@
 
 $(o)/%.luacheck.checked: $(o)/% $(luacheck_files) | $(bootstrap_files) $(luacheck_staged)
 	@LUACHECK_BIN=$(luacheck_staged) $(luacheck_runner) $< $@
 
-.PHONY: teal
 all_teals := $(patsubst %,%.teal.checked,$(all_built_files))
-teal: $(all_teals)
-	@$(teal_reporter) $(o)
+
+teal: $(o)/teal-summary.txt
+
+$(o)/teal-summary.txt: $(all_teals)
+	@$(teal_reporter) $(o) | tee $@
 
 $(o)/%.teal.checked: $(o)/% $(tl_files) | $(bootstrap_files) $(tl_staged)
 	@TL_BIN=$(tl_staged) $(teal_runner) $< $@
@@ -174,10 +180,12 @@ bootstrap: $(bootstrap_files)
 clean:
 	@rm -rf $(o)
 
-.PHONY: check
 all_checks := $(all_astgreps) $(all_luachecks) $(all_teals)
-check: $(all_checks)
-	@$(check_reporter) $(o)
+
+check: $(o)/check-summary.txt
+
+$(o)/check-summary.txt: $(all_checks)
+	@$(check_reporter) $(o) | tee $@
 
 # Update PR title/description from .github/pr/<number>.md
 .PHONY: update-pr


### PR DESCRIPTION
Fixed `make test` and `make check` to be truly idempotent - second runs now do no work and produce no output.

## Changes

- **Makefile**: Removed `.PHONY` from test/check/astgrep/luacheck/teal targets, made them depend on concrete summary files
- **3p/tl/cook.mk**: Removed unbuildable files (o/bin/tl, o/lib/tl.lua) from tl_files that were causing constant rebuilds

## Details

The test and check targets were marked as `.PHONY`, causing their reporters to always run and print all results even when no tests/checks needed to re-run. While the actual tests/checks weren't re-running (their .tested/.checked files were up-to-date), the reporters always executed because the targets were phony.

The `tl` module was defining `tl_files` to include `$(o)/bin/tl` and `$(o)/lib/tl.lua` without build rules, causing all .checked files that depended on these (via `$(tl_files)`) to always rebuild.

## Results

Before:
- `make test; make test` → 38s, then 0.18s (printed all test results both times)
- `make check; make check` → 40s, then 3.2s (printed all check results both times)

After:
- `make test; make test` → 38s, then 0.18s (no output on second run)
- `make check; make check` → 40s, then 0.2s (no output on second run)

## Validation

- [x] `make test; make test` produces no output second run
- [x] `make check; make check` produces no output second run
- [x] Tests re-run when test file touched
- [x] Checks re-run when source file touched
- [x] All tests pass
- [x] All checks pass

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-04T01:54:22Z
</details>