### PR TITLE
build: add only= filter for all targets

### DIFF
--- a/.github/pr/filter-build-targets.md
+++ b/.github/pr/filter-build-targets.md
@@ -1,0 +1,27 @@
+# build: add only= filter for all targets
+
+Add unified `only=` parameter to filter all build targets (test, check, update, build, etc) by substring pattern.
+
+- Makefile - add filter-only function and apply to all base aggregation variables
+
+## Usage
+
+```bash
+make test only='skill'        # test files matching 'skill'
+make check only='lib/skill'   # check files in lib/skill/
+make update only='3p/rg'      # update only rg version
+make test only='test_pr'      # test files with test_pr in name
+```
+
+## Implementation
+
+The filter uses `findstring` for substring matching and is applied early during variable aggregation (`all_files`, `all_tests`, `all_versions`, `all_source_files`). All derived targets (`all_tested`, `all_astgreps`, etc) automatically respect the filter through the dependency chain.
+
+Replaces the old `TEST` variable with a unified interface that works consistently across all targets.
+
+## Validation
+
+- [x] tests filtered correctly by pattern
+- [x] check targets filtered correctly
+- [x] update targets filtered correctly
+- [x] derived variables auto-filter through dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ results/
 .ape*
 bin/
 !bin/cosmic
+!bin/run-test

--- a/bin/run-test
+++ b/bin/run-test
@@ -10,4 +10,4 @@ if [ $# -eq 0 ]; then
   exit 1
 fi
 
-exec make TEST="$1" test
+exec make only="$1" test


### PR DESCRIPTION
Add unified `only=` parameter to filter all build targets (test, check, update, build, etc) by substring pattern.

- Makefile - add filter-only function and apply to all base aggregation variables

## Usage

```bash
make test only='skill'        # test files matching 'skill'
make check only='lib/skill'   # check files in lib/skill/
make update only='3p/rg'      # update only rg version
make test only='test_pr'      # test files with test_pr in name
```

## Implementation

The filter uses `findstring` for substring matching and is applied early during variable aggregation (`all_files`, `all_tests`, `all_versions`, `all_source_files`). All derived targets (`all_tested`, `all_astgreps`, etc) automatically respect the filter through the dependency chain.

Replaces the old `TEST` variable with a unified interface that works consistently across all targets.

## Validation

- [x] tests filtered correctly by pattern
- [x] check targets filtered correctly
- [x] update targets filtered correctly
- [x] derived variables auto-filter through dependencies

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-08T03:56:12Z
</details>