### PR TITLE
skill/pr: auto-detect PR file when branch introduces exactly one

### DIFF
--- a/.github/pr/pr-auto-detect-file.md
+++ b/.github/pr/pr-auto-detect-file.md
@@ -1,0 +1,8 @@
+# skill/pr: auto-detect PR file when branch introduces exactly one
+
+When no `x-cosmic-pr-name` trailer is specified, the PR skill now automatically detects if the branch introduces exactly one `.github/pr/*.md` file and uses it. This reduces friction for simple PRs where there's only one PR file.
+
+## Changes
+
+- `lib/skill/pr.lua` - added `get_pr_files_from_branch()` to find PR files introduced by the branch, integrated fallback logic in `main()`
+- `lib/skill/test_pr.lua` - added tests for branch file detection and main() fallback behavior


### PR DESCRIPTION
When no `x-cosmic-pr-name` trailer is specified, the PR skill now automatically detects if the branch introduces exactly one `.github/pr/*.md` file and uses it. This reduces friction for simple PRs where there's only one PR file.

## Changes

- `lib/skill/pr.lua` - added `get_pr_files_from_branch()` to find PR files introduced by the branch, integrated fallback logic in `main()`
- `lib/skill/test_pr.lua` - added tests for branch file detection and main() fallback behavior

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-11T01:32:15Z
</details>