### PR TITLE
build: add missing bootstrap_cosmic dependencies

### DIFF
--- a/.github/pr/fix-bootstrap-deps.md
+++ b/.github/pr/fix-bootstrap-deps.md
@@ -1,0 +1,22 @@
+# build: add missing bootstrap_cosmic dependencies
+
+Fix release workflow failure caused by missing dependencies on `$(bootstrap_cosmic)`.
+
+## Problem
+
+With parallel builds (`-j`), rules that use `$(bootstrap_cosmic)` in their recipe can start before the binary is built, causing:
+
+```
+/bin/bash: line 1: o/bootstrap/cosmic: No such file or directory
+```
+
+## Changes
+
+- `lib/build/cook.mk` - add order-only dependency to make-help.snap rule
+- `Makefile` - add order-only dependency to help target
+- `Makefile` - add order-only dependency to snap.test.ok pattern rule
+
+## Validation
+
+- [x] `make clean && make -j check test build` passes
+- [x] all 39 tests pass

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ include cook.mk
 
 .PHONY: help
 ## Show this help message
-help: $(build_files)
+help: $(build_files) | $(bootstrap_cosmic)
 	@$(bootstrap_cosmic) $(o)/bin/make-help.lua $(MAKEFILE_LIST)
 
 ## Filter targets by pattern (make test only='skill')
@@ -157,7 +157,7 @@ $(o)/%.test.ok: % $(test_files) | $(bootstrap_files)
 
 # Snapshot test pattern: compare expected vs actual
 $(o)/%.snap.test.ok: .EXTRA_PREREQS = $(build_snap)
-$(o)/%.snap.test.ok: %.snap $(o)/%.snap
+$(o)/%.snap.test.ok: %.snap $(o)/%.snap | $(bootstrap_cosmic)
 	@mkdir -p $(@D)
 	@$(bootstrap_cosmic) $(build_snap) $< $(word 2,$^) > $@
 

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -18,6 +18,6 @@ update_runner := $(bootstrap_cosmic) -- $(build_check_update)
 $(o)/lib/build/test_reporter.lua.test.ok: $$(cosmic_bin) $$(checker_files)
 
 # make-help snapshot: generate actual help output
-$(o)/lib/build/make-help.snap: Makefile $(build_help)
+$(o)/lib/build/make-help.snap: Makefile $(build_help) | $(bootstrap_cosmic)
 	@mkdir -p $(@D)
 	@$(bootstrap_cosmic) $(build_help) Makefile > $@


### PR DESCRIPTION
Fix release workflow failure caused by missing dependencies on `$(bootstrap_cosmic)`.

## Problem

With parallel builds (`-j`), rules that use `$(bootstrap_cosmic)` in their recipe can start before the binary is built, causing:

```
/bin/bash: line 1: o/bootstrap/cosmic: No such file or directory
```

## Changes

- `lib/build/cook.mk` - add order-only dependency to make-help.snap rule
- `Makefile` - add order-only dependency to help target
- `Makefile` - add order-only dependency to snap.test.ok pattern rule

## Validation

- [x] `make clean && make -j check test build` passes
- [x] all 39 tests pass

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-10T22:23:19Z
</details>