### PR TITLE
Generate Makefile targets from version files

### DIFF
--- a/3p/luacheck/version.lua
+++ b/3p/luacheck/version.lua
@@ -1,3 +1,4 @@
+-- update ignore: archived project
 return {
   version = "1.2.0",
   format = "tar.gz",

--- a/3p/nvim-lspconfig/version.lua
+++ b/3p/nvim-lspconfig/version.lua
@@ -1,3 +1,4 @@
+-- update ignore: commit-based versioning
 return {
   version = "41d32cc",
   format = "tar.gz",

--- a/3p/nvim-treesitter/version.lua
+++ b/3p/nvim-treesitter/version.lua
@@ -1,3 +1,4 @@
+-- update ignore: commit-based versioning
 return {
   version = "36fcb4a4",
   format = "tar.gz",

--- a/3p/nvim/version.lua
+++ b/3p/nvim/version.lua
@@ -1,3 +1,4 @@
+-- update ignore: custom fork
 return {
   version = "0.12.0-dev-49450c182c",
   date = "2025.12.28",

--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ $(o)/check-summary.txt: $(all_checks)
 update: $(o)/update-summary.txt
 
 $(o)/update-summary.txt: $(all_updated)
-	@$(update_reporter) $(o) | tee $@
+	@$(update_reporter) $(all_updated) | tee $@
 
 $(o)/%.updated: % $(build_check_update) | $(bootstrap_files)
 	@$(update_runner) $< $@

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ $(foreach m,$(filter-out $(default_deps),$(modules)),\
       $(eval $($(m)_files): $($(d)_staged)))))
 
 all_versions := $(foreach x,$(modules),$($(x)_version))
+all_updated := $(patsubst %,$(o)/%.updated,$(all_versions))
 
 # versioned modules: o/module/.versioned -> version.lua
 $(foreach m,$(modules),$(if $($(m)_version),\
@@ -196,6 +197,14 @@ check: $(o)/check-summary.txt
 
 $(o)/check-summary.txt: $(all_checks)
 	@$(check_reporter) $(o) | tee $@
+
+update: $(o)/update-summary.txt
+
+$(o)/update-summary.txt: $(all_updated)
+	@$(update_reporter) $(o) | tee $@
+
+$(o)/%.updated: % $(build_check_update) | $(bootstrap_files)
+	@$(update_runner) $< $@
 
 # Update PR title/description from .github/pr/<number>.md
 .PHONY: update-pr

--- a/lib/build/check-update.lua
+++ b/lib/build/check-update.lua
@@ -54,6 +54,17 @@ local function main(version_file, output_file)
     return 1
   end
 
+  local _, skip_reason = common.check_first_lines(version_file, {
+    shebangs = {},
+    ignore = "^%-%-%s*update%s+ignore:%s*(.*)",
+  })
+
+  if skip_reason then
+    unix.makedirs(path.dirname(output_file))
+    cosmo.Barf(output_file, common.format_output("skip", skip_reason, "", ""))
+    return 0
+  end
+
   local chunk, err = load(content, version_file)
   if not chunk then
     unix.makedirs(path.dirname(output_file))
@@ -79,7 +90,7 @@ local function main(version_file, output_file)
 
   local status, message, stdout, stderr
   if not latest_version then
-    status = "ignore"
+    status = "fail"
     message = check_err or "could not check"
     stdout = ""
     stderr = ""

--- a/lib/build/check-update.lua
+++ b/lib/build/check-update.lua
@@ -1,0 +1,106 @@
+#!/usr/bin/env lua
+
+local cosmo = require("cosmo")
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+local common = require("checker.common")
+
+local function fetch_json(url)
+  local status, _, body = cosmo.Fetch(url, {
+    headers = {["User-Agent"] = "curl/8.0", ["Accept"] = "application/vnd.github+json"},
+  })
+  if status ~= 200 then
+    return nil, "fetch failed: " .. tostring(status)
+  end
+  return cosmo.DecodeJson(body)
+end
+
+local function extract_github_repo(url)
+  local owner, repo = url:match("github%.com/([^/]+)/([^/]+)")
+  if owner and repo then
+    return string.format("%s/%s", owner, repo)
+  end
+  return nil
+end
+
+local function check_latest_version(config)
+  local repo = extract_github_repo(config.url)
+  if not repo then
+    return nil, "not a GitHub URL"
+  end
+
+  local api_url = "https://api.github.com/repos/" .. repo .. "/releases/latest"
+  local release, err = fetch_json(api_url)
+  if not release then
+    return nil, err
+  end
+
+  local version = release.tag_name
+  local version_clean = version:gsub("^v", "")
+
+  return version_clean
+end
+
+local function main(version_file, output_file)
+  if not version_file or not output_file then
+    io.stderr:write("usage: check-update.lua <version_file> <output_file>\n")
+    return 1
+  end
+
+  local content = cosmo.Slurp(version_file)
+  if not content then
+    unix.makedirs(path.dirname(output_file))
+    cosmo.Barf(output_file, common.format_output("fail", "could not read file", "", ""))
+    return 1
+  end
+
+  local chunk, err = load(content, version_file)
+  if not chunk then
+    unix.makedirs(path.dirname(output_file))
+    cosmo.Barf(output_file, common.format_output("fail", "could not parse: " .. tostring(err), "", ""))
+    return 1
+  end
+
+  local ok, config = pcall(chunk)
+  if not ok then
+    unix.makedirs(path.dirname(output_file))
+    cosmo.Barf(output_file, common.format_output("fail", "could not load: " .. tostring(config), "", ""))
+    return 1
+  end
+
+  local current_version = config.version
+  if not current_version then
+    unix.makedirs(path.dirname(output_file))
+    cosmo.Barf(output_file, common.format_output("fail", "no version field", "", ""))
+    return 1
+  end
+
+  local latest_version, check_err = check_latest_version(config)
+
+  local status, message, stdout, stderr
+  if not latest_version then
+    status = "ignore"
+    message = check_err or "could not check"
+    stdout = ""
+    stderr = ""
+  elseif latest_version == current_version then
+    status = "pass"
+    message = current_version
+    stdout = ""
+    stderr = ""
+  else
+    status = "skip"
+    message = current_version .. " -> " .. latest_version
+    stdout = ""
+    stderr = ""
+  end
+
+  unix.makedirs(path.dirname(output_file))
+  cosmo.Barf(output_file, common.format_output(status, message, stdout, stderr))
+
+  return 0
+end
+
+if cosmo.is_main() then
+  os.exit(main(...))
+end

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -2,7 +2,11 @@ modules += build
 build_fetch := $(o)/bin/build-fetch.lua
 build_stage := $(o)/bin/build-stage.lua
 build_check_report := $(o)/bin/check-report.lua
-build_files := $(build_fetch) $(build_stage) $(build_check_report)
+build_check_update := $(o)/bin/check-update.lua
+build_report_update := $(o)/bin/report-update.lua
+build_files := $(build_fetch) $(build_stage) $(build_check_report) $(build_check_update) $(build_report_update)
 
 .PRECIOUS: $(build_files)
 check_reporter := $(bootstrap_cosmic) $(build_check_report)
+update_runner := $(bootstrap_cosmic) $(build_check_update)
+update_reporter := $(bootstrap_cosmic) $(build_report_update)

--- a/lib/build/report-update.lua
+++ b/lib/build/report-update.lua
@@ -1,0 +1,71 @@
+#!/usr/bin/env lua
+
+local cosmo = require("cosmo")
+local walk = require("cosmic.walk")
+local common = require("checker.common")
+
+local function main(output_dir)
+  output_dir = output_dir or "o"
+
+  local results = {
+    pass = {},
+    skip = {},
+    ignore = {},
+    fail = {},
+  }
+  local all_results = {}
+
+  local updated_files = walk.collect(output_dir, "%.updated$")
+  table.sort(updated_files)
+
+  for _, file in ipairs(updated_files) do
+    local content = cosmo.Slurp(file)
+    if content then
+      local result = common.parse_result(content)
+      if result then
+        local name = file:gsub("^o/", ""):gsub("%.updated$", "")
+        result.name = name
+        result.file = file
+        table.insert(all_results, result)
+
+        local status = result.status
+        if results[status] then
+          table.insert(results[status], result)
+        end
+      end
+    end
+  end
+
+  local status_icons = common.status_icons()
+  for _, result in ipairs(all_results) do
+    local status = string.upper(result.status)
+    local icon = status_icons[result.status] or " "
+    local padded = string.format("%-6s", status)
+    local line = icon .. " " .. padded .. " " .. result.name
+    if result.message then
+      if result.status == "skip" then
+        line = line .. " (updated: " .. result.message .. ")"
+      else
+        line = line .. " (" .. result.message .. ")"
+      end
+    elseif result.status == "skip" then
+      line = line .. " (updated)"
+    end
+    print(line)
+  end
+
+  local total = #results.pass + #results.skip + #results.ignore + #results.fail
+  local updates_available = #results.skip
+
+  print(string.format(
+    "%d checked, %d updates available",
+    total,
+    updates_available
+  ))
+
+  return 0
+end
+
+if cosmo.is_main() then
+  os.exit(main(...))
+end

--- a/lib/build/report-update.lua
+++ b/lib/build/report-update.lua
@@ -1,11 +1,14 @@
 #!/usr/bin/env lua
 
 local cosmo = require("cosmo")
-local walk = require("cosmic.walk")
 local common = require("checker.common")
 
-local function main(output_dir)
-  output_dir = output_dir or "o"
+local function main(...)
+  local files = {...}
+  if #files == 0 then
+    io.stderr:write("usage: report-update.lua <file.updated> ...\n")
+    return 1
+  end
 
   local results = {
     pass = {},
@@ -15,10 +18,9 @@ local function main(output_dir)
   }
   local all_results = {}
 
-  local updated_files = walk.collect(output_dir, "%.updated$")
-  table.sort(updated_files)
+  table.sort(files)
 
-  for _, file in ipairs(updated_files) do
+  for _, file in ipairs(files) do
     local content = cosmo.Slurp(file)
     if content then
       local result = common.parse_result(content)
@@ -63,7 +65,7 @@ local function main(output_dir)
     updates_available
   ))
 
-  return 0
+  return #results.fail > 0 and 1 or 0
 end
 
 if cosmo.is_main() then


### PR DESCRIPTION
Add new `make update` target to check for available updates across all version.lua files. Resurrects and adapts the version checking logic from commit 8504b52 (which was later removed) into a new checker-style workflow.

Key components:
- check-update.lua: Checks GitHub releases for latest versions
- report-update.lua: Summarizes update check results
- %.updated pattern rule: Generates o/%.updated files for each version.lua
- update target: Aggregates all checks into o/update-summary.txt

Output format matches test/check patterns:
- ✓ PASS: Version is up-to-date (shows current version)
- → SKIP: Update available (shows: old_ver -> new_ver)
- ○ IGNORE: Cannot check (not GitHub or fetch error)
- Summary: "N checked, M updates available"

Usage:
  make update              # check all version files
  make update; make update # verify incremental builds work

Benefits:
- Leverages make's dependency resolution (rebuilds only stale checks)
- No duplicate work if already checked
- Consistent with existing test/check workflows