### PR TITLE
checker: return 0 on failures to allow summary generation

### DIFF
--- a/.github/pr/fix-teal-summary-generation.md
+++ b/.github/pr/fix-teal-summary-generation.md
@@ -1,0 +1,12 @@
+# checker: return 0 on failures to allow summary generation
+
+Previously checkers (teal, luacheck, ast-grep) returned exit code 1 on failures, causing Make to stop before running the reporter. This meant no summary was generated when checks failed.
+
+Now checkers always return 0 (like tests do), while still writing "fail" status to output files. This allows Make to continue to the reporter step, which generates summaries even when there are failures.
+
+- lib/checker/common.lua - changed write_result to always return 0
+
+## Validation
+
+- [ ] tests pass
+- [ ] checkers pass

--- a/lib/checker/common.lua
+++ b/lib/checker/common.lua
@@ -41,7 +41,7 @@ local function write_result(status, message, stdout, stderr, source)
   -- write full output to stdout for capture
   local output = format_output(status, message, stdout, stderr, false)
   io.write(output)
-  return status == "fail" and 1 or 0
+  return 0
 end
 
 local function parse_result(content)


### PR DESCRIPTION
Previously checkers (teal, luacheck, ast-grep) returned exit code 1 on failures, causing Make to stop before running the reporter. This meant no summary was generated when checks failed.

Now checkers always return 0 (like tests do), while still writing "fail" status to output files. This allows Make to continue to the reporter step, which generates summaries even when there are failures.

- lib/checker/common.lua - changed write_result to always return 0

## Validation

- [ ] tests pass
- [ ] checkers pass

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-08T06:15:42Z
</details>