### PR TITLE
build: fix parallel build race in test-release

### DIFF
--- a/.github/pr/fix-parallel-build-race.md
+++ b/.github/pr/fix-parallel-build-race.md
@@ -1,0 +1,18 @@
+# build: fix parallel build race in test-release
+
+Fixed race condition in `make -j test-release` where two targets tried to build `$(home_bin)` simultaneously.
+
+- lib/home/cook.mk - `.tested` now depends on `home-release` instead of `$(home_bin)` directly
+
+## Root cause
+
+When running `make -j test-release`:
+1. The `.tested` target had `$(home_bin)` as a dependency, triggering the main make to rebuild it
+2. `home-release` called a sub-make to rebuild `$(home_bin)` with `HOME_NVIM_DIR=$(nvim_bundle_out)`
+
+Their recipes interfered - one's `rm -rf $(home_built)` deleted directories while the other was mid-build.
+
+## Validation
+
+- [x] Reproduced the race locally
+- [x] Verified fix with `make clean && make -j check test build && make -j test-release`

--- a/lib/home/cook.mk
+++ b/lib/home/cook.mk
@@ -68,5 +68,6 @@ home-release: $(nvim_bundle)
 .PHONY: test-release
 test-release: home-release nvim-release-tests $(o)/$(home_release_test).tested
 
-$(o)/$(home_release_test).tested: $(home_release_test) $(home_bin) $(cosmic_bin) $$(cosmos_staged) | $(bootstrap_files)
-	@TEST_RELEASE=1 TEST_DIR=$(home_bin) $< $@
+# Depend on home-release (not home_bin directly) to avoid parallel build race
+$(o)/$(home_release_test).tested: home-release $(home_release_test) $(cosmic_bin) $$(cosmos_staged) | $(bootstrap_files)
+	@TEST_RELEASE=1 TEST_DIR=$(home_bin) $(home_release_test) $@


### PR DESCRIPTION
Fixed race condition in `make -j test-release` where two targets tried to build `$(home_bin)` simultaneously.

- lib/home/cook.mk - `.tested` now depends on `home-release` instead of `$(home_bin)` directly

## Root cause

When running `make -j test-release`:
1. The `.tested` target had `$(home_bin)` as a dependency, triggering the main make to rebuild it
2. `home-release` called a sub-make to rebuild `$(home_bin)` with `HOME_NVIM_DIR=$(nvim_bundle_out)`

Their recipes interfered - one's `rm -rf $(home_built)` deleted directories while the other was mid-build.

## Validation

- [x] Reproduced the race locally
- [x] Verified fix with `make clean && make -j check test build && make -j test-release`

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-11T01:17:38Z
</details>