### PR TITLE
build: fix release formatting

### DIFF
--- a/.github/pr/fix-release-formatting.md
+++ b/.github/pr/fix-release-formatting.md
@@ -1,0 +1,17 @@
+# build: fix release formatting
+
+Remove redundant "home-" prefix from release tags and clean up release presentation.
+
+Previously, releases appeared as "home home-2026-01-11-f977087" with escaped newlines in the description. Now they use clean date-based tags (YYYY-mm-dd-SHA) with no description.
+
+## Changes
+
+- Makefile:278 - Changed tag format from `home-YYYY-mm-dd-SHA` to `YYYY-mm-dd-SHA`
+- Makefile:288 - Changed title from `--title "home $$tag"` to `--title "$$tag"`
+- Makefile:289 - Removed `--notes` parameter entirely
+
+## Validation
+
+- [x] Tag format matches YYYY-mm-dd-SHA pattern
+- [x] Title no longer duplicates "home" prefix
+- [x] No description text in release

--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ release:
 	@cp artifacts/cosmic/cosmic release/cosmic-lua
 	@chmod +x release/*
 	@chmod +x artifacts/cosmos-zip/zip
-	@tag="home-$$(date -u +%Y-%m-%d)-$${GITHUB_SHA::7}"; \
+	@tag="$$(date -u +%Y-%m-%d)-$${GITHUB_SHA::7}"; \
 	base_url="https://github.com/$${GITHUB_REPOSITORY}/releases/download/$$tag"; \
 	LUA_PATH="lib/home/?.lua;;" ./release/cosmic-lua lib/home/gen-platforms.lua \
 		release/platforms "$$base_url" "$$tag" \
@@ -285,8 +285,7 @@ release:
 	(cd release && sha256sum home home-* cosmic-lua > SHA256SUMS && cat SHA256SUMS); \
 	gh release create "$$tag" \
 		$${PRERELEASE_FLAG} \
-		--title "home $$tag" \
-		--notes "## Home binaries\nPlatform-specific dotfiles and bundled tools.\n\n### Quick setup\n\`\`\`bash\ncurl -fsSL https://github.com/$${GITHUB_REPOSITORY}/releases/latest/download/home | sh\n\`\`\`" \
+		--title "$$tag" \
 		release/home release/home-* release/cosmic-lua release/SHA256SUMS
 
 ci_stages := luacheck astgrep teal test build


### PR DESCRIPTION
Remove redundant "home-" prefix from release tags and clean up release presentation.

Previously, releases appeared as "home home-2026-01-11-f977087" with escaped newlines in the description. Now they use clean date-based tags (YYYY-mm-dd-SHA) with no description.

## Changes

- Makefile:278 - Changed tag format from `home-YYYY-mm-dd-SHA` to `YYYY-mm-dd-SHA`
- Makefile:288 - Changed title from `--title "home $$tag"` to `--title "$$tag"`
- Makefile:289 - Removed `--notes` parameter entirely

## Validation

- [x] Tag format matches YYYY-mm-dd-SHA pattern
- [x] Title no longer duplicates "home" prefix
- [x] No description text in release

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-11T17:33:16Z
</details>