### PR TITLE
cosmic: refactor argparsing to use cosmo.getopt

### DIFF
--- a/.github/pr/240.md
+++ b/.github/pr/240.md
@@ -1,0 +1,19 @@
+# cosmic: refactor argparsing to use cosmo.getopt
+
+Updates cosmos to 2026.01.04-f203f0e50 which includes the `cosmo.getopt` module, and refactors lib/cosmic/main.lua to use it for parsing command-line arguments.
+
+## Changes
+
+- 3p/cosmos/version.lua - update to 2026.01.04-f203f0e50 (includes cosmo.getopt)
+- lib/cosmic/main.lua - refactor parse_args() to use cosmo.getopt.parse()
+  - Uses getopt for single flags: -i, -v, -E, -W
+  - Manually collects -e and -l options (which can appear multiple times)
+  - Preserves special handling for --help and --skill via pre-scan
+  - Reduces code complexity while maintaining all functionality
+
+## Validation
+
+- [x] all tests pass (33 passed, 0 failed, 1 skipped)
+- [x] verified -e, -l, -v, -i options work correctly
+- [x] verified multiple -e and -l options work
+- [x] verified --help and --skill work as expected

--- a/.github/pr/240.md
+++ b/.github/pr/240.md
@@ -5,15 +5,15 @@ Updates cosmos to 2026.01.04-f203f0e50 which includes the `cosmo.getopt` module,
 ## Changes
 
 - 3p/cosmos/version.lua - update to 2026.01.04-f203f0e50 (includes cosmo.getopt)
-- lib/cosmic/main.lua - refactor parse_args() to use cosmo.getopt.parse()
-  - Uses getopt with longopts table for all options including --help and --skill
-  - Manually collects -e and -l options (which can appear multiple times)
+- lib/cosmic/main.lua - refactor parse_args() to use cosmo.getopt.new() iterator API
+  - Uses getopt.new() to create a parser that iterates through options one by one
+  - Naturally handles multiple -e and -l options without manual scanning
+  - Single unified loop for all option processing
   - Supports both --help and --help=module syntax
-  - Cleaner single-pass parsing, no pre-scanning needed
+  - Cleaner, more idiomatic option parsing
 
 ## Validation
 
-- [x] all tests pass (33 passed, 0 failed, 1 skipped)
-- [x] verified -e, -l, -v, -i options work correctly
-- [x] verified multiple -e and -l options work
-- [x] verified --help and --skill work as expected
+- [ ] awaiting cosmos release with iterator API (commit bc03f9a)
+- [ ] will test once cosmos is updated to include getopt.new()
+- Code is refactored to use the new iterator API in anticipation of the release

--- a/.github/pr/240.md
+++ b/.github/pr/240.md
@@ -1,10 +1,10 @@
 # cosmic: refactor argparsing to use cosmo.getopt
 
-Updates cosmos to 2026.01.04-f203f0e50 which includes the `cosmo.getopt` module, and refactors lib/cosmic/main.lua to use it for parsing command-line arguments.
+Updates cosmos to 2026.01.04-bc03f9aa8 which includes the `cosmo.getopt` module with iterator API, and refactors lib/cosmic/main.lua to use it for parsing command-line arguments.
 
 ## Changes
 
-- 3p/cosmos/version.lua - update to 2026.01.04-f203f0e50 (includes cosmo.getopt)
+- 3p/cosmos/version.lua - update to 2026.01.04-bc03f9aa8 (includes getopt.new() iterator API)
 - lib/cosmic/main.lua - refactor parse_args() to use cosmo.getopt.new() iterator API
   - Uses getopt.new() to create a parser that iterates through options one by one
   - Naturally handles multiple -e and -l options without manual scanning
@@ -14,6 +14,7 @@ Updates cosmos to 2026.01.04-f203f0e50 which includes the `cosmo.getopt` module,
 
 ## Validation
 
-- [ ] awaiting cosmos release with iterator API (commit bc03f9a)
-- [ ] will test once cosmos is updated to include getopt.new()
-- Code is refactored to use the new iterator API in anticipation of the release
+- [x] all tests pass (33 passed, 0 failed, 1 skipped)
+- [x] verified iterator API collects multiple -e and -l options correctly
+- [x] verified --help and --skill work as expected
+- [x] verified all standard lua options (-i, -v, -E, -W) work

--- a/.github/pr/240.md
+++ b/.github/pr/240.md
@@ -6,10 +6,10 @@ Updates cosmos to 2026.01.04-f203f0e50 which includes the `cosmo.getopt` module,
 
 - 3p/cosmos/version.lua - update to 2026.01.04-f203f0e50 (includes cosmo.getopt)
 - lib/cosmic/main.lua - refactor parse_args() to use cosmo.getopt.parse()
-  - Uses getopt for single flags: -i, -v, -E, -W
+  - Uses getopt with longopts table for all options including --help and --skill
   - Manually collects -e and -l options (which can appear multiple times)
-  - Preserves special handling for --help and --skill via pre-scan
-  - Reduces code complexity while maintaining all functionality
+  - Supports both --help and --help=module syntax
+  - Cleaner single-pass parsing, no pre-scanning needed
 
 ## Validation
 

--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -2,8 +2,8 @@ return {
   format = "zip",
   strip_components = 0,
   platforms = {
-    ["*"] = { sha = "cd2f368b51a3cbfc0eb2f1994a141bdd0c0c36160b5621cfec9b521a8febd63f" },
+    ["*"] = { sha = "7ab711854b92123578bac1b93160258245abab4c73fd09e751ebc136936ed126" },
   },
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.01.04-f203f0e50",
+  version = "2026.01.04-bc03f9aa8",
 }

--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -2,8 +2,8 @@ return {
   format = "zip",
   strip_components = 0,
   platforms = {
-    ["*"] = { sha = "0961617e409bc09eff6b58e5b7206aea2437a527c68169695e05fdf21cdf17c3" },
+    ["*"] = { sha = "cd2f368b51a3cbfc0eb2f1994a141bdd0c0c36160b5621cfec9b521a8febd63f" },
   },
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.01.02-248b4d9b3",
+  version = "2026.01.04-f203f0e50",
 }


### PR DESCRIPTION
Updates cosmos to 2026.01.04-bc03f9aa8 which includes the `cosmo.getopt` module with iterator API, and refactors lib/cosmic/main.lua to use it for parsing command-line arguments.

## Changes

- 3p/cosmos/version.lua - update to 2026.01.04-bc03f9aa8 (includes getopt.new() iterator API)
- lib/cosmic/main.lua - refactor parse_args() to use cosmo.getopt.new() iterator API
  - Uses getopt.new() to create a parser that iterates through options one by one
  - Naturally handles multiple -e and -l options without manual scanning
  - Single unified loop for all option processing
  - Supports both --help and --help=module syntax
  - Cleaner, more idiomatic option parsing

## Validation

- [x] all tests pass (33 passed, 0 failed, 1 skipped)
- [x] verified iterator API collects multiple -e and -l options correctly
- [x] verified --help and --skill work as expected
- [x] verified all standard lua options (-i, -v, -E, -W) work

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-04T18:05:56Z
</details>