### PR TITLE
skill/hooks: add command to manage hook configuration

### DIFF
--- a/.claude/hooks.lua
+++ b/.claude/hooks.lua
@@ -1,0 +1,11 @@
+-- hooks configuration
+-- each handler can be:
+--   true              -> enabled with defaults
+--   false             -> disabled
+--   { enabled = bool, ... }  -> enabled with config options
+return {
+  post_commit_pr_reminder = true,
+  session_start_bootstrap = true,
+  session_start_make_help = true,
+  stop_check_pr_file = true,
+}

--- a/.gitignore
+++ b/.gitignore
@@ -181,5 +181,6 @@ results/
 bin/
 !bin/cosmic
 !bin/hook
+!bin/hooks
 !bin/run-test
 !bin/make

--- a/bin/hooks
+++ b/bin/hooks
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+export LUA_PATH="$PROJECT_DIR/lib/?.lua;$PROJECT_DIR/lib/?/init.lua;;"
+
+# Pass all arguments via _G.arg
+args=""
+for arg in "$@"; do
+  # Escape single quotes in arguments
+  escaped=$(printf '%s' "$arg" | sed "s/'/\\\\'/g")
+  if [ -z "$args" ]; then
+    args="'$escaped'"
+  else
+    args="$args, '$escaped'"
+  fi
+done
+
+exec "$SCRIPT_DIR/cosmic" -e "_G.arg = {$args}; require('skill.hooks').main()"

--- a/lib/skill/hooks.lua
+++ b/lib/skill/hooks.lua
@@ -1,0 +1,403 @@
+-- hooks - manage claude code hook configuration
+-- usage: cosmic -l skill hooks <command> [args...]
+
+local cosmo = require("cosmo")
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+
+local M = {}
+
+-- available handlers that can be enabled/disabled
+M.available_handlers = {
+  session_start_bootstrap = {
+    description = "Add bin/ to PATH on session start",
+    event = "SessionStart",
+  },
+  session_start_make_help = {
+    description = "Display make help on session start",
+    event = "SessionStart",
+  },
+  post_commit_pr_reminder = {
+    description = "Remind about PR files after git commits",
+    event = "PostToolUse",
+  },
+  stop_check_pr_file = {
+    description = "Block stop unless PR file exists and is up-to-date",
+    event = "Stop",
+  },
+}
+
+local function log(msg)
+  io.stderr:write("hooks: " .. msg .. "\n")
+end
+
+-- find the hooks config file path
+local function get_config_path()
+  local cwd = unix.getcwd()
+  if not cwd then
+    return nil, "failed to get cwd"
+  end
+  return path.join(cwd, ".claude", "hooks.lua")
+end
+
+-- load hooks config from file
+function M.load_config(config_path)
+  config_path = config_path or get_config_path()
+  if not config_path then
+    return nil, "failed to get config path"
+  end
+
+  if not path.exists(config_path) then
+    -- return empty config if file doesn't exist
+    return {}
+  end
+
+  local chunk, err = loadfile(config_path)
+  if not chunk then
+    return nil, "failed to load " .. config_path .. ": " .. tostring(err)
+  end
+
+  local ok, result = pcall(chunk)
+  if not ok then
+    return nil, "failed to execute " .. config_path .. ": " .. tostring(result)
+  end
+
+  if type(result) ~= "table" then
+    return nil, "config must return a table"
+  end
+
+  return result
+end
+
+-- serialize a lua value to string
+local function serialize_value(v, indent)
+  indent = indent or ""
+  local t = type(v)
+
+  if t == "string" then
+    return string.format("%q", v)
+  elseif t == "number" or t == "boolean" then
+    return tostring(v)
+  elseif t == "table" then
+    local parts = {}
+    local next_indent = indent .. "  "
+
+    -- check if table is array-like
+    local is_array = true
+    local max_index = 0
+    for k, _ in pairs(v) do
+      if type(k) ~= "number" or k < 1 or math.floor(k) ~= k then
+        is_array = false
+        break
+      end
+      if k > max_index then max_index = k end
+    end
+    is_array = is_array and max_index == #v
+
+    if is_array then
+      for i, val in ipairs(v) do
+        parts[i] = next_indent .. serialize_value(val, next_indent)
+      end
+      if #parts == 0 then
+        return "{}"
+      end
+      return "{\n" .. table.concat(parts, ",\n") .. ",\n" .. indent .. "}"
+    else
+      -- sort keys for consistent output
+      local keys = {}
+      for k in pairs(v) do
+        keys[#keys + 1] = k
+      end
+      table.sort(keys, function(a, b)
+        return tostring(a) < tostring(b)
+      end)
+
+      for _, k in ipairs(keys) do
+        local key_str
+        if type(k) == "string" and k:match("^[%a_][%w_]*$") then
+          key_str = k
+        else
+          key_str = "[" .. serialize_value(k) .. "]"
+        end
+        parts[#parts + 1] = next_indent .. key_str .. " = " .. serialize_value(v[k], next_indent)
+      end
+
+      if #parts == 0 then
+        return "{}"
+      end
+      return "{\n" .. table.concat(parts, ",\n") .. ",\n" .. indent .. "}"
+    end
+  else
+    return "nil"
+  end
+end
+
+-- save hooks config to file
+function M.save_config(config, config_path)
+  config_path = config_path or get_config_path()
+  if not config_path then
+    return nil, "failed to get config path"
+  end
+
+  -- ensure .claude directory exists
+  local dir = path.dirname(config_path)
+  if not path.exists(dir) then
+    local ok, err = unix.makedirs(dir, tonumber("755", 8))
+    if not ok then
+      return nil, "failed to create directory " .. dir .. ": " .. tostring(err)
+    end
+  end
+
+  local content = "-- hooks configuration\n"
+  content = content .. "-- each handler can be:\n"
+  content = content .. "--   true              -> enabled with defaults\n"
+  content = content .. "--   false             -> disabled\n"
+  content = content .. "--   { enabled = bool, ... }  -> enabled with config options\n"
+  content = content .. "return " .. serialize_value(config) .. "\n"
+
+  local f, err = io.open(config_path, "w")
+  if not f then
+    return nil, "failed to open " .. config_path .. ": " .. tostring(err)
+  end
+
+  local ok, write_err = f:write(content)
+  f:close()
+
+  if not ok then
+    return nil, "failed to write " .. config_path .. ": " .. tostring(write_err)
+  end
+
+  return true
+end
+
+-- check if a handler is enabled in config
+function M.is_enabled(config, handler_name)
+  local entry = config[handler_name]
+  if entry == nil then
+    return false
+  end
+  if type(entry) == "boolean" then
+    return entry
+  end
+  if type(entry) == "table" then
+    return entry.enabled ~= false
+  end
+  return false
+end
+
+-- get config options for a handler
+function M.get_handler_config(config, handler_name)
+  local entry = config[handler_name]
+  if type(entry) == "table" then
+    return entry
+  end
+  return {}
+end
+
+-- command: show - display current configuration
+local function cmd_show()
+  local config, err = M.load_config()
+  if not config then
+    return 1, err
+  end
+
+  print("-- hooks configuration")
+  print("return " .. serialize_value(config))
+  return 0
+end
+
+-- command: list - list available handlers
+local function cmd_list()
+  local config, err = M.load_config()
+  if not config then
+    return 1, err
+  end
+
+  -- group by event
+  local by_event = {}
+  for name, info in pairs(M.available_handlers) do
+    local event = info.event
+    if not by_event[event] then
+      by_event[event] = {}
+    end
+    by_event[event][#by_event[event] + 1] = {name = name, info = info}
+  end
+
+  -- sort events
+  local events = {}
+  for event in pairs(by_event) do
+    events[#events + 1] = event
+  end
+  table.sort(events)
+
+  for _, event in ipairs(events) do
+    print(event .. ":")
+    -- sort handlers within event
+    local handlers = by_event[event]
+    table.sort(handlers, function(a, b) return a.name < b.name end)
+
+    for _, h in ipairs(handlers) do
+      local status = M.is_enabled(config, h.name) and "[enabled]" or "[disabled]"
+      print(string.format("  %s %s", status, h.name))
+      print(string.format("    %s", h.info.description))
+    end
+  end
+
+  return 0
+end
+
+-- command: add - enable a handler
+local function cmd_add(handler_name, ...)
+  if not handler_name then
+    return 1, "usage: hooks add <handler> [key=value ...]"
+  end
+
+  if not M.available_handlers[handler_name] then
+    return 1, "unknown handler: " .. handler_name .. "\nuse 'hooks list' to see available handlers"
+  end
+
+  local config, err = M.load_config()
+  if not config then
+    return 1, err
+  end
+
+  -- parse optional config options
+  local opts = {...}
+  if #opts > 0 then
+    local handler_opts = {enabled = true}
+    for _, opt in ipairs(opts) do
+      local key, value = opt:match("^([^=]+)=(.+)$")
+      if key and value then
+        -- try to parse value as boolean or number
+        if value == "true" then
+          handler_opts[key] = true
+        elseif value == "false" then
+          handler_opts[key] = false
+        elseif tonumber(value) then
+          handler_opts[key] = tonumber(value)
+        else
+          handler_opts[key] = value
+        end
+      else
+        return 1, "invalid option format: " .. opt .. " (expected key=value)"
+      end
+    end
+    config[handler_name] = handler_opts
+  else
+    config[handler_name] = true
+  end
+
+  local ok
+  ok, err = M.save_config(config)
+  if not ok then
+    return 1, err
+  end
+
+  log("enabled " .. handler_name)
+  return 0
+end
+
+-- command: remove - disable a handler
+local function cmd_remove(handler_name)
+  if not handler_name then
+    return 1, "usage: hooks remove <handler>"
+  end
+
+  local config, err = M.load_config()
+  if not config then
+    return 1, err
+  end
+
+  if config[handler_name] == nil then
+    log(handler_name .. " is not configured")
+    return 0
+  end
+
+  config[handler_name] = nil
+
+  local ok
+  ok, err = M.save_config(config)
+  if not ok then
+    return 1, err
+  end
+
+  log("removed " .. handler_name)
+  return 0
+end
+
+-- command: disable - disable a handler but keep config
+local function cmd_disable(handler_name)
+  if not handler_name then
+    return 1, "usage: hooks disable <handler>"
+  end
+
+  local config, err = M.load_config()
+  if not config then
+    return 1, err
+  end
+
+  local current = config[handler_name]
+  if type(current) == "table" then
+    current.enabled = false
+    config[handler_name] = current
+  else
+    config[handler_name] = false
+  end
+
+  local ok
+  ok, err = M.save_config(config)
+  if not ok then
+    return 1, err
+  end
+
+  log("disabled " .. handler_name)
+  return 0
+end
+
+local function print_help()
+  print([[
+usage: hooks <command> [args...]
+
+Manage Claude Code hook configuration stored in .claude/hooks.lua
+
+Commands:
+  show              Display current hooks configuration
+  list              List available handlers with status
+  add <handler>     Enable a handler (optionally with key=value config)
+  remove <handler>  Remove a handler from configuration
+  disable <handler> Disable a handler but keep its configuration
+
+Examples:
+  hooks show
+  hooks list
+  hooks add session_start_make_help
+  hooks add stop_check_pr_file strict=true
+  hooks disable post_commit_pr_reminder
+  hooks remove stop_check_pr_file
+]])
+end
+
+function M.main()
+  local cmd = arg[1]
+
+  if not cmd or cmd == "-h" or cmd == "--help" or cmd == "help" then
+    print_help()
+    return 0
+  end
+
+  if cmd == "show" then
+    return cmd_show()
+  elseif cmd == "list" then
+    return cmd_list()
+  elseif cmd == "add" then
+    return cmd_add(arg[2], select(3, table.unpack(arg)))
+  elseif cmd == "remove" then
+    return cmd_remove(arg[2])
+  elseif cmd == "disable" then
+    return cmd_disable(arg[2])
+  else
+    return 1, "unknown command: " .. cmd .. "\nuse 'hooks help' for usage"
+  end
+end
+
+return M

--- a/lib/skill/init.lua
+++ b/lib/skill/init.lua
@@ -4,12 +4,16 @@
 -- teal ignore: type annotations needed
 local cosmo = require("cosmo")
 
+local subcommands = {"update-pr", "hooks"}
+
 local function find_subcommand()
   if not arg then return nil end
 
   for i = -1, #arg do
-    if arg[i] == "update-pr" then
-      return "update-pr", i
+    for _, cmd in ipairs(subcommands) do
+      if arg[i] == cmd then
+        return cmd, i
+      end
     end
   end
 
@@ -34,6 +38,13 @@ if subcommand then
   if subcommand == "update-pr" then
     local pr = require("skill.pr")
     local code, msg = pr.main()
+    if msg then
+      io.stderr:write(msg .. "\n")
+    end
+    os.exit(code or 0)
+  elseif subcommand == "hooks" then
+    local hooks = require("skill.hooks")
+    local code, msg = hooks.main()
     if msg then
       io.stderr:write(msg .. "\n")
     end

--- a/lib/skill/pr-comments.lua
+++ b/lib/skill/pr-comments.lua
@@ -1,0 +1,213 @@
+-- pr-comments - fetch review comments for a PR
+-- usage: cosmic -e "require('skill.pr-comments').main()"
+
+local cosmo = require("cosmo")
+
+local function github_request(method, endpoint, token)
+  local api_url = os.getenv("GITHUB_API_URL") or "https://api.github.com"
+  local url = api_url .. endpoint
+
+  local fetch_opts = {
+    method = method,
+    headers = {
+      ["Accept"] = "application/vnd.github+json",
+      ["X-GitHub-Api-Version"] = "2022-11-28",
+      ["User-Agent"] = "pr-comments.lua/1.0",
+    },
+  }
+
+  if token and token ~= "" then
+    fetch_opts.headers["Authorization"] = "Bearer " .. token
+  end
+
+  local status, headers, response_body = cosmo.Fetch(url, fetch_opts)
+  if not status then
+    return nil, "fetch failed: " .. tostring(headers)
+  end
+
+  local ok, decoded = pcall(cosmo.DecodeJson, response_body)
+  if not ok then
+    return nil, "json decode failed: " .. tostring(decoded)
+  end
+
+  return status, decoded
+end
+
+-- find PR by branch name
+local function find_pr_by_branch(owner, repo, branch, token)
+  local endpoint = string.format("/repos/%s/%s/pulls?head=%s:%s&state=open",
+    owner, repo, owner, branch)
+
+  local status, data = github_request("GET", endpoint, token)
+  if not status then
+    return nil, data
+  end
+
+  if status ~= 200 then
+    return nil, "api error: " .. tostring(status)
+  end
+
+  if #data == 0 then
+    return nil, "no open PR found for branch: " .. branch
+  end
+
+  return data[1]
+end
+
+-- get review comments (comments on specific lines of code)
+local function get_review_comments(owner, repo, pr_number, token)
+  local endpoint = string.format("/repos/%s/%s/pulls/%d/comments", owner, repo, pr_number)
+
+  local status, data = github_request("GET", endpoint, token)
+  if not status then
+    return nil, data
+  end
+
+  if status ~= 200 then
+    return nil, "api error: " .. tostring(status)
+  end
+
+  return data
+end
+
+-- get issue comments (general PR comments, not on specific lines)
+local function get_issue_comments(owner, repo, pr_number, token)
+  local endpoint = string.format("/repos/%s/%s/issues/%d/comments", owner, repo, pr_number)
+
+  local status, data = github_request("GET", endpoint, token)
+  if not status then
+    return nil, data
+  end
+
+  if status ~= 200 then
+    return nil, "api error: " .. tostring(status)
+  end
+
+  return data
+end
+
+-- get reviews (approval/request changes with body)
+local function get_reviews(owner, repo, pr_number, token)
+  local endpoint = string.format("/repos/%s/%s/pulls/%d/reviews", owner, repo, pr_number)
+
+  local status, data = github_request("GET", endpoint, token)
+  if not status then
+    return nil, data
+  end
+
+  if status ~= 200 then
+    return nil, "api error: " .. tostring(status)
+  end
+
+  return data
+end
+
+local function format_comment(c, kind)
+  local author = c.user and c.user.login or "unknown"
+  local body = c.body or ""
+  local created = c.created_at or ""
+
+  local header = string.format("## %s by @%s (%s)", kind, author, created:sub(1, 10))
+
+  if c.path then
+    header = header .. string.format("\nFile: %s", c.path)
+    if c.line then
+      header = header .. string.format(":%d", c.line)
+    elseif c.original_line then
+      header = header .. string.format(":%d", c.original_line)
+    end
+  end
+
+  if c.state and c.state ~= "COMMENTED" then
+    header = header .. string.format("\nState: %s", c.state)
+  end
+
+  return header .. "\n\n" .. body .. "\n"
+end
+
+local function main()
+  local token = os.getenv("GITHUB_TOKEN")
+  if not token or token == "" then
+    io.stderr:write("GITHUB_TOKEN not set\n")
+    io.stderr:write("Set it with: export GITHUB_TOKEN=<your-token>\n")
+    return 1
+  end
+
+  local repo = os.getenv("GITHUB_REPOSITORY") or "whilp/world"
+  local owner, repo_name = repo:match("^([^/]+)/(.+)$")
+  if not owner then
+    io.stderr:write("invalid GITHUB_REPOSITORY: " .. repo .. "\n")
+    return 1
+  end
+
+  -- get branch from current git branch
+  local spawn = require("cosmic.spawn").spawn
+  local handle = spawn({"git", "rev-parse", "--abbrev-ref", "HEAD"})
+  local ok, out = handle:read()
+  local branch
+  if ok and out then
+    branch = out:match("^%s*(.-)%s*$")
+  end
+
+  if not branch then
+    io.stderr:write("could not determine branch\n")
+    return 1
+  end
+
+  io.stderr:write("Looking for PR on branch: " .. branch .. "\n")
+
+  -- find PR
+  local pr, err = find_pr_by_branch(owner, repo_name, branch, token)
+  if not pr then
+    io.stderr:write("error: " .. tostring(err) .. "\n")
+    return 1
+  end
+
+  local pr_number = pr.number
+  io.stderr:write(string.format("Found PR #%d: %s\n\n", pr_number, pr.title))
+
+  -- get all types of comments
+  local review_comments = get_review_comments(owner, repo_name, pr_number, token) or {}
+  local issue_comments = get_issue_comments(owner, repo_name, pr_number, token) or {}
+  local reviews = get_reviews(owner, repo_name, pr_number, token) or {}
+
+  local has_comments = false
+
+  -- print reviews with body
+  for _, r in ipairs(reviews) do
+    if r.body and r.body ~= "" then
+      print(format_comment(r, "Review"))
+      has_comments = true
+    end
+  end
+
+  -- print issue comments
+  for _, c in ipairs(issue_comments) do
+    print(format_comment(c, "Comment"))
+    has_comments = true
+  end
+
+  -- print review comments (on specific lines)
+  for _, c in ipairs(review_comments) do
+    print(format_comment(c, "Line Comment"))
+    has_comments = true
+  end
+
+  if not has_comments then
+    print("No comments found on this PR.")
+  end
+
+  return 0
+end
+
+if cosmo.is_main() then
+  os.exit(main())
+end
+
+return {
+  main = main,
+  find_pr_by_branch = find_pr_by_branch,
+  get_review_comments = get_review_comments,
+  get_issue_comments = get_issue_comments,
+  get_reviews = get_reviews,
+}

--- a/lib/skill/test_hooks.lua
+++ b/lib/skill/test_hooks.lua
@@ -1,0 +1,132 @@
+#!/usr/bin/env run-test.lua
+-- teal ignore: test file
+
+local hooks = require("skill.hooks")
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+
+local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
+
+--------------------------------------------------------------------------------
+-- serialize tests
+--------------------------------------------------------------------------------
+
+local function test_load_config_empty()
+  -- test loading from non-existent file returns empty table
+  local config_path = path.join(tmpdir, "nonexistent_hooks.lua")
+  local config = hooks.load_config(config_path)
+  assert(type(config) == "table", "expected table")
+  assert(next(config) == nil, "expected empty table")
+end
+test_load_config_empty()
+
+local function test_save_and_load_config()
+  local config_path = path.join(tmpdir, "test_hooks.lua")
+
+  -- save config
+  local config = {
+    session_start_bootstrap = true,
+    session_start_make_help = false,
+    stop_check_pr_file = {enabled = true, strict = false},
+  }
+  local ok, err = hooks.save_config(config, config_path)
+  assert(ok, "save failed: " .. tostring(err))
+
+  -- load config
+  local loaded = hooks.load_config(config_path)
+  assert(loaded.session_start_bootstrap == true, "expected bootstrap true")
+  assert(loaded.session_start_make_help == false, "expected make_help false")
+  assert(type(loaded.stop_check_pr_file) == "table", "expected stop_check_pr_file table")
+  assert(loaded.stop_check_pr_file.enabled == true, "expected enabled true")
+  assert(loaded.stop_check_pr_file.strict == false, "expected strict false")
+
+  -- cleanup
+  os.remove(config_path)
+end
+test_save_and_load_config()
+
+--------------------------------------------------------------------------------
+-- is_enabled tests
+--------------------------------------------------------------------------------
+
+local function test_is_enabled()
+  local config = {
+    enabled_bool = true,
+    disabled_bool = false,
+    enabled_table = {enabled = true, option = "value"},
+    disabled_table = {enabled = false, option = "value"},
+    implicit_enabled = {option = "value"},
+  }
+
+  assert(hooks.is_enabled(config, "enabled_bool"), "expected enabled_bool enabled")
+  assert(not hooks.is_enabled(config, "disabled_bool"), "expected disabled_bool disabled")
+  assert(hooks.is_enabled(config, "enabled_table"), "expected enabled_table enabled")
+  assert(not hooks.is_enabled(config, "disabled_table"), "expected disabled_table disabled")
+  assert(hooks.is_enabled(config, "implicit_enabled"), "expected implicit_enabled enabled")
+  assert(not hooks.is_enabled(config, "not_present"), "expected not_present disabled")
+end
+test_is_enabled()
+
+--------------------------------------------------------------------------------
+-- get_handler_config tests
+--------------------------------------------------------------------------------
+
+local function test_get_handler_config()
+  local config = {
+    with_options = {enabled = true, strict = true, timeout = 30},
+    bool_only = true,
+  }
+
+  local opts = hooks.get_handler_config(config, "with_options")
+  assert(opts.strict == true, "expected strict option")
+  assert(opts.timeout == 30, "expected timeout option")
+
+  opts = hooks.get_handler_config(config, "bool_only")
+  assert(next(opts) == nil, "expected empty options for bool config")
+end
+test_get_handler_config()
+
+--------------------------------------------------------------------------------
+-- available_handlers tests
+--------------------------------------------------------------------------------
+
+local function test_available_handlers()
+  assert(hooks.available_handlers.session_start_bootstrap, "expected session_start_bootstrap")
+  assert(hooks.available_handlers.session_start_make_help, "expected session_start_make_help")
+  assert(hooks.available_handlers.post_commit_pr_reminder, "expected post_commit_pr_reminder")
+  assert(hooks.available_handlers.stop_check_pr_file, "expected stop_check_pr_file")
+
+  -- check structure
+  local handler = hooks.available_handlers.session_start_bootstrap
+  assert(handler.description, "expected description")
+  assert(handler.event == "SessionStart", "expected event")
+end
+test_available_handlers()
+
+--------------------------------------------------------------------------------
+-- integration tests (with temp directory)
+--------------------------------------------------------------------------------
+
+local function test_config_roundtrip()
+  local config_dir = path.join(tmpdir, ".claude")
+  unix.makedirs(config_dir, tonumber("755", 8))
+  local config_path = path.join(config_dir, "hooks.lua")
+
+  -- test full roundtrip
+  local original = {
+    session_start_bootstrap = true,
+    stop_check_pr_file = {enabled = true, strict = false},
+  }
+
+  local ok, err = hooks.save_config(original, config_path)
+  assert(ok, "save failed: " .. tostring(err))
+
+  local loaded = hooks.load_config(config_path)
+  assert(loaded.session_start_bootstrap == true, "bootstrap mismatch")
+  assert(loaded.stop_check_pr_file.strict == false, "strict mismatch")
+
+  -- cleanup
+  os.remove(config_path)
+  unix.rmrf(config_dir)
+end
+test_config_roundtrip()


### PR DESCRIPTION
Add a hooks command to interact with Claude Code hook configuration:
- hooks show: display current configuration
- hooks list: list available handlers with enabled/disabled status
- hooks add <handler>: enable a handler (with optional key=value config)
- hooks remove <handler>: remove a handler from config
- hooks disable <handler>: disable without removing config

Configuration is stored in .claude/hooks.lua as a serialized Lua table
(similar to version.lua). Handlers can be enabled with `true`, disabled
with `false`, or configured with a table like `{enabled = true, strict = false}`.

Updates hook.lua dispatcher to read config and only run enabled handlers.
Each handler receives its config options as a second parameter.