### PR TITLE
release: embed platform metadata in home binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,13 @@ jobs:
           name: cosmic
           path: o/bin/cosmic
 
+      - id: upload-cosmos-zip
+        if: matrix.platform == 'linux-x86_64'
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        with:
+          name: cosmos-zip
+          path: o/cosmos/.staged/zip
+
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
       - id: make-check-test-build
         run: make check test build
 
+      - id: make-test-release
+        run: make test-release
+
       - id: upload-home
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -228,13 +228,20 @@ release:
 	@cp artifacts/home-linux-x86_64/home release/home
 	@cp artifacts/cosmic/cosmic release/cosmic-lua
 	@chmod +x release/*
-	@cd release && sha256sum * > SHA256SUMS && cat SHA256SUMS
+	@chmod +x artifacts/cosmos-zip/zip
 	@tag="home-$$(date -u +%Y-%m-%d)-$${GITHUB_SHA::7}"; \
+	base_url="https://github.com/$${GITHUB_REPOSITORY}/releases/download/$$tag"; \
+	LUA_PATH="lib/home/?.lua;;" ./release/cosmic-lua lib/home/gen-platforms.lua \
+		release/platforms "$$base_url" "$$tag" \
+		release/home-darwin-arm64 release/home-linux-arm64 release/home-linux-x86_64; \
+	cd release/platforms && ../../artifacts/cosmos-zip/zip -j ../home platforms.lua; \
+	cd release/platforms && ../../artifacts/cosmos-zip/zip -r ../home manifests; \
+	cd release && sha256sum home home-* cosmic-lua > SHA256SUMS && cat SHA256SUMS; \
 	gh release create "$$tag" \
 		$${PRERELEASE_FLAG} \
 		--title "home $$tag" \
 		--notes "## Home binaries\nPlatform-specific dotfiles and bundled tools.\n\n### Quick setup\n\`\`\`bash\ncurl -fsSL https://github.com/$${GITHUB_REPOSITORY}/releases/latest/download/home | sh\n\`\`\`" \
-		release/*
+		release/home release/home-* release/cosmic-lua release/SHA256SUMS
 
 debug-modules:
 	@echo $(modules)

--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,8 @@ release:
 		release/home-darwin-arm64 release/home-linux-arm64 release/home-linux-x86_64; \
 	cd release/platforms && ../../artifacts/cosmos-zip/zip -j ../home platforms.lua; \
 	cd release/platforms && ../../artifacts/cosmos-zip/zip -r ../home manifests; \
+	./release/home unpack --with-platform --dry-run /tmp/verify-release >/dev/null || \
+		{ echo "error: platform metadata verification failed" >&2; exit 1; }; \
 	cd release && sha256sum home home-* cosmic-lua > SHA256SUMS && cat SHA256SUMS; \
 	gh release create "$$tag" \
 		$${PRERELEASE_FLAG} \

--- a/Makefile
+++ b/Makefile
@@ -236,8 +236,6 @@ release:
 		release/home-darwin-arm64 release/home-linux-arm64 release/home-linux-x86_64; \
 	cd release/platforms && ../../artifacts/cosmos-zip/zip -j ../home platforms.lua; \
 	cd release/platforms && ../../artifacts/cosmos-zip/zip -r ../home manifests; \
-	./release/home unpack --with-platform --dry-run /tmp/verify-release >/dev/null || \
-		{ echo "error: platform metadata verification failed" >&2; exit 1; }; \
 	cd release && sha256sum home home-* cosmic-lua > SHA256SUMS && cat SHA256SUMS; \
 	gh release create "$$tag" \
 		$${PRERELEASE_FLAG} \

--- a/lib/home/cook.mk
+++ b/lib/home/cook.mk
@@ -4,6 +4,7 @@ home_libs := $(addprefix $(o)/,$(home_srcs))
 home_bin := $(o)/bin/home
 home_files := $(home_bin) $(home_libs)
 home_tests := lib/home/test_main.lua
+home_release_test := lib/home/test_release.lua
 
 # 3p tools to bundle (nvim handled specially for bundled version)
 home_3p_tools := ast-grep biome comrak delta duckdb gh luacheck marksman rg ruff shfmt sqruff stylua superhtml tree-sitter uv
@@ -48,3 +49,10 @@ $(home_bin): $(home_libs) $(o)/home/dotfiles.zip $$(cosmos_staged) $(cosmic_bin)
 home: $(home_bin)
 
 .PHONY: home
+
+# Release test verifies platform metadata can be embedded and used
+.PHONY: test-release
+test-release: $(o)/$(home_release_test).tested
+
+$(o)/$(home_release_test).tested: $(home_release_test) $(home_bin) $(cosmic_bin) $$(cosmos_staged) | $(bootstrap_files)
+	@TEST_RELEASE=1 TEST_DIR=$(home_bin) $< $@

--- a/lib/home/test_release.lua
+++ b/lib/home/test_release.lua
@@ -1,0 +1,81 @@
+#!/usr/bin/env run-test.lua
+-- teal ignore: test file
+-- ast-grep ignore: test file
+
+-- This test is slow and only needed for release validation
+assert(os.getenv("TEST_RELEASE"), "IGNORE: release validation test")
+
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+local spawn = require("cosmic.spawn")
+
+local home_bin = path.join(os.getenv("TEST_BIN"), "home")
+local cosmic_bin = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmos_zip = unix.realpath(path.join(os.getenv("TEST_O"), "cosmos/.staged/zip"))
+
+-- Create a release-like home binary with platform metadata
+local release_dir = path.join(TEST_TMPDIR, "release")
+local platforms_dir = path.join(release_dir, "platforms")
+local test_home = path.join(release_dir, "home")
+local test_asset = path.join(release_dir, "home-linux-x86_64")
+
+unix.makedirs(platforms_dir)
+
+-- Copy home binary (once as main, once as platform asset)
+local ok, err = spawn({ "cp", home_bin, test_home }):wait()
+assert(ok, "failed to copy home binary: " .. tostring(err))
+ok, err = spawn({ "cp", home_bin, test_asset }):wait()
+assert(ok, "failed to copy home asset: " .. tostring(err))
+
+-- Generate platform metadata
+local gen_platforms = "lib/home/gen-platforms.lua"
+
+-- Build env with LUA_PATH prepended (unix.environ returns array of "K=V" strings)
+local env = { "LUA_PATH=lib/home/?.lua;;" }
+for _, entry in ipairs(unix.environ()) do
+  if not entry:match("^LUA_PATH=") then
+    table.insert(env, entry)
+  end
+end
+
+local output
+local proc = spawn({
+  cosmic_bin, gen_platforms,
+  platforms_dir, "https://example.com/releases/test", "test-tag",
+  test_asset,
+}, { env = env })
+local stdout = proc.stdout:read()
+local stderr = proc.stderr:read()
+local exit_code = proc:wait()
+ok = exit_code == 0
+assert(ok, "gen-platforms failed (exit " .. tostring(exit_code) .. "): " .. tostring(stderr))
+
+-- Verify platforms.lua was generated
+local platforms_lua = path.join(platforms_dir, "platforms.lua")
+assert(unix.stat(platforms_lua), "platforms.lua not generated")
+
+-- Embed platforms.lua into test home binary
+ok, output = spawn({ cosmos_zip, "-j", test_home, platforms_lua }):read()
+assert(ok, "failed to embed platforms.lua: " .. tostring(output))
+
+-- Embed manifests directory (need to cd first since zip stores relative paths)
+proc = spawn({ "sh", "-c", "cd " .. platforms_dir .. " && " .. cosmos_zip .. " -r " .. test_home .. " manifests" })
+stdout = proc.stdout:read()
+stderr = proc.stderr:read()
+exit_code = proc:wait()
+ok = exit_code == 0
+assert(ok, "failed to embed manifests (exit " .. tostring(exit_code) .. "): " .. tostring(stderr) .. " | " .. tostring(stdout))
+
+-- Verify platforms.lua is in the binary
+ok, output = spawn({ "unzip", "-l", test_home }):read()
+assert(ok, "failed to list zip contents")
+assert(output:find("platforms%.lua"), "platforms.lua not found in binary")
+assert(output:find("manifests/"), "manifests/ not found in binary")
+
+-- Verify --with-platform works (dry-run)
+ok, output = spawn({ test_home, "unpack", "--with-platform", "--dry-run", TEST_TMPDIR }):read()
+assert(ok, "--with-platform failed: " .. tostring(output))
+
+-- Verify original binary without platform metadata fails
+ok, output = spawn({ home_bin, "unpack", "--with-platform", "--dry-run", TEST_TMPDIR }):read()
+assert(not ok, "original binary should fail with --with-platform")

--- a/lib/test/run-test.lua
+++ b/lib/test/run-test.lua
@@ -88,11 +88,15 @@ local function main(test, out)
     result = "pass"
   else
     local err_str = tostring(err)
-    -- check for SKIP in error message
-    local skip_reason = err_str:match("SKIP%s+(.+)")
+    -- check for SKIP or IGNORE in error message
+    local skip_reason = err_str:match("SKIP%s*:?%s*(.+)")
+    local ignore_reason = err_str:match("IGNORE%s*:?%s*(.+)")
     if skip_reason then
       result = "skip"
       message = skip_reason
+    elseif ignore_reason then
+      result = "ignore"
+      message = ignore_reason
     else
       result = "fail"
       -- strip path prefix to show just filename:line: message


### PR DESCRIPTION
## Summary
- Fix setup.sh failing with "no platform metadata available" on new hosts
- Generate platforms.lua and per-platform manifests during release
- Embed metadata into the main home binary using cosmos zip tool

## Test plan
- [x] Verified locally that home binary with embedded platforms.lua works with `--with-platform`
- [x] Confirmed original home binary fails with "no platform metadata available"
- [x] `run-test lib/home/test_main.lua` passes