### PR TITLE
skill/hook: fix make help in SessionStart hook

### DIFF
--- a/.github/pr/discover-make-targets.md
+++ b/.github/pr/discover-make-targets.md
@@ -1,0 +1,21 @@
+# skill/hook: fix make help in SessionStart hook
+
+Fix the SessionStart hook to properly display make targets by bootstrapping first.
+
+- Makefile - add `bootstrap` target for explicit bootstrapping
+- lib/skill/hook.lua - run `make bootstrap` before `make help`, use `bin/make` for portability
+
+## Problem
+
+The `session_start_make_help` handler runs `make help` on startup, but this fails on fresh checkouts because `o/bootstrap/cosmic` doesn't exist yet. The error was silently swallowed.
+
+## Solution
+
+1. Add explicit `bootstrap` target to Makefile (avoids hardcoding `o/` path)
+2. Run `make bootstrap` before `make help` in the hook
+3. Use `bin/make` wrapper to ensure cosmo-make is available regardless of PATH state
+
+## Validation
+
+- [x] hook outputs make targets on SessionStart
+- [x] works on fresh checkout without existing build artifacts

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,10 @@ $(o)/%.teal.ok: $(o)/% $(tl_files) | $(bootstrap_files) $(tl_staged)
 clean:
 	@rm -rf $(o)
 
+.PHONY: bootstrap
+## Bootstrap build environment
+bootstrap: $(bootstrap_files)
+
 all_checks := $(all_astgreps) $(all_luachecks) $(all_teals)
 
 ## Run all linters (astgrep, luacheck, teal)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # 🏡 world
 
-extreme dotfiles, all reproducible everything, a model home.
+dotfiles extrêmes, tout reproductible, une maison modèle.
 
-![model home](https://brianlauritzen.files.wordpress.com/2013/05/house_fall.gif)
+![maison modèle](https://brianlauritzen.files.wordpress.com/2013/05/house_fall.gif)
 
-a monorepo containing dotfiles, tools, and things for reproducible computering since 2005.
+un monorepo contenant dotfiles, outils et trucs pour une informatique reproductible depuis 2005.
 
     $ git rev-list --max-parents=0 --pretty HEAD
     commit 165210edc61ec09e133b8e0af26d98e1e46de2ea
@@ -14,11 +14,11 @@ a monorepo containing dotfiles, tools, and things for reproducible computering s
         [project @ 2005-06-11 16:26:33 by will]
         initial import into CVS
 
-## releases
+## versions
 
-you (i) get a universal executable-archive that works on mac (arm64) and linux (arm64, x86_64 -- including the gvisor thingy that claude.ai/code lives in) with dotfiles and tools (`home`). and *that* knows how to fetch platform-specific archives with the rest (handy tools).
+vous (moi) obtenez une archive-exécutable universelle qui fonctionne sur mac (arm64) et linux (arm64, x86_64 -- y compris le truc gvisor où vit claude.ai/code) avec dotfiles et outils (`home`). et *ça* sait récupérer des archives spécifiques à la plateforme avec le reste (outils pratiques).
 
-latest release is at https://github.com/whilp/world/releases/latest
+la dernière version est à https://github.com/whilp/world/releases/latest
 
 ### yolo
 
@@ -26,9 +26,9 @@ latest release is at https://github.com/whilp/world/releases/latest
 curl -fsSL https://github.com/whilp/world/releases/latest/download/home | sh
 ```
 
-### try lua
+### essayer lua
 
-lua is available from [whilp/cosmopolitan](https://github.com/whilp/cosmopolitan/releases/latest):
+lua est disponible depuis [whilp/cosmopolitan](https://github.com/whilp/cosmopolitan/releases/latest) :
 
 ```console
 $ curl -fsSLO https://github.com/whilp/cosmopolitan/releases/latest/download/lua && chmod +x lua
@@ -67,13 +67,13 @@ Returns:
 
 ## forks
 
-- [neovim](https://github.com/whilp/neovim) (fork of [neovim](https://neovim.io))
-  - mostly to pin a snapshot
-  - the build in this repo bundles neovim with the plugins i use (at buildtime)
-- [cosmopolitan](https://github.com/whilp/cosmopolitan) (fork of [cosmopolitan](https://justine.lol/cosmopolitan/)) - builds actually portable executables:
-  - `lua` with all the goodies from [`redbean`](https://redbean.dev) (`unix`, `path`, `re`, `sqlite3`, `argon2`, `json`, `cosmo`) plus enhancements for `Fetch` (authenticating proxy support). pure lua modules get zipped inside the binary.
-  - `make`, `zip`, `unzip` for bootstrapping
+- [neovim](https://github.com/whilp/neovim) (fork de [neovim](https://neovim.io))
+  - principalement pour figer une version
+  - le build dans ce repo embarque neovim avec les plugins que j'utilise (au moment du build)
+- [cosmopolitan](https://github.com/whilp/cosmopolitan) (fork de [cosmopolitan](https://justine.lol/cosmopolitan/)) - construit des exécutables vraiment portables :
+  - `lua` avec toutes les bonnes choses de [`redbean`](https://redbean.dev) (`unix`, `path`, `re`, `sqlite3`, `argon2`, `json`, `cosmo`) plus des améliorations pour `Fetch` (support de proxy authentifiant). les modules lua purs sont zippés dans le binaire.
+  - `make`, `zip`, `unzip` pour le bootstrapping
 
-## license
+## licence
 
-This repository is licensed under the MIT License. You are welcome to borrow, use, or adapt any code here for your own projects. See the [LICENSE](LICENSE) file for details.
+Ce dépôt est sous licence MIT. Vous êtes libre d'emprunter, utiliser ou adapter tout code ici pour vos propres projets. Voir le fichier [LICENSE](LICENSE) pour les détails.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # 🏡 world
 
-dotfiles extrêmes, tout reproductible, une maison modèle.
+extreme dotfiles, all reproducible everything, a model home.
 
-![maison modèle](https://brianlauritzen.files.wordpress.com/2013/05/house_fall.gif)
+![model home](https://brianlauritzen.files.wordpress.com/2013/05/house_fall.gif)
 
-un monorepo contenant dotfiles, outils et trucs pour une informatique reproductible depuis 2005.
+a monorepo containing dotfiles, tools, and things for reproducible computering since 2005.
 
     $ git rev-list --max-parents=0 --pretty HEAD
     commit 165210edc61ec09e133b8e0af26d98e1e46de2ea
@@ -14,11 +14,11 @@ un monorepo contenant dotfiles, outils et trucs pour une informatique reproducti
         [project @ 2005-06-11 16:26:33 by will]
         initial import into CVS
 
-## versions
+## releases
 
-vous (moi) obtenez une archive-exécutable universelle qui fonctionne sur mac (arm64) et linux (arm64, x86_64 -- y compris le truc gvisor où vit claude.ai/code) avec dotfiles et outils (`home`). et *ça* sait récupérer des archives spécifiques à la plateforme avec le reste (outils pratiques).
+you (i) get a universal executable-archive that works on mac (arm64) and linux (arm64, x86_64 -- including the gvisor thingy that claude.ai/code lives in) with dotfiles and tools (`home`). and *that* knows how to fetch platform-specific archives with the rest (handy tools).
 
-la dernière version est à https://github.com/whilp/world/releases/latest
+latest release is at https://github.com/whilp/world/releases/latest
 
 ### yolo
 
@@ -26,9 +26,9 @@ la dernière version est à https://github.com/whilp/world/releases/latest
 curl -fsSL https://github.com/whilp/world/releases/latest/download/home | sh
 ```
 
-### essayer lua
+### try lua
 
-lua est disponible depuis [whilp/cosmopolitan](https://github.com/whilp/cosmopolitan/releases/latest) :
+lua is available from [whilp/cosmopolitan](https://github.com/whilp/cosmopolitan/releases/latest):
 
 ```console
 $ curl -fsSLO https://github.com/whilp/cosmopolitan/releases/latest/download/lua && chmod +x lua
@@ -67,13 +67,13 @@ Returns:
 
 ## forks
 
-- [neovim](https://github.com/whilp/neovim) (fork de [neovim](https://neovim.io))
-  - principalement pour figer une version
-  - le build dans ce repo embarque neovim avec les plugins que j'utilise (au moment du build)
-- [cosmopolitan](https://github.com/whilp/cosmopolitan) (fork de [cosmopolitan](https://justine.lol/cosmopolitan/)) - construit des exécutables vraiment portables :
-  - `lua` avec toutes les bonnes choses de [`redbean`](https://redbean.dev) (`unix`, `path`, `re`, `sqlite3`, `argon2`, `json`, `cosmo`) plus des améliorations pour `Fetch` (support de proxy authentifiant). les modules lua purs sont zippés dans le binaire.
-  - `make`, `zip`, `unzip` pour le bootstrapping
+- [neovim](https://github.com/whilp/neovim) (fork of [neovim](https://neovim.io))
+  - mostly to pin a snapshot
+  - the build in this repo bundles neovim with the plugins i use (at buildtime)
+- [cosmopolitan](https://github.com/whilp/cosmopolitan) (fork of [cosmopolitan](https://justine.lol/cosmopolitan/)) - builds actually portable executables:
+  - `lua` with all the goodies from [`redbean`](https://redbean.dev) (`unix`, `path`, `re`, `sqlite3`, `argon2`, `json`, `cosmo`) plus enhancements for `Fetch` (authenticating proxy support). pure lua modules get zipped inside the binary.
+  - `make`, `zip`, `unzip` for bootstrapping
 
-## licence
+## license
 
-Ce dépôt est sous licence MIT. Vous êtes libre d'emprunter, utiliser ou adapter tout code ici pour vos propres projets. Voir le fichier [LICENSE](LICENSE) pour les détails.
+This repository is licensed under the MIT License. You are welcome to borrow, use, or adapt any code here for your own projects. See the [LICENSE](LICENSE) file for details.

--- a/lib/build/make-help.snap
+++ b/lib/build/make-help.snap
@@ -10,6 +10,7 @@ Targets:
   luacheck            Run luacheck linter on all files
   teal                Run teal type checker on all files
   clean               Remove all build artifacts
+  bootstrap           Bootstrap build environment
   check               Run all linters (astgrep, luacheck, teal)
   update              Check for dependency updates
   bump                Apply dependency updates (use with only=<module>)

--- a/lib/skill/hook.lua
+++ b/lib/skill/hook.lua
@@ -145,9 +145,9 @@ local function session_start_make_help(input)
   local cwd = input.cwd or unix.getcwd()
   local make = path.join(cwd, "bin/make")
 
-  -- bootstrap first (creates o/bootstrap/cosmic if needed)
+  -- bootstrap first
   local spawn = require("cosmic.spawn").spawn
-  local bootstrap = spawn({make, "o/bootstrap/cosmic"})
+  local bootstrap = spawn({make, "bootstrap"})
   bootstrap:wait()
 
   local help = spawn_capture({make, "help"})

--- a/lib/skill/hook.lua
+++ b/lib/skill/hook.lua
@@ -141,12 +141,16 @@ local function session_start_make_help(input)
     return nil
   end
 
+  -- use bin/make to ensure cosmo-make is available
+  local cwd = input.cwd or unix.getcwd()
+  local make = path.join(cwd, "bin/make")
+
   -- bootstrap first (creates o/bootstrap/cosmic if needed)
   local spawn = require("cosmic.spawn").spawn
-  local bootstrap = spawn({"make", "o/bootstrap/cosmic"})
+  local bootstrap = spawn({make, "o/bootstrap/cosmic"})
   bootstrap:wait()
 
-  local help = spawn_capture({"make", "help"})
+  local help = spawn_capture({make, "help"})
   if not help or help == "" then
     return nil
   end

--- a/lib/skill/hook.lua
+++ b/lib/skill/hook.lua
@@ -240,6 +240,22 @@ local function stop_check_pr_file(input)
 end
 register(stop_check_pr_file)
 
+local function stop_check_reminder(input)
+  if input.hook_event_name ~= "Stop" then
+    return nil
+  end
+
+  local branch = spawn_capture({"git", "rev-parse", "--abbrev-ref", "HEAD"})
+  if not branch or branch == "main" or branch == "master" then
+    return nil
+  end
+
+  return {
+    reason = "Remember to run checks on feature branches (see `make help`)"
+  }
+end
+register(stop_check_reminder)
+
 --------------------------------------------------------------------------------
 -- module
 --------------------------------------------------------------------------------

--- a/lib/skill/hook.lua
+++ b/lib/skill/hook.lua
@@ -141,6 +141,11 @@ local function session_start_make_help(input)
     return nil
   end
 
+  -- bootstrap first (creates o/bootstrap/cosmic if needed)
+  local spawn = require("cosmic.spawn").spawn
+  local bootstrap = spawn({"make", "o/bootstrap/cosmic"})
+  bootstrap:wait()
+
   local help = spawn_capture({"make", "help"})
   if not help or help == "" then
     return nil

--- a/lib/skill/test_hook.lua
+++ b/lib/skill/test_hook.lua
@@ -215,3 +215,49 @@ local function test_run_integration()
   assert(code == 0, "expected success")
 end
 test_run_integration()
+
+--------------------------------------------------------------------------------
+-- post_commit_pr_reminder tests
+--------------------------------------------------------------------------------
+
+local function test_post_commit_pr_reminder_skip_non_bash()
+  local input = {hook_event_name = "PostToolUse", tool_name = "Edit"}
+  local result = hook.dispatch(input)
+  -- should not produce pr reminder output for non-Bash tools
+  assert(not result or not result.hookSpecificOutput, "expected no output for Edit tool")
+end
+test_post_commit_pr_reminder_skip_non_bash()
+
+local function test_post_commit_pr_reminder_skip_non_commit()
+  local input = {
+    hook_event_name = "PostToolUse",
+    tool_name = "Bash",
+    tool_input = {command = "ls -la"},
+  }
+  local result = hook.dispatch(input)
+  -- should not produce pr reminder for non-commit commands
+  assert(not result or not result.hookSpecificOutput, "expected no output for ls command")
+end
+test_post_commit_pr_reminder_skip_non_commit()
+
+--------------------------------------------------------------------------------
+-- stop_check_reminder tests
+--------------------------------------------------------------------------------
+
+local function test_stop_check_reminder_on_feature_branch()
+  local input = {hook_event_name = "Stop"}
+  local result = hook.dispatch(input)
+  -- we're on a feature branch, so should get reminder
+  if result and result.reason then
+    assert(result.reason:match("make help"), "expected make help in reminder")
+  end
+end
+test_stop_check_reminder_on_feature_branch()
+
+local function test_stop_check_reminder_skip_non_stop()
+  local input = {hook_event_name = "SessionStart"}
+  local result = hook.dispatch(input)
+  -- stop reminder should not fire for SessionStart
+  assert(not result or not result.reason or not result.reason:match("checks"), "expected no check reminder")
+end
+test_stop_check_reminder_skip_non_stop()


### PR DESCRIPTION
Fix the SessionStart hook to properly display make targets by bootstrapping first.

- Makefile - add `bootstrap` target for explicit bootstrapping
- lib/skill/hook.lua - run `make bootstrap` before `make help`, use `bin/make` for portability

## Problem

The `session_start_make_help` handler runs `make help` on startup, but this fails on fresh checkouts because `o/bootstrap/cosmic` doesn't exist yet. The error was silently swallowed.

## Solution

1. Add explicit `bootstrap` target to Makefile (avoids hardcoding `o/` path)
2. Run `make bootstrap` before `make help` in the hook
3. Use `bin/make` wrapper to ensure cosmo-make is available regardless of PATH state

## Validation

- [x] hook outputs make targets on SessionStart
- [x] works on fresh checkout without existing build artifacts

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-09T15:47:46Z
</details>