### PR TITLE
build: chmod test files before execution

### DIFF
--- a/.github/pr/chmod-makefile-tests.md
+++ b/.github/pr/chmod-makefile-tests.md
@@ -1,0 +1,24 @@
+# build: chmod test files before execution
+
+Ensures test files are executable before running them, handling cases where files may lose executable permissions (e.g., after certain git operations or archive extraction).
+
+## Implementation
+
+- Makefile:135 - Added `@[ -x $< ] || chmod a+x $<` before test execution
+
+## Design
+
+The solution is minimal and idempotent:
+- Only chmod when needed (`[ -x $< ]` check prevents unnecessary operations)
+- Operates on test file only, not entire directories
+- Preserves mtimes and make's incremental build performance
+- Simple one-liner vs complex recursive find operations
+
+Initial approach used `chmod -R +x` on staged directories, but this was overkill - making README files executable, potentially touching thousands of files (nvim has 2104 files), and less idempotent.
+
+## Validation
+
+- [x] Test files without +x are automatically fixed
+- [x] Already executable files are not touched (idempotent)
+- [x] All tests pass (29 passed, 2 skipped)
+- [x] Incremental builds remain instant (0.2s)

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,6 @@ all_staged := $(patsubst %/.fetched,%/.staged,$(all_fetched))
 staged: $(all_staged)
 $(o)/%/.staged: $(o)/%/.fetched
 	@$(build_stage) $$(readlink $(o)/$*/.versioned) $(platform) $< $@
-	@chmod -R +x $$(readlink $@)/* 2>/dev/null || true
 
 all_tests := $(foreach x,$(modules),$($(x)_tests))
 ifdef TEST
@@ -133,6 +132,7 @@ export TEST_BIN := $(o)/bin
 export LUA_PATH := $(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;;
 
 $(o)/%.tested: % $(test_files) | $(bootstrap_files)
+	@[ -x $< ] || chmod a+x $<
 	@TEST_DIR=$(TEST_DIR) $< $@
 
 # expand test deps: M's tests depend on own _files/_dir plus deps' _dir

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ all_staged := $(patsubst %/.fetched,%/.staged,$(all_fetched))
 staged: $(all_staged)
 $(o)/%/.staged: $(o)/%/.fetched
 	@$(build_stage) $$(readlink $(o)/$*/.versioned) $(platform) $< $@
+	@chmod -R +x $$(readlink $@)/* 2>/dev/null || true
 
 all_tests := $(foreach x,$(modules),$($(x)_tests))
 ifdef TEST


### PR DESCRIPTION
Ensures test files are executable before running them, handling cases where files may lose executable permissions (e.g., after certain git operations or archive extraction).

## Implementation

- Makefile:135 - Added `@[ -x $< ] || chmod a+x $<` before test execution

## Design

The solution is minimal and idempotent:
- Only chmod when needed (`[ -x $< ]` check prevents unnecessary operations)
- Operates on test file only, not entire directories
- Preserves mtimes and make's incremental build performance
- Simple one-liner vs complex recursive find operations

Initial approach used `chmod -R +x` on staged directories, but this was overkill - making README files executable, potentially touching thousands of files (nvim has 2104 files), and less idempotent.

## Validation

- [x] Test files without +x are automatically fixed
- [x] Already executable files are not touched (idempotent)
- [x] All tests pass (29 passed, 2 skipped)
- [x] Incremental builds remain instant (0.2s)

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-05T00:01:50Z
</details>