### PR TITLE
skill/hook: add stop_hook_active check and 15s timeout

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/bin/hook\""
+            "command": "\"$CLAUDE_PROJECT_DIR/bin/hook\"",
+            "timeout": 15
           }
         ]
       }
@@ -17,7 +18,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/bin/hook\""
+            "command": "\"$CLAUDE_PROJECT_DIR/bin/hook\"",
+            "timeout": 15
           }
         ]
       }
@@ -28,7 +30,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/bin/hook\""
+            "command": "\"$CLAUDE_PROJECT_DIR/bin/hook\"",
+            "timeout": 15
           }
         ]
       }

--- a/.github/pr/stop-hook-timeout.md
+++ b/.github/pr/stop-hook-timeout.md
@@ -1,0 +1,10 @@
+# skill/hook: add stop_hook_active check and 15s timeout
+
+Prevent infinite loops in stop hooks and add timeout safety.
+
+- lib/skill/hook.lua - check stop_hook_active in Stop handlers to exit early when already continuing
+- .claude/settings.json - add 15s timeout to all hooks (SessionStart, PostToolUse, Stop)
+
+## Validation
+
+- [x] tests pass

--- a/lib/skill/hook.lua
+++ b/lib/skill/hook.lua
@@ -213,6 +213,9 @@ local function stop_check_commit_trailer(input)
   if input.hook_event_name ~= "Stop" then
     return nil
   end
+  if input.stop_hook_active then
+    return nil
+  end
 
   local branch = spawn_capture({"git", "rev-parse", "--abbrev-ref", "HEAD"})
   if not branch or branch == "main" or branch == "master" then
@@ -243,6 +246,9 @@ register(stop_check_commit_trailer)
 
 local function stop_check_reminder(input)
   if input.hook_event_name ~= "Stop" then
+    return nil
+  end
+  if input.stop_hook_active then
     return nil
   end
 


### PR DESCRIPTION
Prevent infinite loops in stop hooks and add timeout safety.

- lib/skill/hook.lua - check stop_hook_active in Stop handlers to exit early when already continuing
- .claude/settings.json - add 15s timeout to all hooks (SessionStart, PostToolUse, Stop)

## Validation

- [x] tests pass

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-10T21:20:30Z
</details>