### PR TITLE
# Summary

### DIFF
--- a/.github/pr/ast-grep-teal-support.md
+++ b/.github/pr/ast-grep-teal-support.md
@@ -1,0 +1,16 @@
+## Summary
+
+- Add ast-grep support for `.tl` files (PR 1.3 from teal migration plan)
+- Enable linting of teal files using lua parser
+
+## Changes
+
+- `3p/ast-grep/run-astgrep.lua` - add `.tl` to `supported_extensions`
+- `sgconfig.yml` - add `**/*.tl` to `languageGlobs.lua`
+- `docs/teal-migration.md` - mark PR 1.3 as done
+
+## Test plan
+
+- [x] `make astgrep` passes (134 checks, 125 passed)
+- [x] `lib/checker/common.tl` is linted successfully
+- [x] `make test` passes

--- a/3p/ast-grep/run-astgrep.lua
+++ b/3p/ast-grep/run-astgrep.lua
@@ -9,6 +9,7 @@ local common = require("checker.common")
 
 local supported_extensions = {
   [".lua"] = true,
+  [".tl"] = true,
 }
 
 local supported_patterns = {

--- a/docs/teal-migration.md
+++ b/docs/teal-migration.md
@@ -52,13 +52,13 @@ Create the type infrastructure needed for migration.
 3. `.tl` files compile to `o/teal/lib/` directory via `tl gen -o`
 4. Added `o/teal/lib` to `LUA_PATH` for runtime module resolution
 
-#### PR 1.3: Add ast-grep support for .tl files
+#### PR 1.3: Add ast-grep support for .tl files ✓
 
-Currently ast-grep ignores `.tl` files as "unsupported file type". Since teal syntax is lua with type annotations, ast-grep's lua parser should work for most lint rules.
+**Status: DONE**
 
-1. Update `run-astgrep.lua` to recognize `.tl` extension
-2. Test that existing lua rules work on teal files
-3. Add any teal-specific rules if needed (e.g., flag `any` type usage)
+- Added `.tl` to `supported_extensions` in `run-astgrep.lua`
+- Added `**/*.tl` to `languageGlobs.lua` in `sgconfig.yml`
+- Existing lua rules work correctly on teal files (tested with `lib/checker/common.tl`)
 
 ### Phase 2: Core modules
 

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -4,6 +4,7 @@ ruleDirs:
 languageGlobs:
   lua:
     - "**/*.lua"
+    - "**/*.tl"
     - ".local/bin/*"
     - ".claude/skills/*/main.lua"
 


### PR DESCRIPTION
- Add ast-grep support for `.tl` files (PR 1.3 from teal migration plan)
- Enable linting of teal files using lua parser

## Changes

- `3p/ast-grep/run-astgrep.lua` - add `.tl` to `supported_extensions`
- `sgconfig.yml` - add `**/*.tl` to `languageGlobs.lua`
- `docs/teal-migration.md` - mark PR 1.3 as done

## Test plan

- [x] `make astgrep` passes (134 checks, 125 passed)
- [x] `lib/checker/common.tl` is linted successfully
- [x] `make test` passes

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-11T05:03:11Z
</details>