### PR TITLE
nvim: use packadd for bundled plugins

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -5,11 +5,11 @@
 local home = vim.fn.expand("~")
 package.path = home .. "/lib/?.lua;" .. home .. "/lib/3p/?.lua;" .. package.path
 
--- Add bundled site directory (relative to nvim binary) to runtimepath
+-- Add bundled site directory (relative to nvim binary) to packpath
 local version_dir = vim.fn.fnamemodify(vim.v.progpath, ":h:h")
 local bundled_site = version_dir .. "/share/nvim/site"
 if vim.fn.isdirectory(bundled_site) == 1 then
-  vim.opt.runtimepath:prepend(bundled_site)
+  vim.opt.packpath:prepend(bundled_site)
 end
 
 -- Add extras to runtimepath if it exists
@@ -18,16 +18,8 @@ if vim.fn.isdirectory(extras_nvim) == 1 then
   vim.opt.runtimepath:append(extras_nvim)
 end
 
--- Load plugins before anything else
-vim.pack.add({
-  { src = "https://github.com/nvim-mini/mini.nvim" },
-})
-
-vim.pack.add({
-  { src = "https://github.com/neovim/nvim-lspconfig" },
-  { src = "https://github.com/stevearc/conform.nvim", version = vim.version.range("9.1.0") },
-})
-
-vim.pack.add({
-  { src = "https://github.com/nvim-treesitter/nvim-treesitter", branch = "main" },
-})
+-- Load bundled plugins
+vim.cmd.packadd('mini.nvim')
+vim.cmd.packadd('nvim-lspconfig')
+vim.cmd.packadd('conform.nvim')
+vim.cmd.packadd('nvim-treesitter')

--- a/3p/nvim/cook.mk
+++ b/3p/nvim/cook.mk
@@ -1,6 +1,6 @@
 modules += nvim
 nvim_version := 3p/nvim/version.lua
-nvim_tests := 3p/nvim/test_nvim.lua 3p/nvim/test_treesitter.lua
+nvim_tests := 3p/nvim/test_nvim.lua 3p/nvim/test_treesitter.lua 3p/nvim/test_packpath.lua
 nvim_deps := nvim-conform nvim-mini nvim-lspconfig nvim-treesitter nvim-parsers
 
 # Override _dir: bundle staged nvim + plugins + parsers

--- a/3p/nvim/test_packpath.lua
+++ b/3p/nvim/test_packpath.lua
@@ -1,0 +1,67 @@
+#!/usr/bin/env run-test.lua
+-- teal ignore: test file
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+
+local bin = path.join(TEST_DIR, "bin", "nvim")
+local bundled_site = path.join(TEST_DIR, "share", "nvim", "site")
+
+-- test: bundled plugins exist
+local function test_bundled_plugins_exist()
+  local plugins = { "mini.nvim", "nvim-lspconfig", "conform.nvim", "nvim-treesitter" }
+  for _, plugin in ipairs(plugins) do
+    local plugin_path = path.join(bundled_site, "pack", "core", "opt", plugin)
+    assert(unix.stat(plugin_path), "bundled " .. plugin .. " should exist at: " .. plugin_path)
+  end
+end
+test_bundled_plugins_exist()
+
+-- test: bundled plugins load via packadd
+local function test_bundled_plugins_load()
+  local test_init = path.join(TEST_TMPDIR, "init.lua")
+  local f = io.open(test_init, "w")
+  f:write([[
+local version_dir = vim.fn.fnamemodify(vim.v.progpath, ":h:h")
+local bundled_site = version_dir .. "/share/nvim/site"
+vim.opt.packpath:prepend(bundled_site)
+
+-- load bundled plugins
+vim.cmd.packadd('mini.nvim')
+vim.cmd.packadd('nvim-lspconfig')
+vim.cmd.packadd('conform.nvim')
+vim.cmd.packadd('nvim-treesitter')
+
+-- verify plugins loaded
+local results = {}
+results.mini = pcall(require, 'mini.bufremove')
+results.lspconfig = pcall(require, 'lspconfig')
+results.conform = pcall(require, 'conform')
+results.treesitter = pcall(require, 'nvim-treesitter')
+
+local result_file = io.open(vim.env.TEST_RESULT_FILE, "w")
+for name, ok in pairs(results) do
+  result_file:write(name .. "=" .. tostring(ok) .. "\n")
+end
+result_file:close()
+]])
+  f:close()
+
+  local result_file = path.join(TEST_TMPDIR, "result.txt")
+  local env = unix.environ()
+  table.insert(env, "TEST_RESULT_FILE=" .. result_file)
+  local ok = spawn({ bin, "--headless", "-u", test_init, "+qa" }, { env = env }):wait()
+  assert(ok, "nvim failed to run")
+
+  local result = io.open(result_file, "r")
+  assert(result, "result file not created")
+  local content = result:read("*a")
+  result:close()
+
+  local expected = { "mini", "lspconfig", "conform", "treesitter" }
+  for _, name in ipairs(expected) do
+    assert(content:find(name .. "=true"), name .. " plugin should load. Result:\n" .. content)
+  end
+end
+test_bundled_plugins_load()


### PR DESCRIPTION
## Summary

- Replace `vim.pack.add()` with `vim.cmd.packadd()` for loading bundled plugins
- Add test verifying bundled plugins load correctly via packadd

## Problem

Nvim was downloading plugins at startup even though they were bundled with the distribution.

## Solution

Use `packadd` to load bundled plugins instead of `vim.pack.add()` which tries to download them.