### PR TITLE
skill/hook: convert stop hooks to post tool use on git push

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,17 +13,6 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/bin/hook\""
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
         "matcher": "",
         "hooks": [
           {

--- a/.github/pr/convert-stop-hooks.md
+++ b/.github/pr/convert-stop-hooks.md
@@ -1,0 +1,17 @@
+# skill/hook: convert stop hooks to post tool use on git push
+
+Convert stop hooks to PostToolUse hooks triggered on git push instead of session end.
+
+- settings.json: remove Stop hook, change PostToolUse matcher to "" (match all)
+- hook.lua: stop_check_commit_trailer → post_push_pr_check
+- hook.lua: stop_check_reminder → post_push_check_reminder
+- test_hook.lua: update tests for new post_push handler behavior
+
+## Rationale
+
+Stop hooks fire at session end which is too late for actionable feedback. By triggering on git push, users get immediate feedback about PR descriptions and running checks right when they push.
+
+## Validation
+
+- [x] make test passes
+- [x] hook tests updated and passing


### PR DESCRIPTION
Convert stop hooks to PostToolUse hooks triggered on git push instead of session end.

- settings.json: remove Stop hook, change PostToolUse matcher to "" (match all)
- hook.lua: stop_check_commit_trailer → post_push_pr_check
- hook.lua: stop_check_reminder → post_push_check_reminder
- test_hook.lua: update tests for new post_push handler behavior

## Rationale

Stop hooks fire at session end which is too late for actionable feedback. By triggering on git push, users get immediate feedback about PR descriptions and running checks right when they push.

## Validation

- [x] make test passes
- [x] hook tests updated and passing

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-10T21:39:30Z
</details>