### PR TITLE
docs: add teal migration plan

### DIFF
--- a/3p/tl/run-teal.lua
+++ b/3p/tl/run-teal.lua
@@ -9,6 +9,7 @@ local common = require("checker.common")
 
 local supported_extensions = {
   [".lua"] = true,
+  [".tl"] = true,
 }
 
 local supported_patterns = {
@@ -74,8 +75,9 @@ local function main(source)
   end
 
   local tl_bin = path.join(os.getenv("TL_BIN"), "tl")
+  local include_dir = os.getenv("TL_INCLUDE_DIR") or "lib/types"
 
-  local handle = spawn({ tl_bin, "check", source })
+  local handle = spawn({ tl_bin, "check", "-I", include_dir, source })
   if handle.stdin then
     handle.stdin:close()
   end

--- a/docs/teal-migration.md
+++ b/docs/teal-migration.md
@@ -231,15 +231,19 @@ Use Teal's strict mode where possible, but allow `any` types at module boundarie
 
 ### Makefile updates needed
 
-1. Add pattern rule for `.tl` → `.lua` compilation:
+1. Define type declaration files:
    ```makefile
-   $(o)/%.lua: %.tl | $(tl_staged)
-       @mkdir -p $(@D)
-       @$(tl_gen) $< -o $@
+   types_files := $(wildcard lib/types/*.d.tl lib/types/**/*.d.tl)
    ```
 
-2. Update vpath to find `.tl` sources
-3. Ensure type declarations are available during compilation
+2. Add pattern rule for `.tl` → `.lua` compilation:
+   ```makefile
+   $(o)/%.lua: %.tl $(types_files) | $(tl_staged)
+       @mkdir -p $(@D)
+       @$(tl_gen) -I lib/types $< -o $@
+   ```
+
+3. Update vpath to find `.tl` sources
 
 ## Development workflow
 

--- a/docs/teal-migration.md
+++ b/docs/teal-migration.md
@@ -61,10 +61,11 @@ Migrate foundational modules that other code depends on.
 - Good test of the migration workflow
 
 Steps:
-1. Rename `lib/checker/common.lua` → `lib/checker/common.tl`
-2. Add type annotations
-3. Update cook.mk to compile it
-4. Verify tests pass
+1. Remove `-- teal ignore` comment
+2. Rename `lib/checker/common.lua` → `lib/checker/common.tl`
+3. Add type annotations
+4. Update cook.mk to compile it
+5. Verify tests pass
 
 #### PR 2.2: Migrate standalone library files
 
@@ -188,11 +189,7 @@ Recommendation: Start with option 3 (type-check but keep as lua) to get value wi
 
 ### Phase 7: Cleanup
 
-#### PR 7.1: Remove teal ignore comments
-
-Once all files are migrated or properly typed, remove the `-- teal ignore` comments.
-
-#### PR 7.2: Update documentation
+#### PR 7.1: Update documentation
 
 - Update CLAUDE.md with teal patterns
 - Add type annotation guidelines
@@ -262,11 +259,13 @@ run-test test_foo      # run specific test (includes type check)
 
 ### Converting an existing file
 
-1. Rename `foo.lua` → `foo.tl`
-2. Add type annotations
-3. Remove `-- teal ignore` comment
+1. Remove `-- teal ignore` comment (enables type checking immediately)
+2. Rename `foo.lua` → `foo.tl`
+3. Add type annotations
 4. Run `make teal` to verify
 5. Run tests
+
+Note: Remove the `-- teal ignore` directive as part of each file migration, not as a separate cleanup phase. This ensures type checking is enabled immediately for migrated files.
 
 ## Metrics
 

--- a/docs/teal-migration.md
+++ b/docs/teal-migration.md
@@ -1,0 +1,293 @@
+# Teal migration plan
+
+This document outlines the incremental migration from Lua to Teal for comprehensive type checking.
+
+## Goals
+
+1. **Type safety**: Catch type errors at build time, not runtime
+2. **Fast iteration**: Quick typechecking during development via `make teal`
+3. **Clean releases**: Ship teal-compiled lua in release artifacts
+4. **Incremental adoption**: Migrate file-by-file without breaking the build
+
+## Current state
+
+- 107 lua files with `-- teal ignore` comments
+- Teal 0.24.8 installed as 3p dependency
+- `make teal` target exists (runs `tl check` on each file)
+- Checker infrastructure already supports `.tl` extension
+- No `.tl` or `.d.tl` files exist yet
+- No `tlconfig.lua` configuration
+
+## Migration phases
+
+### Phase 1: Foundation
+
+Create the type infrastructure needed for migration.
+
+#### PR 1.1: Add tlconfig.lua and type declarations for external deps
+
+1. Create `tlconfig.lua` at repo root:
+   ```lua
+   return {
+     gen_target = "5.1",
+     gen_compat = "off",
+     include_dir = { "types" },
+     source_dir = ".",
+     build_dir = "o/teal",
+   }
+   ```
+
+2. Create `types/` directory for type declarations
+
+3. Add type declarations for external dependencies:
+   - `types/cosmo.d.tl` - cosmo module (Fetch, is_main, EncodeJson, etc.)
+   - `types/cosmo/unix.d.tl` - unix functions (fork, pipe, exec, etc.)
+   - `types/cosmo/path.d.tl` - path functions (join, basename, dirname, etc.)
+   - `types/luaunit.d.tl` - luaunit testing framework
+   - `types/argparse.d.tl` - argparse library
+
+4. Update `make teal` to use tlconfig.lua
+
+#### PR 1.2: Build system support for .tl files
+
+1. Add `tl gen` compilation step to build pipeline
+2. Update module cook.mk pattern to handle both `.lua` and `.tl` sources
+3. Ensure `.tl` files compile to `.lua` in `o/` directory
+4. Update release target to use compiled lua
+
+### Phase 2: Core modules
+
+Migrate foundational modules that other code depends on.
+
+#### PR 2.1: Migrate lib/checker/common.lua
+
+- Small, well-defined module (239 lines)
+- Used by all checker scripts
+- Good test of the migration workflow
+
+Steps:
+1. Rename `lib/checker/common.lua` → `lib/checker/common.tl`
+2. Add type annotations
+3. Update cook.mk to compile it
+4. Verify tests pass
+
+#### PR 2.2: Migrate standalone library files
+
+Convert simple, standalone files:
+- `lib/file.lua` (file operations)
+- `lib/ulid.lua` (ULID generation)
+- `lib/utils.lua` (utility functions)
+- `lib/platform.lua` (platform detection)
+
+#### PR 2.3: Migrate lib/cosmic/spawn.lua
+
+- Critical module for process spawning
+- Well-contained (171 lines)
+- Good example of complex types (pipe handles, spawn options)
+
+### Phase 3: Library modules
+
+Migrate lib modules in dependency order.
+
+#### PR 3.1: Migrate lib/environ
+
+- Small module for environment variable handling
+- No external dependencies beyond cosmo
+
+#### PR 3.2: Migrate lib/daemonize
+
+- Process daemonization utilities
+- Depends on cosmo.unix
+
+#### PR 3.3: Migrate lib/whereami
+
+- Location detection utilities
+- Simple, self-contained
+
+#### PR 3.4: Migrate lib/cosmic
+
+Full cosmic module migration:
+- `lib/cosmic/init.lua`
+- `lib/cosmic/walk.lua`
+- `lib/cosmic/help.lua`
+- `lib/cosmic/main.lua`
+- `lib/cosmic/lfs.lua`
+
+#### PR 3.5: Migrate lib/checker
+
+Complete checker module:
+- Already have `common.tl` from PR 2.1
+- Migrate test utilities
+
+#### PR 3.6: Migrate lib/build
+
+Build system utilities:
+- `build-fetch.lua`
+- `build-stage.lua`
+- `check-update.lua`
+- `reporter.lua`
+- `make-help.lua`
+- `test-snap.lua`
+
+### Phase 4: Application modules
+
+#### PR 4.1: Migrate lib/work
+
+Work item management (largest module):
+- `data.lua` (587 lines)
+- `process.lua` (548 lines)
+- `api.lua` (479 lines)
+- `render.lua` (283 lines)
+
+#### PR 4.2: Migrate lib/skill
+
+Skill modules:
+- `hook.lua`
+- `pr.lua`
+- `pr_comments.lua`
+- `bootstrap.lua`
+
+#### PR 4.3: Migrate lib/aerosnap
+
+Window management (296 lines)
+
+#### PR 4.4: Migrate lib/cleanshot
+
+Screenshot utilities (316 lines)
+
+#### PR 4.5: Migrate lib/nvim
+
+Neovim integration:
+- `main.lua` (489 lines)
+- `init.lua`
+
+#### PR 4.6: Migrate lib/home
+
+Home binary (largest):
+- `main.lua` (829 lines)
+- `setup/*.lua` (multiple setup modules)
+- `mac/*.lua` (macOS defaults)
+
+#### PR 4.7: Migrate lib/claude
+
+Claude API integration
+
+### Phase 5: Third-party runners
+
+#### PR 5.1: Migrate 3p checker runners
+
+- `3p/tl/run-teal.lua`
+- `3p/luacheck/run-luacheck.lua`
+- `3p/ast-grep/run-astgrep.lua`
+
+### Phase 6: Tests
+
+#### PR 6.1: Decide on test migration strategy
+
+Options:
+1. Keep tests as lua (faster iteration)
+2. Migrate tests to teal (full type coverage)
+3. Hybrid: type-check tests but keep as lua
+
+Recommendation: Start with option 3 (type-check but keep as lua) to get value without churn.
+
+### Phase 7: Cleanup
+
+#### PR 7.1: Remove teal ignore comments
+
+Once all files are migrated or properly typed, remove the `-- teal ignore` comments.
+
+#### PR 7.2: Update documentation
+
+- Update CLAUDE.md with teal patterns
+- Add type annotation guidelines
+
+## Special considerations
+
+### Generated files
+
+Two files are auto-generated and should remain lua:
+- `lib/emoji/emoji.lua` (35k lines) - generated emoji data
+- `lib/symbols/symbols.lua` (60k lines) - generated symbol data
+
+Add these to tlconfig.lua exclusions.
+
+### External dependencies without types
+
+For 3p dependencies without type declarations, create minimal `.d.tl` stubs that declare the public API we use.
+
+### Type strictness
+
+Use Teal's strict mode where possible, but allow `any` types at module boundaries with untyped external code.
+
+### CI integration
+
+`make ci` already runs teal checks. As files are migrated, they will be type-checked automatically.
+
+## Build system changes
+
+### Current flow
+```
+.lua files → copy to o/ → bundle into binary
+```
+
+### Target flow
+```
+.tl files → tl gen → o/*.lua → bundle into binary
+.lua files → copy to o/ → bundle into binary
+```
+
+### Makefile updates needed
+
+1. Add pattern rule for `.tl` → `.lua` compilation:
+   ```makefile
+   $(o)/%.lua: %.tl | $(tl_staged)
+       @mkdir -p $(@D)
+       @$(tl_gen) $< -o $@
+   ```
+
+2. Update vpath to find `.tl` sources
+3. Ensure type declarations are available during compilation
+
+## Development workflow
+
+### Type checking during development
+
+```bash
+make teal              # check all files
+run-test test_foo      # run specific test (includes type check)
+```
+
+### Adding a new typed file
+
+1. Create `foo.tl` with type annotations
+2. Update `cook.mk` if needed (should auto-detect via wildcards)
+3. Run `make teal` to verify types
+4. Run tests
+
+### Converting an existing file
+
+1. Rename `foo.lua` → `foo.tl`
+2. Add type annotations
+3. Remove `-- teal ignore` comment
+4. Run `make teal` to verify
+5. Run tests
+
+## Metrics
+
+Track migration progress:
+- Files remaining with `-- teal ignore`: 107 → 0
+- `.tl` files created: 0 → ~100
+- Type errors found and fixed during migration
+
+## Timeline notes
+
+This plan is designed for incremental adoption. Each PR should:
+- Be self-contained and reviewable
+- Not break existing functionality
+- Add value immediately (each migrated file gets type checking)
+
+Order can be adjusted based on priorities. Focus first on:
+1. High-churn files (more bugs prevented)
+2. Core modules (dependencies of many others)
+3. Complex logic (where types help most)

--- a/docs/teal-migration.md
+++ b/docs/teal-migration.md
@@ -15,8 +15,8 @@ This document outlines the incremental migration from Lua to Teal for comprehens
 - Teal 0.24.8 installed as 3p dependency
 - `make teal` target exists (runs `tl check` on each file)
 - Checker infrastructure already supports `.tl` extension
-- No `.tl` or `.d.tl` files exist yet
-- No `tlconfig.lua` configuration
+- Type declarations in `lib/types/` for external deps
+- `tlconfig.lua` at repo root
 
 ## Migration phases
 
@@ -24,29 +24,24 @@ This document outlines the incremental migration from Lua to Teal for comprehens
 
 Create the type infrastructure needed for migration.
 
-#### PR 1.1: Add tlconfig.lua and type declarations for external deps
+#### PR 1.1: Add tlconfig.lua and type declarations for external deps ✓
 
-1. Create `tlconfig.lua` at repo root:
-   ```lua
-   return {
-     gen_target = "5.1",
-     gen_compat = "off",
-     include_dir = { "types" },
-     source_dir = ".",
-     build_dir = "o/teal",
-   }
-   ```
+**Status: DONE**
 
-2. Create `types/` directory for type declarations
+1. Created `tlconfig.lua` at repo root with `include_dir = { "lib/types" }`
 
-3. Add type declarations for external dependencies:
-   - `types/cosmo.d.tl` - cosmo module (Fetch, is_main, EncodeJson, etc.)
-   - `types/cosmo/unix.d.tl` - unix functions (fork, pipe, exec, etc.)
-   - `types/cosmo/path.d.tl` - path functions (join, basename, dirname, etc.)
-   - `types/luaunit.d.tl` - luaunit testing framework
-   - `types/argparse.d.tl` - argparse library
+2. Created `lib/types/` directory with type declarations:
+   - `lib/types/cosmo.d.tl` - cosmo module (Fetch, is_main, EncodeJson, etc.)
+   - `lib/types/cosmo/unix.d.tl` - unix functions (fork, pipe, exec, etc.)
+   - `lib/types/cosmo/path.d.tl` - path functions (join, basename, dirname, etc.)
+   - `lib/types/cosmo/getopt.d.tl` - getopt argument parser
+   - `lib/types/luaunit.d.tl` - luaunit testing framework
+   - `lib/types/argparse.d.tl` - argparse library
+   - `lib/types/cosmic/init.d.tl` - cosmic main wrapper
+   - `lib/types/cosmic/spawn.d.tl` - process spawning
+   - `lib/types/cosmic/walk.d.tl` - directory walking
 
-4. Update `make teal` to use tlconfig.lua
+3. Updated `run-teal.lua` to pass `-I lib/types` to tl check
 
 #### PR 1.2: Build system support for .tl files
 

--- a/lib/types/argparse.d.tl
+++ b/lib/types/argparse.d.tl
@@ -1,0 +1,63 @@
+-- type declarations for argparse
+
+local record Argument
+  args: function(self: Argument, n: string | number): Argument
+  count: function(self: Argument, n: string | number): Argument
+  target: function(self: Argument, name: string): Argument
+  default: function(self: Argument, value: any): Argument
+  convert: function(self: Argument, fn: function(string): any): Argument
+  choices: function(self: Argument, list: {string}): Argument
+  hidden: function(self: Argument, hidden?: boolean): Argument
+end
+
+local record Option
+  args: function(self: Option, n: string | number): Option
+  count: function(self: Option, n: string | number): Option
+  target: function(self: Option, name: string): Option
+  default: function(self: Option, value: any): Option
+  convert: function(self: Option, fn: function(string): any): Option
+  choices: function(self: Option, list: {string}): Option
+  hidden: function(self: Option, hidden?: boolean): Option
+  argname: function(self: Option, name: string): Option
+end
+
+local record Flag
+  target: function(self: Flag, name: string): Flag
+  count: function(self: Flag, n: string | number): Flag
+  hidden: function(self: Flag, hidden?: boolean): Flag
+  action: function(self: Flag, fn: function()): Flag
+end
+
+local record Command
+  argument: function(self: Command, name: string, description?: string): Argument
+  option: function(self: Command, name: string, description?: string): Option
+  flag: function(self: Command, name: string, description?: string): Flag
+  command: function(self: Command, name: string, description?: string): Command
+  require_command: function(self: Command, require?: boolean): Command
+  parse: function(self: Command, args?: {string}): {string:any}
+  pparse: function(self: Command, args?: {string}): boolean, {string:any} | string
+  get_help: function(self: Command): string
+  add_help: function(self: Command, help?: boolean | string): Command
+  epilog: function(self: Command, text: string): Command
+  group: function(self: Command, name: string): Command
+end
+
+local record Parser
+  argument: function(self: Parser, name: string, description?: string): Argument
+  option: function(self: Parser, name: string, description?: string): Option
+  flag: function(self: Parser, name: string, description?: string): Flag
+  command: function(self: Parser, name: string, description?: string): Command
+  require_command: function(self: Parser, require?: boolean): Parser
+  parse: function(self: Parser, args?: {string}): {string:any}
+  pparse: function(self: Parser, args?: {string}): boolean, {string:any} | string
+  get_help: function(self: Parser): string
+  add_help: function(self: Parser, help?: boolean | string): Parser
+  epilog: function(self: Parser, text: string): Parser
+  group: function(self: Parser, name: string): Parser
+end
+
+local record argparse
+  metamethod __call: function(self: argparse, name?: string, description?: string): Parser
+end
+
+return argparse

--- a/lib/types/cosmic/init.d.tl
+++ b/lib/types/cosmic/init.d.tl
@@ -1,0 +1,16 @@
+-- type declarations for cosmic
+
+local record Env
+  stdout: FILE
+  stderr: FILE
+end
+
+local type MainFn = function(args: {string}, env: Env): number, string
+
+local record cosmic
+  _VERSION: string
+  _DESCRIPTION: string
+  main: function(fn: MainFn)
+end
+
+return cosmic

--- a/lib/types/cosmic/spawn.d.tl
+++ b/lib/types/cosmic/spawn.d.tl
@@ -1,0 +1,31 @@
+-- type declarations for cosmic.spawn
+
+local record Pipe
+  fd: number
+  write: function(self: Pipe, data: string): number
+  read: function(self: Pipe, size?: number): string
+  close: function(self: Pipe)
+end
+
+local record SpawnHandle
+  pid: number
+  stdin: Pipe
+  stdout: Pipe
+  stderr: Pipe
+  wait: function(self: SpawnHandle): number, string
+  read: function(self: SpawnHandle, size?: number): boolean | string, string, number
+end
+
+local record SpawnOpts
+  stdin: string | number
+  stdout: number
+  stderr: number
+  env: {string:string}
+end
+
+local record spawn
+  spawn: function(argv: {string}, opts?: SpawnOpts): SpawnHandle, string
+  metamethod __call: function(self: spawn, argv: {string}, opts?: SpawnOpts): SpawnHandle, string
+end
+
+return spawn

--- a/lib/types/cosmic/walk.d.tl
+++ b/lib/types/cosmic/walk.d.tl
@@ -1,0 +1,19 @@
+-- type declarations for cosmic.walk
+
+local unix = require("cosmo.unix")
+
+local type Stat = unix.Stat
+
+local type Visitor = function(full_path: string, entry: string, stat: Stat, ctx: any): boolean
+
+local record FileInfo
+  mode: number
+end
+
+local record walk
+  walk: function<T>(dir: string, visitor: Visitor, ctx?: T): T
+  collect: function(dir: string, pattern: string): {string}
+  collect_all: function(dir: string, base?: string, files?: {string:FileInfo}): {string:FileInfo}
+end
+
+return walk

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -1,0 +1,36 @@
+-- type declarations for cosmo (cosmopolitan lua)
+
+local record cosmo
+  -- http
+  Fetch: function(url: string, opts?: {string:any}): number, {string:string}, string
+
+  -- file i/o
+  Barf: function(path: string, data: string, mode?: number): boolean
+  Slurp: function(path: string): string
+
+  -- hashing
+  Sha256: function(data: string): string
+
+  -- encoding
+  EncodeHex: function(data: string): string
+  EncodeJson: function(value: any): string
+  DecodeJson: function(json: string): any
+  EncodeLua: function(value: any): string
+
+  -- system info
+  GetHostOs: function(): string
+  GetHostIsa: function(): string
+  GetRandomBytes: function(count: number): string
+
+  -- script detection
+  is_main: function(): boolean
+
+  -- submodules (for require path hints)
+  record unix end
+  record path end
+  record getopt end
+  record zip end
+  record lsqlite3 end
+end
+
+return cosmo

--- a/lib/types/cosmo/getopt.d.tl
+++ b/lib/types/cosmo/getopt.d.tl
@@ -1,0 +1,13 @@
+-- type declarations for cosmo.getopt
+
+local record Parser
+  next: function(self): string, string
+  remaining: function(self): {string}
+end
+
+local record getopt
+  type LongOpt = {string, string}
+  new: function(args: {string}, shortopts: string, longopts: {LongOpt}): Parser
+end
+
+return getopt

--- a/lib/types/cosmo/path.d.tl
+++ b/lib/types/cosmo/path.d.tl
@@ -1,0 +1,10 @@
+-- type declarations for cosmo.path
+
+local record path
+  join: function(...: string): string
+  dirname: function(p: string): string
+  basename: function(p: string): string
+  exists: function(p: string): boolean
+end
+
+return path

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -1,0 +1,121 @@
+-- type declarations for cosmo.unix
+
+local record Stat
+  mode: function(self): number
+  size: function(self): number
+  mtim: function(self): number
+end
+
+local record DirHandle
+  read: function(self): string
+  close: function(self)
+end
+
+local record unix
+  -- process control
+  fork: function(): number
+  execve: function(path: string, argv: {string}, env: {string:string})
+  execvpe: function(cmd: string, argv: {string}, env: {string:string})
+  wait: function(pid: number): number, number
+  exit: function(code: number)
+  kill: function(pid: number, signal: number): boolean
+  getpid: function(): number
+  daemon: function(nochdir: boolean, noclose: boolean): boolean
+
+  -- pipes
+  pipe: function(): number, number
+  dup: function(fd: number): number
+
+  -- file operations
+  open: function(path: string, flags: number, mode?: number): number
+  close: function(fd: number): boolean
+  read: function(fd: number, size: number): string
+  write: function(fd: number, data: string): number
+  lseek: function(fd: number, offset: number, whence: number): number
+  ftruncate: function(fd: number, length: number): boolean
+
+  -- directory operations
+  opendir: function(path: string): DirHandle
+  mkdir: function(path: string, mode: number): boolean
+  makedirs: function(path: string): boolean
+  mkdtemp: function(template: string): string
+  rmrf: function(path: string): boolean
+  rename: function(src: string, dst: string): boolean
+  unlink: function(path: string): boolean
+  symlink: function(target: string, link_path: string): boolean
+  readlink: function(path: string): string
+
+  -- path/directory functions
+  getcwd: function(): string
+  chdir: function(path: string): boolean
+  realpath: function(path: string): string
+  access: function(path: string, mode: number): boolean
+  chmod: function(path: string, mode: number): boolean
+  stat: function(path: string, flags?: number): Stat
+
+  -- environment
+  environ: function(): {string:string}
+  setenv: function(name: string, value: string): boolean
+  unsetenv: function(name: string): boolean
+  commandv: function(cmd: string): string
+  gethostname: function(): string
+
+  -- time
+  nanosleep: function(sec: number, nsec: number)
+
+  -- network
+  socket: function(family: number, socktype: number): number
+  connect: function(fd: number, path: string): boolean
+
+  -- signals
+  sigaction: function(signal: number, handler: function())
+
+  -- file locking
+  fcntl: function(fd: number, cmd: number, arg: number): number
+
+  -- file flags
+  O_RDONLY: number
+  O_WRONLY: number
+  O_RDWR: number
+  O_CREAT: number
+  O_EXCL: number
+  O_TRUNC: number
+  O_APPEND: number
+
+  -- file type tests
+  S_ISDIR: function(mode: number): boolean
+  S_ISREG: function(mode: number): boolean
+  S_ISLNK: function(mode: number): boolean
+
+  -- process status
+  WIFEXITED: function(status: number): boolean
+  WEXITSTATUS: function(status: number): number
+
+  -- access modes
+  F_OK: number
+  X_OK: number
+  R_OK: number
+  W_OK: number
+
+  -- lock modes
+  F_SETLK: number
+  F_WRLCK: number
+
+  -- signals
+  SIGINT: number
+  SIGTERM: number
+
+  -- network constants
+  AF_UNIX: number
+  SOCK_STREAM: number
+
+  -- stat flags
+  AT_SYMLINK_NOFOLLOW: number
+
+  -- seek whence
+  SEEK_SET: number
+  SEEK_CUR: number
+  SEEK_END: number
+end
+
+return unix

--- a/lib/types/luaunit.d.tl
+++ b/lib/types/luaunit.d.tl
@@ -1,0 +1,42 @@
+-- type declarations for luaunit
+
+local record luaunit
+  -- equality assertions
+  assertEquals: function(actual: any, expected: any, msg?: string)
+  assertNotEquals: function(actual: any, expected: any, msg?: string)
+
+  -- nil assertions
+  assertNil: function(value: any, msg?: string)
+  assertNotNil: function(value: any, msg?: string)
+
+  -- boolean assertions
+  assertTrue: function(value: any, msg?: string)
+  assertFalse: function(value: any, msg?: string)
+
+  -- string assertions
+  assertStrContains: function(str: string, substring: string, msg?: string)
+  assertNotStrContains: function(str: string, substring: string, msg?: string)
+  assertStrMatches: function(str: string, pattern: string, msg?: string)
+
+  -- type assertions
+  assertIsString: function(value: any, msg?: string)
+  assertIsNumber: function(value: any, msg?: string)
+  assertIsTable: function(value: any, msg?: string)
+  assertIsFunction: function(value: any, msg?: string)
+  assertIsBoolean: function(value: any, msg?: string)
+
+  -- error assertions
+  assertError: function(fn: function, ...: any)
+  assertErrorMsgContains: function(expected: string, fn: function, ...: any)
+
+  -- table assertions
+  assertItemsEquals: function(actual: {any}, expected: {any}, msg?: string)
+
+  -- skip test
+  skip: function(msg: string)
+
+  -- run tests
+  run: function(args?: {string}): number
+end
+
+return luaunit

--- a/tlconfig.lua
+++ b/tlconfig.lua
@@ -1,0 +1,7 @@
+return {
+  gen_target = "5.1",
+  gen_compat = "off",
+  include_dir = { "lib/types" },
+  source_dir = ".",
+  build_dir = "o/teal",
+}


### PR DESCRIPTION
Comprehensive plan for incrementally migrating from Lua to Teal:
- Foundation phase: tlconfig.lua, type declarations for external deps
- Core modules: checker/common, standalone libs, cosmic/spawn
- Library modules: environ, daemonize, whereami, cosmic, build
- Application modules: work, skill, aerosnap, cleanshot, nvim, home
- Third-party runners and tests
- Build system changes for .tl compilation