### PR TITLE
bootstrap: update cosmic-lua to home-2026-01-05-a64eed2

### DIFF
--- a/bin/cosmic
+++ b/bin/cosmic
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -e
 
-RELEASE_URL="https://github.com/whilp/world/releases/download/home-2026-01-05-a64eed2/cosmic-lua"
-
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 COSMIC_LUA="${SCRIPT_DIR}/cosmic-lua"

--- a/bin/cosmic
+++ b/bin/cosmic
@@ -6,6 +6,7 @@ RELEASE_URL="https://github.com/whilp/world/releases/download/home-2026-01-05-a6
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 COSMIC_LUA="${SCRIPT_DIR}/cosmic-lua"
+RELEASE_URL="https://github.com/whilp/world/releases/download/home-2026-01-05-a64eed2/cosmic-lua"
 
 # Download cosmic-lua if it doesn't exist
 if [ ! -f "${COSMIC_LUA}" ]; then

--- a/bin/cosmic
+++ b/bin/cosmic
@@ -1,10 +1,11 @@
 #!/bin/sh
 set -e
 
+RELEASE_URL="https://github.com/whilp/world/releases/download/home-2026-01-05-a64eed2/cosmic-lua"
+
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 COSMIC_LUA="${SCRIPT_DIR}/cosmic-lua"
-RELEASE_URL="https://github.com/whilp/world/releases/download/home-2026-01-04-e6b3456/cosmic-lua"
 
 # Download cosmic-lua if it doesn't exist
 if [ ! -f "${COSMIC_LUA}" ]; then

--- a/bootstrap.mk
+++ b/bootstrap.mk
@@ -4,8 +4,11 @@ bootstrap_files := $(bootstrap_cosmic)
 
 export PATH := $(o)/bootstrap:$(PATH)
 
-$(bootstrap_cosmic):
+bin/cosmic-lua: bin/cosmic
+	@bin/cosmic --version >/dev/null 2>&1 || true
+
+$(bootstrap_cosmic): bin/cosmic-lua
 	@mkdir -p $(@D)
-	@curl -ssLo $@ https://github.com/whilp/world/releases/download/home-2026-01-02-75caba6/cosmic-lua
+	@cp bin/cosmic-lua $@
 	@chmod +x $@
 	@ln -sf cosmic $(@D)/lua


### PR DESCRIPTION
## Summary
- Update bootstrap.mk and bin/cosmic wrapper to use latest cosmic-lua release
- Includes varargs fix for script arguments (#257)

## Test plan
- [x] `make clean test` passes (32 tests: 31 passed, 1 skipped)