### PR TITLE
workflows: skip pr-update when file missing

### DIFF
--- a/.github/workflows/pr-update.yml
+++ b/.github/workflows/pr-update.yml
@@ -14,7 +14,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
+      - name: Check if PR file exists
+        id: check-pr-file
+        run: |
+          [ -f ".github/pr/${{ github.event.number }}.md" ] && \
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+
       - name: Update PR
+        if: steps.check-pr-file.outputs.exists == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
Skip the pr-update workflow step when there's no `.github/pr/<number>.md` file for the PR.

- Adds a check step that only sets `exists=true` output if the file exists
- Makes the update step conditional on that check
- Saves CI resources by not running `make update-pr` when there's nothing to update

The workflow still runs and provides feedback, it just skips the actual update step when the PR file doesn't exist.