### PR TITLE
build: add tl gen compilation support for .tl files

### DIFF
--- a/.github/pr/teal-build-support.md
+++ b/.github/pr/teal-build-support.md
@@ -1,0 +1,22 @@
+# build: add tl gen compilation support for .tl files
+
+Add build system infrastructure for compiling Teal (.tl) files to Lua. This is PR 1.2 of the teal migration plan.
+
+- 3p/tl/tl-gen.lua - wrapper script for tl gen (works around -o option bug)
+- 3p/tl/cook.mk - add tl_gen command using wrapper script
+- Makefile - pattern rule $(o)/%.lua: %.tl for compilation
+- lib/cook.mk - types_files variable and pattern for standalone libs
+- lib/checker/cook.mk - handle both .lua and .tl sources
+- lib/cosmic/cook.mk - handle both .lua and .tl sources
+- lib/skill/cook.mk - handle both .lua and .tl sources
+
+When a .tl file is added to a module:
+1. The *_tl_srcs variable picks it up via wildcard
+2. The pattern rule compiles it using tl gen
+3. The compiled .lua file goes to o/ alongside other lua files
+
+## Validation
+
+- [x] make clean test passes
+- [x] make teal passes
+- [x] test .tl file compiles correctly to o/

--- a/3p/tl/cook.mk
+++ b/3p/tl/cook.mk
@@ -2,9 +2,13 @@ modules += tl
 tl_version := 3p/tl/version.lua
 tl_srcs := $(wildcard 3p/tl/*.lua)
 tl_run := $(o)/bin/run-teal.lua
-tl_files := $(tl_run)
+tl_gen_script := $(o)/bin/tl-gen.lua
+tl_files := $(tl_run) $(tl_gen_script)
 tl_tests := $(wildcard 3p/tl/test_*.lua)
 tl_deps := argparse cosmos
 
 .PRECIOUS: $(tl_files)
 teal_runner := $(bootstrap_cosmic) -- $(tl_run)
+
+# tl gen: compile .tl files to .lua (using wrapper script)
+tl_gen = TL_BIN=$(tl_staged) $(bootstrap_cosmic) -- $(tl_gen_script)

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,11 @@ $(o)/%: %
 	@mkdir -p $(@D)
 	@$(cp) $< $@
 
+# compile .tl files to .lua (extension changes)
+$(o)/%.lua: %.tl $(types_files) | $(tl_staged)
+	@mkdir -p $(@D)
+	@$(tl_gen) $< -o $@
+
 # bin scripts: o/bin/X.lua from lib/*/X.lua and 3p/*/X.lua
 vpath %.lua lib/build lib/test 3p/ast-grep 3p/luacheck 3p/tl
 $(o)/bin/%.lua: %.lua

--- a/lib/checker/cook.mk
+++ b/lib/checker/cook.mk
@@ -1,4 +1,9 @@
 modules += checker
-checker_srcs := $(wildcard lib/checker/*.lua)
-checker_tests := $(filter lib/checker/test_%.lua,$(checker_srcs))
-checker_files := $(addprefix $(o)/,$(filter-out $(checker_tests),$(checker_srcs)))
+checker_lua_srcs := $(wildcard lib/checker/*.lua)
+checker_tl_srcs := $(wildcard lib/checker/*.tl)
+checker_srcs := $(checker_lua_srcs) $(checker_tl_srcs)
+checker_tests := $(filter lib/checker/test_%.lua,$(checker_lua_srcs))
+# output files: .lua sources copied, .tl sources compiled to .lua
+checker_lua_files := $(addprefix $(o)/,$(filter-out $(checker_tests),$(checker_lua_srcs)))
+checker_tl_files := $(patsubst %.tl,$(o)/%.lua,$(checker_tl_srcs))
+checker_files := $(checker_lua_files) $(checker_tl_files)

--- a/lib/cook.mk
+++ b/lib/cook.mk
@@ -4,6 +4,9 @@ lib_dirs :=
 lib_libs :=
 lib_tests := lib/test_version.lua
 
+# type declaration files for teal compilation
+types_files := $(wildcard lib/types/*.d.tl lib/types/*/*.d.tl)
+
 # standalone lib files
 lib_dirs += o/any/lib
 lib_libs += o/any/lib/version.lua o/any/lib/platform.lua o/any/lib/utils.lua o/any/lib/ulid.lua o/any/lib/file.lua
@@ -11,6 +14,11 @@ lib_libs += o/any/lib/version.lua o/any/lib/platform.lua o/any/lib/utils.lua o/a
 o/any/lib/%.lua: lib/%.lua
 	mkdir -p $(@D)
 	cp $< $@
+
+# compile .tl files to .lua
+o/any/lib/%.lua: lib/%.tl $(types_files) | $(tl_staged)
+	mkdir -p $(@D)
+	$(tl_gen) $< -o $@
 
 include lib/aerosnap/cook.mk
 include lib/build/cook.mk

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -1,9 +1,15 @@
 modules += cosmic
-cosmic_srcs := $(wildcard lib/cosmic/*.lua)
-cosmic_tests := $(filter lib/cosmic/test_%.lua,$(cosmic_srcs))
+cosmic_lua_srcs := $(wildcard lib/cosmic/*.lua)
+cosmic_tl_srcs := $(wildcard lib/cosmic/*.tl)
+cosmic_srcs := $(cosmic_lua_srcs) $(cosmic_tl_srcs)
+cosmic_tests := $(filter lib/cosmic/test_%.lua,$(cosmic_lua_srcs))
 cosmic_main := lib/cosmic/main.lua
 cosmic_args := lib/cosmic/.args
-cosmic_libs := $(addprefix $(o)/,$(filter-out $(cosmic_tests) lib/cosmic/lfs.lua $(cosmic_main),$(cosmic_srcs)))
+# lua sources: filter out tests, lfs, and main, then add o/ prefix
+cosmic_lua_libs := $(addprefix $(o)/,$(filter-out $(cosmic_tests) lib/cosmic/lfs.lua $(cosmic_main),$(cosmic_lua_srcs)))
+# tl sources: compile to .lua in o/
+cosmic_tl_libs := $(patsubst %.tl,$(o)/%.lua,$(cosmic_tl_srcs))
+cosmic_libs := $(cosmic_lua_libs) $(cosmic_tl_libs)
 cosmic_lfs := $(o)/lib/cosmic/lfs.lua
 cosmic_bin := $(o)/bin/cosmic
 cosmic_files := $(cosmic_bin) $(cosmic_libs) $(cosmic_lfs)

--- a/lib/skill/cook.mk
+++ b/lib/skill/cook.mk
@@ -1,5 +1,9 @@
 modules += skill
-skill_srcs := $(wildcard lib/skill/*.lua)
-skill_tests := $(filter lib/skill/test_%.lua,$(skill_srcs))
-skill_libs := $(addprefix $(o)/,$(filter-out $(skill_tests),$(skill_srcs)))
+skill_lua_srcs := $(wildcard lib/skill/*.lua)
+skill_tl_srcs := $(wildcard lib/skill/*.tl)
+skill_srcs := $(skill_lua_srcs) $(skill_tl_srcs)
+skill_tests := $(filter lib/skill/test_%.lua,$(skill_lua_srcs))
+skill_lua_libs := $(addprefix $(o)/,$(filter-out $(skill_tests),$(skill_lua_srcs)))
+skill_tl_libs := $(patsubst %.tl,$(o)/%.lua,$(skill_tl_srcs))
+skill_libs := $(skill_lua_libs) $(skill_tl_libs)
 skill_files := $(skill_libs)


### PR DESCRIPTION
Add build system infrastructure for compiling Teal (.tl) files to Lua. This is PR 1.2 of the teal migration plan.

- 3p/tl/tl-gen.lua - wrapper script for tl gen (works around -o option bug)
- 3p/tl/cook.mk - add tl_gen command using wrapper script
- Makefile - pattern rule $(o)/%.lua: %.tl for compilation
- lib/cook.mk - types_files variable and pattern for standalone libs
- lib/checker/cook.mk - handle both .lua and .tl sources
- lib/cosmic/cook.mk - handle both .lua and .tl sources
- lib/skill/cook.mk - handle both .lua and .tl sources

When a .tl file is added to a module:
1. The *_tl_srcs variable picks it up via wildcard
2. The pattern rule compiles it using tl gen
3. The compiled .lua file goes to o/ alongside other lua files

## Validation

- [x] make clean test passes
- [x] make teal passes
- [x] test .tl file compiles correctly to o/

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-11T00:32:01Z
</details>