### PR TITLE
checker: remove exclusions, add skip directives to files

### DIFF
--- a/.config/hammerspoon/aero-switcher.lua
+++ b/.config/hammerspoon/aero-switcher.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 -- Native switcher using aerospace directly with MRU tracking
 local M = {}
 

--- a/.config/hammerspoon/auto-layout.lua
+++ b/.config/hammerspoon/auto-layout.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 local M = {}
 
 M.config = {

--- a/.config/hammerspoon/chooser-style.lua
+++ b/.config/hammerspoon/chooser-style.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 local M = {}
 
 M.apply = function(chooser)

--- a/.config/hammerspoon/clues/apps.lua
+++ b/.config/hammerspoon/clues/apps.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 local function focusChromeProfile(profileName)
   return function()
     local chrome = hs.application.get("Google Chrome")

--- a/.config/hammerspoon/clues/cleanshot.lua
+++ b/.config/hammerspoon/clues/cleanshot.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 return Leader("c", "CleanShot", {
   Bind("a", "All-in-one capture", { url = "cleanshot://all-in-one" }),
   Bind("c", "Capture area", { url = "cleanshot://capture-area" }),

--- a/.config/hammerspoon/clues/emoji.lua
+++ b/.config/hammerspoon/clues/emoji.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 return Leader("p", "Picker", {
   Bind("e", "Emoji", { mode = "emoji" }),
   Bind("s", "Symbol", { mode = "symbol" }),

--- a/.config/hammerspoon/clues/hammerspoon.lua
+++ b/.config/hammerspoon/clues/hammerspoon.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 return Leader("h", "Hammerspoon", {
   Bind("r", "Reload config", { fn = function() hs.reload() end }),
   Bind("c", "Console", { fn = function() hs.openConsole() end }),

--- a/.config/hammerspoon/clues/superwhisper.lua
+++ b/.config/hammerspoon/clues/superwhisper.lua
@@ -1,3 +1,5 @@
+-- luacheck ignore: hammerspoon runtime
+-- ast-grep ignore: hammerspoon runtime
 --check:false
 local bindings = {
   Bind("r", "Start recording", { url = "superwhisper://record" })

--- a/.config/hammerspoon/clues/system.lua
+++ b/.config/hammerspoon/clues/system.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 return Leader("s", "System", {
   Bind("s", "Settings", { shell = 'open "x-apple.systempreferences:"' }),
   Bind("a", "Accessibility", { shell = 'open "x-apple.systempreferences:com.apple.Accessibility-Settings.extension"' }),

--- a/.config/hammerspoon/clues/windows.lua
+++ b/.config/hammerspoon/clues/windows.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 -- Window management moved to AeroSpace
 -- Use AeroSpace keybindings: alt-h/j/k/l for focus, alt-shift-h/j/k/l for move
 -- Workspace switching: alt-1 through alt-9

--- a/.config/hammerspoon/dispatch.lua
+++ b/.config/hammerspoon/dispatch.lua
@@ -1,3 +1,5 @@
+-- luacheck ignore: hammerspoon runtime
+-- ast-grep ignore: hammerspoon runtime
 --check:false
 local M = {}
 

--- a/.config/hammerspoon/emoji-picker.lua
+++ b/.config/hammerspoon/emoji-picker.lua
@@ -1,3 +1,5 @@
+-- luacheck ignore: hammerspoon runtime
+-- ast-grep ignore: hammerspoon runtime
 --check:false
 local M = {}
 

--- a/.config/hammerspoon/fuzzy.lua
+++ b/.config/hammerspoon/fuzzy.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 local Fuzzy = {}
 
 local TYPE_PRIORITY = {

--- a/.config/hammerspoon/hyper-key.lua
+++ b/.config/hammerspoon/hyper-key.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 local HyperKey = {}
 HyperKey.__index = HyperKey
 

--- a/.config/hammerspoon/init.lua
+++ b/.config/hammerspoon/init.lua
@@ -1,3 +1,5 @@
+-- luacheck ignore: hammerspoon runtime
+-- ast-grep ignore: hammerspoon runtime
 --check:false
 local HyperKey = require("hyper-key")
 local notchClock = require("notch-clock")

--- a/.config/hammerspoon/leader-dsl.lua
+++ b/.config/hammerspoon/leader-dsl.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 local M = {}
 
 M.tree = {}

--- a/.config/hammerspoon/leader-modal.lua
+++ b/.config/hammerspoon/leader-modal.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 local M = {}
 
 M.config = {

--- a/.config/hammerspoon/notch-clock.lua
+++ b/.config/hammerspoon/notch-clock.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 local NotchClock = {}
 
 local clock = nil

--- a/.config/hammerspoon/picker-utils.lua
+++ b/.config/hammerspoon/picker-utils.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 local M = {}
 
 -- Creates a cached picker from a data module

--- a/.config/hammerspoon/symbol-picker.lua
+++ b/.config/hammerspoon/symbol-picker.lua
@@ -1,3 +1,5 @@
+-- luacheck ignore: hammerspoon runtime
+-- ast-grep ignore: hammerspoon runtime
 --check:false
 local M = {}
 

--- a/.config/hammerspoon/window-management.lua
+++ b/.config/hammerspoon/window-management.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 local WindowManagement = {}
 
 -- grid configuration

--- a/.config/hammerspoon/window-switcher.lua
+++ b/.config/hammerspoon/window-switcher.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: hammerspoon runtime
 local WindowSwitcher = {}
 
 local fuzzy = require("fuzzy")

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -1,3 +1,5 @@
+-- luacheck ignore: neovim runtime
+-- ast-grep ignore: neovim runtime
 --check:false
 -- nvim configuration entry point
 

--- a/.config/nvim/lua/work/actions.lua
+++ b/.config/nvim/lua/work/actions.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 -- work.nvim - user-facing actions
 local M = {}
 

--- a/.config/nvim/lua/work/buffer.lua
+++ b/.config/nvim/lua/work/buffer.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 -- work.nvim - buffer management for work items
 local M = {}
 

--- a/.config/nvim/lua/work/date_picker.lua
+++ b/.config/nvim/lua/work/date_picker.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 local M = {}
 
 local util = require("work.util")

--- a/.config/nvim/lua/work/form.lua
+++ b/.config/nvim/lua/work/form.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 -- work.form - native implementation
 local work = require("work")
 local api = work.api

--- a/.config/nvim/lua/work/init.lua
+++ b/.config/nvim/lua/work/init.lua
@@ -1,3 +1,5 @@
+-- luacheck ignore: neovim runtime
+-- ast-grep ignore: neovim runtime
 --check:false
 -- work.nvim - minimal configuration for work system
 local M = {}

--- a/.config/nvim/lua/work/picker.lua
+++ b/.config/nvim/lua/work/picker.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 -- work.nvim - mini.pick integration for work items
 local M = {}
 

--- a/.config/nvim/lua/work/util.lua
+++ b/.config/nvim/lua/work/util.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 local M = {}
 
 -- ID regex pattern constant

--- a/.config/nvim/parsers.lua
+++ b/.config/nvim/parsers.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 return {
   "python",
   "markdown",

--- a/.config/nvim/plugin/clue.lua
+++ b/.config/nvim/plugin/clue.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 local ok_clue, clue = pcall(require, "mini.clue")
 if not ok_clue then
   return

--- a/.config/nvim/plugin/editing.lua
+++ b/.config/nvim/plugin/editing.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 local opt = vim.opt
 local map = vim.keymap.set
 local opts = { silent = true }

--- a/.config/nvim/plugin/grep.lua
+++ b/.config/nvim/plugin/grep.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 local opt = vim.opt
 
 -- Grep configuration

--- a/.config/nvim/plugin/interface.lua
+++ b/.config/nvim/plugin/interface.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 local opt = vim.opt
 
 -- Visual and UI settings

--- a/.config/nvim/plugin/lsp.lua
+++ b/.config/nvim/plugin/lsp.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 local ok, conform = pcall(require, "conform")
 if ok then
   conform.setup({

--- a/.config/nvim/plugin/mini.lua
+++ b/.config/nvim/plugin/mini.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 -- Setup mini.nvim modules individually (don't require 'mini' directly)
 local ok_bufremove, _ = pcall(require, "mini.bufremove")
 if ok_bufremove then

--- a/.config/nvim/plugin/system.lua
+++ b/.config/nvim/plugin/system.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 local opt = vim.opt
 
 -- File handling

--- a/.config/nvim/plugin/tab.lua
+++ b/.config/nvim/plugin/tab.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 local map = vim.keymap.set
 
 -- Tab management

--- a/.config/nvim/plugin/terminal.lua
+++ b/.config/nvim/plugin/terminal.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 local map = vim.keymap.set
 
 -- Terminal mode keybindings

--- a/.config/nvim/plugin/treesitter.lua
+++ b/.config/nvim/plugin/treesitter.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 local lang = dofile(vim.fn.stdpath("config") .. "/parsers.lua")
 
 local ok, ts = pcall(require, "nvim-treesitter")

--- a/.config/nvim/plugin/window.lua
+++ b/.config/nvim/plugin/window.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 local opt = vim.opt
 local map = vim.keymap.set
 

--- a/.config/nvim/plugin/work.lua
+++ b/.config/nvim/plugin/work.lua
@@ -1,3 +1,4 @@
+-- luacheck ignore: neovim runtime
 -- work.nvim - plugin entry point
 -- keybindings and commands for work todo system
 

--- a/.local/bin/aerosnap
+++ b/.local/bin/aerosnap
@@ -1,3 +1,4 @@
 #!/usr/bin/env lua
+-- luacheck ignore: script runtime
 local aerosnap = require("aerosnap")
 os.exit(aerosnap.main(arg) or 0)

--- a/.local/bin/claude
+++ b/.local/bin/claude
@@ -1,3 +1,4 @@
 #!/usr/bin/env lua
+-- luacheck ignore: script runtime
 local claude = require("claude.main")
 os.exit(claude.main(arg) or 0)

--- a/.local/bin/cleanshot
+++ b/.local/bin/cleanshot
@@ -1,3 +1,4 @@
 #!/usr/bin/env lua
+-- luacheck ignore: script runtime
 local cleanshot = require("cleanshot")
 os.exit(cleanshot.main(arg) or 0)

--- a/.local/bin/comrak-fmt
+++ b/.local/bin/comrak-fmt
@@ -1,4 +1,5 @@
 #!/usr/bin/env lua
+-- luacheck ignore: script runtime
 
 local posix = require('posix')
 local unistd = require('posix.unistd')

--- a/.local/bin/editor
+++ b/.local/bin/editor
@@ -1,4 +1,5 @@
 #!/usr/bin/env lua
+-- luacheck ignore: script runtime
 
 local posix = require("posix")
 local unistd = require("posix.unistd")

--- a/.local/bin/emoji-dump
+++ b/.local/bin/emoji-dump
@@ -1,4 +1,5 @@
 #!/usr/bin/env lua
+-- luacheck ignore: script runtime
 
 local serpent = require("serpent")
 local dump = require("emoji.dump")

--- a/.local/bin/gh
+++ b/.local/bin/gh
@@ -1,4 +1,5 @@
 #!/usr/bin/env lua
+-- luacheck ignore: script runtime
 
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")

--- a/.local/bin/hs-dispatch
+++ b/.local/bin/hs-dispatch
@@ -1,4 +1,5 @@
 #!/usr/bin/env lua
+-- luacheck ignore: script runtime
 
 local posix = require('posix')
 local unistd = require('posix.unistd')

--- a/.local/bin/nvim
+++ b/.local/bin/nvim
@@ -1,3 +1,4 @@
 #!/usr/bin/env lua
+-- luacheck ignore: script runtime
 local nvim = require("nvim.main")
 os.exit(nvim.main(arg) or 0)

--- a/.local/bin/symbol-dump
+++ b/.local/bin/symbol-dump
@@ -1,4 +1,5 @@
 #!/usr/bin/env lua
+-- luacheck ignore: script runtime
 
 local serpent = require("serpent")
 local dump = require("symbols.dump")

--- a/.local/bin/use-skills
+++ b/.local/bin/use-skills
@@ -1,4 +1,5 @@
 #!/usr/bin/env lua
+-- luacheck ignore: script runtime
 
 local cosmo = require("cosmo")
 

--- a/.local/bin/whereami
+++ b/.local/bin/whereami
@@ -1,4 +1,5 @@
 #!/usr/bin/env lua
+-- luacheck ignore: script runtime
 -- Get hostname or box-name/host_env identifier
 
 local whereami = require('whereami')

--- a/.local/bin/work
+++ b/.local/bin/work
@@ -1,4 +1,5 @@
 #!/usr/bin/env lua
+-- luacheck ignore: script runtime
 
 local api = require("work.api").init()
 local render = require("work.render")

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,13 +1,6 @@
 std = "lua54"
 max_line_length = 120
 
--- TODO: fix luacheck issues in excluded directories
-exclude_files = {
-  ".config/hammerspoon/",
-  ".config/nvim/",
-  ".config/voyager/",
-  ".local/bin/",
-}
 
 -- Fennel-inspired strictness
 --

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -7,9 +7,3 @@ languageGlobs:
     - ".local/bin/*"
     - ".claude/skills/*/main.lua"
 
-# TODO: fix ast-grep issues in excluded directories
-ignoreGlobs:
-  - ".config/hammerspoon/**"
-  - ".config/nvim/**"
-  - ".config/voyager/**"
-  - ".local/bin/**"


### PR DESCRIPTION
Remove path exclusions from .luacheckrc and sgconfig.yml for
.config/hammerspoon/, .config/nvim/, .config/voyager/, and .local/bin/.

Instead, add file-level skip directives to each affected file:
- luacheck ignore: for hammerspoon, neovim, and script runtimes
- ast-grep ignore: for files using package.path, io.popen, path concat

This makes the exclusions explicit and visible in each file rather than
hidden in config files.