### PR TITLE
skill/pr: add .md extension when trailer omits it

### DIFF
--- a/.github/pr/fix-pr-skill-extension.md
+++ b/.github/pr/fix-pr-skill-extension.md
@@ -1,0 +1,15 @@
+# skill/pr: add .md extension when trailer omits it
+
+When the `x-cosmic-pr-name` trailer value doesn't include the `.md` extension, the pr skill now appends it automatically. This allows users to write either:
+
+```
+x-cosmic-pr-name: feature-name
+x-cosmic-pr-name: feature-name.md
+```
+
+Both will correctly resolve to `.github/pr/feature-name.md`.
+
+## Changes
+
+- `lib/skill/pr.lua` - added `normalize_pr_name()` helper that appends `.md` if missing
+- `lib/skill/test_pr.lua` - added test verifying extension-less trailers work

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,11 +29,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 20
 
-      - name: build
-        run: bin/make build
-
       - id: update-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_NUMBER: ${{ github.event.number }}
-        run: o/bin/cosmic --skill pr
+        run: ./bin/cosmic --skill pr

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,8 +29,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 20
 
+      - name: build
+        run: bin/make build
+
       - id: update-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_NUMBER: ${{ github.event.number }}
-        run: ./bin/cosmic --skill pr
+        run: o/bin/cosmic --skill pr

--- a/lib/skill/pr.lua
+++ b/lib/skill/pr.lua
@@ -52,6 +52,14 @@ local function get_commit_sha()
   return out:match("^%s*(.-)%s*$") or "unknown"
 end
 
+local function normalize_pr_name(name)
+  if not name then return nil end
+  if not name:match("%.md$") then
+    return name .. ".md"
+  end
+  return name
+end
+
 local function get_pr_name_from_trailer(opts)
   opts = opts or {}
   local do_spawn = opts.spawn or spawn
@@ -246,7 +254,7 @@ end
 
 local function print_help()
   local pr_name = get_pr_name_from_trailer()
-  local pr_file = pr_name and path.join(".github/pr", pr_name) or ".github/pr/<name>.md"
+  local pr_file = pr_name and path.join(".github/pr", normalize_pr_name(pr_name)) or ".github/pr/<name>.md"
 
   local help = string.format([[
 usage: pr.lua [-h]
@@ -315,7 +323,7 @@ local function do_update(owner, repo_name, pr_number, pr_name, trailer_info, tok
     log("using " .. trailer_info.winning_sha:sub(1, 8) .. " " .. trailer_info.winning_trailer)
   end
 
-  local pr_file = path.join(".github/pr", pr_name)
+  local pr_file = path.join(".github/pr", normalize_pr_name(pr_name))
 
   if not path.exists(pr_file) then
     log(pr_file .. " not found, skipping")


### PR DESCRIPTION
When the `x-cosmic-pr-name` trailer value doesn't include the `.md` extension, the pr skill now appends it automatically. This allows users to write either:

```
x-cosmic-pr-name: feature-name
x-cosmic-pr-name: feature-name.md
```

Both will correctly resolve to `.github/pr/feature-name.md`.

## Changes

- `lib/skill/pr.lua` - added `normalize_pr_name()` helper that appends `.md` if missing
- `lib/skill/test_pr.lua` - added test verifying extension-less trailers work

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-11T00:51:43Z
</details>