### PR TITLE
build: add bump target for applying dependency updates

### DIFF
--- a/.github/pr/bump-target.md
+++ b/.github/pr/bump-target.md
@@ -1,0 +1,20 @@
+# build: add bump target for applying dependency updates
+
+Add `make bump` target to apply version updates checked by `make update`.
+
+- lib/build/check-update.lua - add `--apply` flag to write updated versions
+- Makefile - add `bump` target with help documentation
+- lib/build/make-help.lua - add `parse_phony_targets` function
+- lib/build/test_help.lua - add test ensuring all phony targets are documented
+
+## Usage
+
+```bash
+make update only=gh   # check for updates
+make bump only=gh     # apply updates
+```
+
+## Validation
+
+- [x] tests pass
+- [x] `make help` shows bump target

--- a/3p/gh/version.lua
+++ b/3p/gh/version.lua
@@ -1,5 +1,5 @@
 return {
-  version = "2.79.0",
+  version = "2.83.2",
   strip_components = 1,
   url = "https://github.com/cli/cli/releases/download/v{version}/gh_{version}_{os}_{arch}.{ext}",
   platforms = {
@@ -8,21 +8,21 @@ return {
       arch = "arm64",
       ext = "zip",
       format = "zip",
-      sha = "5454f9509e3dbb8f321310e9e344877d9a01ebb8f8703886b1afb0936d60ffaa",
+      sha = "ba3e0396ebbc8da17256144ddda503e4e79c8b502166335569f8390d6b75fa8d",
     },
     ["linux-arm64"] = {
       os = "linux",
       arch = "arm64",
       ext = "tar.gz",
       format = "tar.gz",
-      sha = "1b91e546b30181a8ee6d8c72bbf59eaadbb0600bab014dfbcc199676c83ea102",
+      sha = "b1a0c0a0fcf18524e36996caddc92a062355ed014defc836203fe20fba75a38e",
     },
     ["linux-x86_64"] = {
       os = "linux",
       arch = "amd64",
       ext = "tar.gz",
       format = "tar.gz",
-      sha = "e7af0c72a607c0528fda1989f7c8e3be85e67d321889002af0e2938ad9c8fb68",
+      sha = "ca6e7641214fbd0e21429cec4b64a7ba626fd946d8f9d6d191467545b092015e",
     },
   },
 }

--- a/3p/gh/version.lua
+++ b/3p/gh/version.lua
@@ -1,5 +1,5 @@
 return {
-  version = "2.83.2",
+  version = "2.79.0",
   strip_components = 1,
   url = "https://github.com/cli/cli/releases/download/v{version}/gh_{version}_{os}_{arch}.{ext}",
   platforms = {
@@ -8,21 +8,21 @@ return {
       arch = "arm64",
       ext = "zip",
       format = "zip",
-      sha = "ba3e0396ebbc8da17256144ddda503e4e79c8b502166335569f8390d6b75fa8d",
+      sha = "5454f9509e3dbb8f321310e9e344877d9a01ebb8f8703886b1afb0936d60ffaa",
     },
     ["linux-arm64"] = {
       os = "linux",
       arch = "arm64",
       ext = "tar.gz",
       format = "tar.gz",
-      sha = "b1a0c0a0fcf18524e36996caddc92a062355ed014defc836203fe20fba75a38e",
+      sha = "1b91e546b30181a8ee6d8c72bbf59eaadbb0600bab014dfbcc199676c83ea102",
     },
     ["linux-x86_64"] = {
       os = "linux",
       arch = "amd64",
       ext = "tar.gz",
       format = "tar.gz",
-      sha = "ca6e7641214fbd0e21429cec4b64a7ba626fd946d8f9d6d191467545b092015e",
+      sha = "e7af0c72a607c0528fda1989f7c8e3be85e67d321889002af0e2938ad9c8fb68",
     },
   },
 }

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,15 @@ $(o)/%.update.ok: % $(build_check_update) | $(bootstrap_files)
 	@mkdir -p $(@D)
 	@$(update_runner) $< > $@
 
+# bump: check for updates and apply them
+# e.g., make bump MODULE=gh
+.PHONY: bump
+bump: $(all_updated)
+	@for ok in $^; do \
+	  ver=$${ok#$(o)/}; ver=$${ver%.update.ok}; \
+	  $(update_runner) --apply "$$ok" "$$ver"; \
+	done
+
 .PHONY: build
 ## Build home and cosmic binaries
 build: home cosmic

--- a/Makefile
+++ b/Makefile
@@ -225,8 +225,7 @@ $(o)/%.update.ok: % $(build_check_update) | $(bootstrap_files)
 	@mkdir -p $(@D)
 	@$(update_runner) $< > $@
 
-# bump: check for updates and apply them
-# e.g., make bump MODULE=gh
+## Apply dependency updates (use with only=<module>)
 .PHONY: bump
 bump: $(all_updated)
 	@for ok in $^; do \

--- a/lib/build/make-help.lua
+++ b/lib/build/make-help.lua
@@ -127,7 +127,22 @@ if cosmo.is_main() then
   os.exit(exit_code)
 end
 
+-- Extract all .PHONY targets from makefile content
+local function parse_phony_targets(content)
+  local targets = {}
+  for line in content:gmatch("[^\r\n]+") do
+    local phony = line:match("^%.PHONY:%s*(.+)$")
+    if phony then
+      for target in phony:gmatch("%S+") do
+        targets[target] = true
+      end
+    end
+  end
+  return targets
+end
+
 return {
   parse_makefile = parse_makefile,
   format_help = format_help,
+  parse_phony_targets = parse_phony_targets,
 }

--- a/lib/build/make-help.snap
+++ b/lib/build/make-help.snap
@@ -12,6 +12,7 @@ Targets:
   clean               Remove all build artifacts
   check               Run all linters (astgrep, luacheck, teal)
   update              Check for dependency updates
+  bump                Apply dependency updates (use with only=<module>)
   build               Build home and cosmic binaries
   release             Create release artifacts (CI only)
   ci                  Run full CI pipeline (luacheck, astgrep, teal, test, build)


### PR DESCRIPTION
Add `make bump` target to apply version updates checked by `make update`.

- lib/build/check-update.lua - add `--apply` flag to write updated versions
- Makefile - add `bump` target with help documentation
- lib/build/make-help.lua - add `parse_phony_targets` function
- lib/build/test_help.lua - add test ensuring all phony targets are documented

## Usage

```bash
make update only=gh   # check for updates
make bump only=gh     # apply updates
```

## Validation

- [x] tests pass
- [x] `make help` shows bump target

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-08T06:59:32Z
</details>