### PR TITLE
# Summary

### DIFF
--- a/.github/pr/fix-checker-deps.md
+++ b/.github/pr/fix-checker-deps.md
@@ -1,0 +1,19 @@
+## Summary
+
+- Add missing `$(checker_files)` dependency to update and test rules in Makefile
+- Fixes `make update` failing after checker.common migration to teal
+
+## Changes
+
+- `Makefile:251` - Add `$(checker_files)` to update rule prerequisites
+- `Makefile:158` - Add explicit `$(checker_files)` to test rule prerequisites
+
+The update rule was missing the dependency on `$(checker_files)`, causing `check-update.lua` to fail with "module 'checker.common' not found" since the teal file wasn't compiled before running the script.
+
+The test rule had implicit coverage via auto-expansion (lines 169-180), but making it explicit matches the pattern used by ast-grep, luacheck, and teal rules.
+
+## Test plan
+
+- [x] `make clean && make update` succeeds
+- [x] `make clean && make test only=checker` succeeds
+- [x] `make clean && make check only=checker` succeeds

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ export NO_COLOR := 1
 
 $(o)/%.test.ok: .PLEDGE = stdio rpath wpath cpath proc exec
 $(o)/%.test.ok: .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwc:$(o) rwc:/tmp rx:/usr rx:/proc r:/etc r:/dev/null
-$(o)/%.test.ok: % $(test_files) | $(bootstrap_files)
+$(o)/%.test.ok: % $(test_files) $(checker_files) | $(bootstrap_files)
 	@mkdir -p $(@D)
 	@[ -x $< ] || chmod a+x $<
 	@TEST_DIR=$(TEST_DIR) $(test_runner) $< > $@

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ update: $(o)/update-summary.txt
 $(o)/update-summary.txt: $(all_updated) | $(build_reporter)
 	@$(reporter) --dir $(o) $^ | tee $@
 
-$(o)/%.update.ok: % $(build_check_update) | $(bootstrap_files)
+$(o)/%.update.ok: % $(build_check_update) $(checker_files) | $(bootstrap_files)
 	@mkdir -p $(@D)
 	@$(update_runner) $< > $@
 


### PR DESCRIPTION
- Add missing `$(checker_files)` dependency to update and test rules in Makefile
- Fixes `make update` failing after checker.common migration to teal

## Changes

- `Makefile:251` - Add `$(checker_files)` to update rule prerequisites
- `Makefile:158` - Add explicit `$(checker_files)` to test rule prerequisites

The update rule was missing the dependency on `$(checker_files)`, causing `check-update.lua` to fail with "module 'checker.common' not found" since the teal file wasn't compiled before running the script.

The test rule had implicit coverage via auto-expansion (lines 169-180), but making it explicit matches the pattern used by ast-grep, luacheck, and teal rules.

## Test plan

- [x] `make clean && make update` succeeds
- [x] `make clean && make test only=checker` succeeds
- [x] `make clean && make check only=checker` succeeds

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-11T02:21:25Z
</details>