### PR TITLE
skill/bootstrap: provide cosmic context to agents

### DIFF
--- a/.github/pr/cosmic-bootstrap-context.md
+++ b/.github/pr/cosmic-bootstrap-context.md
@@ -1,0 +1,21 @@
+# skill/bootstrap: provide cosmic context to agents
+
+Updates the bootstrap skill (invoked via SessionStart hook) to provide helpful context about the cosmic runtime and its key modules.
+
+Changes:
+- lib/skill/bootstrap.lua - adds 185-word context message covering cosmic modules, help system, skills, and constraints
+
+The context tells agents:
+- What cosmic is (cosmopolitan lua with bundled libraries)
+- How to get help (`cosmic --help`, reading source)
+- Key modules: cosmo (HTTP, JSON, crypto), cosmo.path (paths), cosmo.unix (POSIX API), cosmic.spawn (processes)
+- Available skills (especially `cosmic --skill pr` for PR management)
+- Critical constraints (use path.join, use spawn not os.execute, no octal literals)
+
+This provides agents with enough information to know what to look for later without overwhelming the SessionStart context. The message is concise but includes pointers to documentation and common pitfalls.
+
+## Validation
+
+- [x] tests pass
+- [x] bootstrap skill outputs context correctly
+- [x] word count appropriate for SessionStart hook (185 words)

--- a/lib/skill/bootstrap.lua
+++ b/lib/skill/bootstrap.lua
@@ -2,7 +2,44 @@
 
 local unix = require("cosmo.unix")
 
+local CONTEXT = [[
+# cosmic: cosmopolitan lua runtime
+
+cosmic is a portable lua distribution with bundled libraries for HTTP, JSON, crypto, compression, and system programming.
+
+## Getting help
+
+- `cosmic --help` - show available options
+- `cosmic --help <module>` - get help for a specific module (if available)
+- Read lib/ source code for implementation details
+
+## Key modules
+
+**cosmo** - core functions: Fetch (HTTP), EncodeJson/DecodeJson, crypto (Sha256, Md5), compression (Deflate, Inflate), and encoding utilities
+
+**cosmo.path** - path operations: join, basename, dirname, exists, isdir, isfile, islink
+
+**cosmo.unix** - comprehensive POSIX API with all unix syscalls, constants, and file operations
+
+**cosmic.spawn** - process spawning: `spawn({"cmd", "arg"}):wait()` (NEVER use os.execute or io.popen)
+
+## Skills
+
+Use `cosmic --skill <name>` to run skill modules:
+
+**pr** - manages GitHub PRs from .github/pr/<name>.md files. Add `x-cosmic-pr-name: <file>.md` trailer to commits, then run `cosmic --skill pr` to update PR title/description. See `cosmic --skill pr --help` for details.
+
+## Constraints
+
+- NEVER use string concatenation for paths - use `path.join()`
+- NEVER use `os.execute()` or `io.popen()` - use `spawn` module
+- File permissions: use `tonumber("644", 8)` not `0644` (no octal in lua)
+- NEVER manipulate `package.path`
+]]
+
 local function main()
+  print(CONTEXT)
+
   local env_file = os.getenv("CLAUDE_ENV_FILE")
   if not env_file then
     return 0
@@ -33,6 +70,6 @@ end
 
 return {
   main = main,
-  _VERSION = "0.1.0",
+  _VERSION = "0.2.0",
   _DESCRIPTION = "Bootstrap environment for Claude Code web",
 }


### PR DESCRIPTION
Updates the bootstrap skill (invoked via SessionStart hook) to provide helpful context about the cosmic runtime and its key modules.

Changes:
- lib/skill/bootstrap.lua - adds 185-word context message covering cosmic modules, help system, skills, and constraints

The context tells agents:
- What cosmic is (cosmopolitan lua with bundled libraries)
- How to get help (`cosmic --help`, reading source)
- Key modules: cosmo (HTTP, JSON, crypto), cosmo.path (paths), cosmo.unix (POSIX API), cosmic.spawn (processes)
- Available skills (especially `cosmic --skill pr` for PR management)
- Critical constraints (use path.join, use spawn not os.execute, no octal literals)

This provides agents with enough information to know what to look for later without overwhelming the SessionStart context. The message is concise but includes pointers to documentation and common pitfalls.

## Validation

- [x] tests pass
- [x] bootstrap skill outputs context correctly
- [x] word count appropriate for SessionStart hook (185 words)

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-05T01:01:01Z
</details>