### PR TITLE
release: default to stable releases

### DIFF
--- a/.github/pr/release-stable-default.md
+++ b/.github/pr/release-stable-default.md
@@ -1,0 +1,12 @@
+# release: default to stable releases
+
+Change release workflow to create stable releases by default instead of prereleases.
+
+- .github/workflows/release.yml - set PRERELEASE to false
+
+Stable releases are automatically marked as "latest" by GitHub, fixing the
+`/releases/latest/download/home` URL used in the bootstrap command.
+
+## Validation
+
+- [x] workflow syntax valid

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
         default: false
 
 env:
-  PRERELEASE: true  # Set to false to create stable releases
+  PRERELEASE: false
 
 jobs:
   build:


### PR DESCRIPTION
Change release workflow to create stable releases by default instead of prereleases.

- .github/workflows/release.yml - set PRERELEASE to false

Stable releases are automatically marked as "latest" by GitHub, fixing the
`/releases/latest/download/home` URL used in the bootstrap command.

## Validation

- [x] workflow syntax valid

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-11T05:03:55Z
</details>