### PR TITLE
cosmic: bundle teal compiler for bootstrap

### DIFF
--- a/.github/pr/bundle-teal-cosmic.md
+++ b/.github/pr/bundle-teal-cosmic.md
@@ -1,0 +1,25 @@
+# cosmic: bundle teal compiler for bootstrap
+
+Bundle the teal compiler (tl.lua) and a teal transpiler script (tl-gen.lua) into the cosmic binary to enable self-hosted teal compilation.
+
+- lib/cosmic/cook.mk - add tl dependency and bundle tl.lua with tl-gen.lua
+- lib/cosmic/tl-gen.lua - new script that uses bundled teal for transpilation
+
+## Implementation
+
+The tl-gen.lua script uses teal's low-level API (lex + parse_program + generate) to transpile .tl files to .lua without type checking. This is sufficient for bootstrap purposes.
+
+Usage:
+```bash
+cosmic -- /zip/tl-gen.lua input.tl -o output.lua
+```
+
+## Impact
+
+Once this version of cosmic is released, we can remove the lib/build/*.lua bootstrap files that were needed during the teal migration, since cosmic will be able to compile its own .tl source files.
+
+## Validation
+
+- [x] make clean test passes
+- [x] teal transpilation works correctly
+- [x] cosmic binary includes tl.lua and tl-gen.lua

--- a/docs/teal-migration.md
+++ b/docs/teal-migration.md
@@ -237,9 +237,21 @@ Options:
 
 Recommendation: Start with option 3 (type-check but keep as lua) to get value without churn.
 
-### Phase 7: Cleanup
+### Phase 7: Bootstrap and cleanup
 
-#### PR 7.1: Update documentation
+#### PR 7.1: Bundle teal compiler in cosmic ✓
+
+**Status: DONE**
+
+Enable self-hosted teal compilation by bundling the teal compiler into cosmic:
+- Bundle `tl.lua` into cosmic binary
+- Add `tl-gen.lua` script using bundled teal for transpilation
+- Uses lex + parse_program + generate (no type checking, just transpilation)
+- Usage: `cosmic -- /zip/tl-gen.lua input.tl -o output.lua`
+
+Impact: Once this version of cosmic is released, we can remove the `lib/build/*.lua` bootstrap files that were needed during the migration, since cosmic will be able to compile its own `.tl` source files.
+
+#### PR 7.2: Update documentation
 
 - Update CLAUDE.md with teal patterns
 - Add type annotation guidelines

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -5,19 +5,20 @@ cosmic_srcs := $(cosmic_lua_srcs) $(cosmic_tl_srcs)
 cosmic_tests := $(filter lib/cosmic/test_%.lua,$(cosmic_lua_srcs))
 cosmic_main := $(o)/lib/cosmic/main.lua
 cosmic_args := lib/cosmic/.args
-# lua sources: filter out tests, lfs, and main, then add o/ prefix
-cosmic_lua_libs := $(addprefix $(o)/,$(filter-out $(cosmic_tests) lib/cosmic/lfs.lua $(cosmic_main),$(cosmic_lua_srcs)))
+cosmic_tl_gen := lib/cosmic/tl-gen.lua
+# lua sources: filter out tests, lfs, main, and tl-gen, then add o/ prefix
+cosmic_lua_libs := $(addprefix $(o)/,$(filter-out $(cosmic_tests) lib/cosmic/lfs.lua $(cosmic_main) $(cosmic_tl_gen),$(cosmic_lua_srcs)))
 # tl sources: compile to .lua in o/ (excluding main which is bundled separately)
 cosmic_tl_libs := $(filter-out $(cosmic_main),$(patsubst %.tl,$(o)/%.lua,$(cosmic_tl_srcs)))
 cosmic_libs := $(cosmic_lua_libs) $(cosmic_tl_libs)
 cosmic_lfs := $(o)/lib/cosmic/lfs.lua
 cosmic_bin := $(o)/bin/cosmic
 cosmic_files := $(cosmic_bin) $(cosmic_libs) $(cosmic_lfs)
-cosmic_deps := cosmos luaunit argparse skill
+cosmic_deps := cosmos luaunit argparse skill tl
 
 cosmic_built := $(o)/cosmic/.built
 
-$(cosmic_bin): $(cosmic_libs) $(cosmic_lfs) $(skill_libs) $(cosmic_main) $(cosmic_args)
+$(cosmic_bin): $(cosmic_libs) $(cosmic_lfs) $(skill_libs) $(cosmic_main) $(cosmic_args) $(cosmic_tl_gen) $$(tl_staged)
 	@rm -rf $(cosmic_built)
 	@mkdir -p $(cosmic_built)/.lua/cosmic $(cosmic_built)/.lua/skill $(@D)
 	@$(cp) $(cosmic_libs) $(cosmic_built)/.lua/cosmic/
@@ -25,10 +26,11 @@ $(cosmic_bin): $(cosmic_libs) $(cosmic_lfs) $(skill_libs) $(cosmic_main) $(cosmi
 	@$(cp) $(skill_libs) $(cosmic_built)/.lua/skill/
 	@$(cp) $(luaunit_dir)/*.lua $(cosmic_built)/.lua/
 	@$(cp) $(argparse_dir)/*.lua $(cosmic_built)/.lua/
+	@$(cp) $(tl_dir)/tl.lua $(cosmic_built)/.lua/
 	@$(cp) $(cosmos_lua) $@
 	@chmod +x $@
 	@cd $(cosmic_built) && $(CURDIR)/$(cosmos_zip) -qr $(CURDIR)/$@ .lua
-	@$(cosmos_zip) -qj $@ $(cosmic_main) $(cosmic_args)
+	@$(cosmos_zip) -qj $@ $(cosmic_main) $(cosmic_args) $(cosmic_tl_gen)
 
 cosmic: $(cosmic_bin)
 

--- a/lib/cosmic/tl-gen.lua
+++ b/lib/cosmic/tl-gen.lua
@@ -1,0 +1,94 @@
+-- teal ignore: bootstrap script
+-- tl gen implementation using bundled tl.lua
+-- Usage: cosmic -- tl-gen.lua INPUT -o OUTPUT
+
+local tl = require("tl")
+
+local function main(...)
+  local args = {...}
+  local input_file = nil
+  local output_file = nil
+
+  -- Parse args: INPUT -o OUTPUT
+  local i = 1
+  while i <= #args do
+    if args[i] == "-o" or args[i] == "--output" then
+      i = i + 1
+      output_file = args[i]
+    elseif not input_file then
+      input_file = args[i]
+    end
+    i = i + 1
+  end
+
+  if not input_file or not output_file then
+    io.stderr:write("usage: tl-gen.lua INPUT -o OUTPUT\n")
+    return 1
+  end
+
+  -- Read input file
+  local f, err = io.open(input_file, "r")
+  if not f then
+    io.stderr:write("error: cannot open " .. input_file .. ": " .. (err or "unknown") .. "\n")
+    return 1
+  end
+  local input = f:read("*a")
+  f:close()
+
+  -- Lex the input
+  local tokens = tl.lex(input)
+  if not tokens then
+    io.stderr:write("error: lexing failed for " .. input_file .. "\n")
+    return 1
+  end
+
+  -- Parse the program
+  local ast, errs = tl.parse_program(tokens, {}, input_file)
+
+  -- Only report errors that have actual error messages
+  local real_errors = {}
+  if errs then
+    for _, e in ipairs(errs) do
+      if e.msg then
+        table.insert(real_errors, e)
+      end
+    end
+  end
+
+  if #real_errors > 0 then
+    for _, e in ipairs(real_errors) do
+      io.stderr:write(string.format("%s:%d:%d: %s\n", input_file, e.y or 0, e.x or 0, e.msg))
+    end
+    return 1
+  end
+
+  if not ast then
+    io.stderr:write("error: parsing failed for " .. input_file .. "\n")
+    return 1
+  end
+
+  -- Generate lua code (no type checking - just transpile)
+  local lua_code = tl.generate(ast, {})
+
+  -- Write output
+  local out, write_err = io.open(output_file, "w")
+  if not out then
+    io.stderr:write("error: cannot write " .. output_file .. ": " .. (write_err or "unknown") .. "\n")
+    return 1
+  end
+  out:write(lua_code)
+  out:close()
+
+  -- Report success
+  local basename = output_file:match("([^/]+)$") or output_file
+  io.stdout:write("Wrote: " .. basename .. "\n")
+  return 0
+end
+
+-- Support both varargs and arg table (for dofile)
+local args = {...}
+if #args == 0 and arg then
+  args = arg
+end
+local code = main(table.unpack(args))
+os.exit(code)


### PR DESCRIPTION
Bundle the teal compiler (tl.lua) and a teal transpiler script (tl-gen.lua) into the cosmic binary to enable self-hosted teal compilation.

- lib/cosmic/cook.mk - add tl dependency and bundle tl.lua with tl-gen.lua
- lib/cosmic/tl-gen.lua - new script that uses bundled teal for transpilation

## Implementation

The tl-gen.lua script uses teal's low-level API (lex + parse_program + generate) to transpile .tl files to .lua without type checking. This is sufficient for bootstrap purposes.

Usage:
```bash
cosmic -- /zip/tl-gen.lua input.tl -o output.lua
```

## Impact

Once this version of cosmic is released, we can remove the lib/build/*.lua bootstrap files that were needed during the teal migration, since cosmic will be able to compile its own .tl source files.

## Validation

- [x] make clean test passes
- [x] teal transpilation works correctly
- [x] cosmic binary includes tl.lua and tl-gen.lua

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-11T17:09:17Z
</details>