### PR TITLE
lib: migrate phase 3.3 build module to teal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ $(o)/%: %
 	@$(cp) $< $@
 
 # compile .tl files to .lua (extension changes)
-$(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files) | $(tl_staged)
+# tl_staged must be regular prereq (not order-only) for parallel builds
+$(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files) $(tl_staged)
 	@mkdir -p $(@D)
 	@$(tl_gen) $< -o $@
 
@@ -209,7 +210,7 @@ luacheck: $(o)/luacheck-summary.txt
 $(o)/luacheck-summary.txt: $(all_luachecks) | $(build_reporter)
 	@$(reporter) --dir $(o) $^ | tee $@
 
-$(o)/%.luacheck.ok: $(o)/% $(luacheck_files) $(checker_files) $(tl_staged) | $(bootstrap_files) $(luacheck_staged)
+$(o)/%.luacheck.ok: $(o)/% $(luacheck_files) $(checker_files) $(tl_staged) $(cosmos_staged) | $(bootstrap_files) $(luacheck_staged)
 	@mkdir -p $(@D)
 	@LUACHECK_BIN=$(luacheck_staged) $(luacheck_runner) $< > $@
 

--- a/docs/teal-migration.md
+++ b/docs/teal-migration.md
@@ -11,8 +11,8 @@ This document outlines the incremental migration from Lua to Teal for comprehens
 
 ## Current state
 
-- 93 lua files with `-- teal ignore` comments (down from 107)
-- 14 `.tl` files migrated:
+- 87 lua files with `-- teal ignore` comments (down from 107)
+- 20 `.tl` files migrated:
   - `lib/checker/common.tl`
   - `lib/ulid.tl`
   - `lib/utils.tl`
@@ -27,6 +27,12 @@ This document outlines the incremental migration from Lua to Teal for comprehens
   - `lib/environ/init.tl`
   - `lib/daemonize/init.tl`
   - `lib/whereami/init.tl`
+  - `lib/build/build-fetch.tl`
+  - `lib/build/build-stage.tl`
+  - `lib/build/check-update.tl`
+  - `lib/build/reporter.tl`
+  - `lib/build/make-help.tl`
+  - `lib/build/test-snap.tl`
 - Teal 0.24.8 installed as 3p dependency
 - `make teal` target exists (runs `tl check` on each file)
 - Checker infrastructure already supports `.tl` extension
@@ -165,15 +171,23 @@ Complete checker module:
 - Already have `common.tl` from PR 2.1
 - Migrate test utilities
 
-#### PR 3.6: Migrate lib/build
+#### PR 3.6: Migrate lib/build ✓
 
-Build system utilities:
-- `build-fetch.lua`
-- `build-stage.lua`
-- `check-update.lua`
-- `reporter.lua`
-- `make-help.lua`
-- `test-snap.lua`
+**Status: DONE** (migrated in parallel using agent strategy)
+
+Build system utilities - special handling required:
+- Build module has bootstrap dependency (needs itself to fetch/stage teal)
+- Solution: keep both `.lua` and `.tl` files for bootstrap-critical modules
+- `.lua` files used for bootstrap (copied to o/bin/)
+- `.tl` files used for type checking via `make teal`
+
+Migrated files:
+- `lib/build/build-fetch.tl` - fetch archive downloads
+- `lib/build/build-stage.tl` - archive extraction and staging
+- `lib/build/check-update.tl` - GitHub release version checking
+- `lib/build/reporter.tl` - test/check result reporting
+- `lib/build/make-help.tl` - Makefile help generation
+- `lib/build/test-snap.tl` - snapshot testing utility
 
 ### Phase 4: Application modules
 
@@ -373,13 +387,14 @@ Batch 3.2 - Cosmic module ✓ (completed with 5 parallel agents):
 - `lib/cosmic/main.tl`
 - `lib/cosmic/lfs.tl`
 
-Batch 3.3 - Build utilities (6 agents):
-- `lib/build/build-fetch.lua`
-- `lib/build/build-stage.lua`
-- `lib/build/check-update.lua`
-- `lib/build/reporter.lua`
-- `lib/build/make-help.lua`
-- `lib/build/test-snap.lua`
+Batch 3.3 - Build utilities ✓ (completed with 6 parallel agents):
+- `lib/build/build-fetch.tl`
+- `lib/build/build-stage.tl`
+- `lib/build/check-update.tl`
+- `lib/build/reporter.tl`
+- `lib/build/make-help.tl`
+- `lib/build/test-snap.tl`
+- Note: Build module keeps both .lua and .tl due to bootstrap dependency
 
 **Phase 4: Application modules** (can run some in parallel)
 

--- a/lib/build/build-fetch.tl
+++ b/lib/build/build-fetch.tl
@@ -1,0 +1,158 @@
+#!/usr/bin/env lua
+-- ast-grep ignore: builds relative symlink paths
+local cosmo = require("cosmo")
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+
+local record PlatformSpec
+  sha: string
+  format: string
+end
+
+local record VersionSpec
+  version: string
+  url: string
+  format: string
+  platforms: {string:PlatformSpec}
+end
+
+local record FetchOpts
+  headers: {string:string}
+  maxresponse: number
+end
+
+local function interpolate(template: string, vars: {string:string}): string
+  return template:gsub("{([%w_]+)}", function(key: string): string
+    return vars[key] or ""
+  end)
+end
+
+local function build_url(spec: VersionSpec, platform: string): string, string
+  local plat = spec.platforms[platform] or spec.platforms["*"]
+  if not plat then
+    return nil, "unknown platform: " .. platform
+  end
+
+  local vars: {string:string} = {platform = platform}
+  for k, v in pairs(spec as {string:any}) do
+    if type(v) ~= "table" then
+      vars[k] = tostring(v)
+    end
+  end
+  for k, v in pairs(plat as {string:any}) do
+    vars[k] = tostring(v)
+  end
+
+  return interpolate(spec.url, vars)
+end
+
+local function download(url: string): string, string
+  local status: number
+  local headers: {string:string}
+  local body: string
+  local last_err: string
+  local opts: FetchOpts = {headers = {["User-Agent"] = "curl/8.0"}, maxresponse = 100 * 1024 * 1024}
+
+  for attempt = 1, 8 do
+    status, headers, body = cosmo.Fetch(url, opts as {string:any})
+    if status then break end
+    last_err = tostring(headers or "unknown")
+    if attempt < 8 then unix.nanosleep(math.min(30, 2 ^ attempt), 0) end
+  end
+
+  if not status then return nil, "fetch failed: " .. last_err end
+  if status ~= 200 then return nil, "fetch status " .. tostring(status) end
+  return body
+end
+
+local function verify_sha256(content: string, expected: string): boolean, string
+  local actual = cosmo.EncodeHex(cosmo.Sha256(content)):lower()
+  if actual == expected:lower() then return true end
+  return nil, string.format("sha256 mismatch: expected %s, got %s", expected, actual)
+end
+
+local function main(version_file: string, platform: string, output: string): boolean, string
+  if not version_file or not platform or not output then
+    return nil, "usage: fetch.lua <version_file> <platform> <output>"
+  end
+
+  local output_dir = path.dirname(output)
+  local fetch_o = os.getenv("FETCH_O")
+  if not fetch_o then
+    return nil, "FETCH_O env var required"
+  end
+
+  local ok, spec = pcall(dofile, version_file) as (boolean, VersionSpec)
+  if not ok then
+    return nil, "failed to load " .. version_file .. ": " .. tostring(spec)
+  end
+
+  local plat = spec.platforms[platform] or spec.platforms["*"]
+  if not plat then
+    return nil, "unknown platform: " .. platform
+  end
+
+  local url, url_err = build_url(spec, platform)
+  if not url then
+    return nil, url_err
+  end
+
+  local body, err = download(url)
+  if not body then
+    return nil, err
+  end
+
+  local verify_ok: boolean
+  verify_ok, err = verify_sha256(body, plat.sha)
+  if not verify_ok then
+    return nil, err
+  end
+
+  -- derive module name from output path: o/<module>/.fetched
+  local module_name = path.basename(output_dir)
+
+  -- build archive path: $FETCH_O/<module>/<version>-<sha>/<archive>
+  -- for binary/gz format, use fixed name "binary" so staging knows what to look for
+  local format = spec.format or plat.format or "tar.gz"
+  local archive_name: string
+  if format == "binary" or format == "gz" then
+    archive_name = "binary"
+  else
+    archive_name = url:match("([^/]+)$")
+  end
+  local version_sha = spec.version .. "-" .. plat.sha
+  local archive_dir = path.join(fetch_o, module_name, version_sha)
+  local archive_path = path.join(archive_dir, archive_name)
+
+  io.stderr:write(string.format("↓ FETCH  %s\n", url))
+
+  unix.makedirs(archive_dir)
+
+  if not cosmo.Barf(archive_path, body, tonumber("644", 8)) then
+    return nil, "failed to write " .. archive_path
+  end
+
+  -- remove old symlink/file if exists, create relative symlink
+  -- output is o/<module>/.fetched -> o/fetched/<module>/<ver>-<sha>/
+  unix.unlink(output)
+  local fetch_o_basename = fetch_o:match("([^/]+)$")
+  local rel_path = "../" .. fetch_o_basename .. "/" .. module_name .. "/" .. version_sha
+  local link_ok, link_err = unix.symlink(rel_path, output)
+  if not link_ok then
+    return nil, "failed to symlink: " .. tostring(link_err)
+  end
+
+  return true
+end
+
+if cosmo.is_main() then
+  local result, err = main(...)
+  if not result then
+    io.stderr:write("error: " .. err .. "\n")
+    os.exit(1)
+  end
+end
+
+return {
+  build_url = build_url,
+}

--- a/lib/build/build-stage.tl
+++ b/lib/build/build-stage.tl
@@ -1,0 +1,275 @@
+#!/usr/bin/env lua
+-- ast-grep ignore: builds relative symlink paths
+-- stage.lua: extract fetched archives based on version.lua format
+
+local cosmo = require("cosmo")
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+local spawn = require("cosmic.spawn")
+
+local record Stat
+  mode: function(Stat): number
+end
+
+local record DirHandle
+  read: function(DirHandle): string
+  close: function(DirHandle)
+end
+
+local record PlatformSpec
+  sha: string
+  format: string
+end
+
+local record VersionSpec
+  version: string
+  format: string
+  strip_components: number
+  strip_prefix: string
+  platforms: {string:PlatformSpec}
+end
+
+local function move_contents(source_dir: string, dest_dir: string): boolean, string
+  local dir = unix.opendir(source_dir) as DirHandle
+  if not dir then
+    return nil, "failed to open directory " .. source_dir
+  end
+  while true do
+    local name = dir:read()
+    if not name then break end
+    if name ~= "." and name ~= ".." then
+      local src = path.join(source_dir, name)
+      local dst = path.join(dest_dir, name)
+      local ok, err = unix.rename(src, dst)
+      if not ok then
+        return nil, "failed to move " .. src .. " to " .. dst .. ": " .. tostring(err)
+      end
+    end
+  end
+  return true
+end
+
+local function strip_components(source_dir: string, dest_dir: string, strip: number): boolean, string
+  if strip == 0 then
+    return move_contents(source_dir, dest_dir)
+  end
+
+  local current = source_dir
+  for _ = 1, strip do
+    local dir = unix.opendir(current) as DirHandle
+    if not dir then
+      return nil, "failed to open directory " .. current
+    end
+    local entries: {string} = {}
+    while true do
+      local name = dir:read()
+      if not name then break end
+      if name ~= "." and name ~= ".." then
+        table.insert(entries, name)
+      end
+    end
+    if #entries ~= 1 then
+      return nil, string.format("strip %d: expected 1 entry at level, found %d", strip, #entries)
+    end
+    current = path.join(current, entries[1])
+  end
+
+  local stat = unix.stat(current) as Stat
+  if stat and unix.S_ISDIR(stat:mode()) then
+    return move_contents(current, dest_dir)
+  else
+    local dst = path.join(dest_dir, path.basename(current))
+    return unix.rename(current, dst)
+  end
+end
+
+local function extract_zip(archive: string, dest_dir: string, strip: number): boolean, string
+  local temp_dir = unix.mkdtemp(path.join(path.dirname(dest_dir), ".stage_XXXXXX"))
+  local handle = spawn({"/usr/bin/unzip", "-o", "-q", "-d", temp_dir, archive})
+  local exit_code = handle:wait()
+  if exit_code ~= 0 then
+    unix.rmrf(temp_dir)
+    return nil, "unzip failed with exit code " .. exit_code
+  end
+  local ok, err = strip_components(temp_dir, dest_dir, strip)
+  unix.rmrf(temp_dir)
+  return ok, err
+end
+
+local function extract_targz(archive: string, dest_dir: string, strip: number): boolean, string
+  local temp_dir = unix.mkdtemp(path.join(path.dirname(dest_dir), ".stage_XXXXXX"))
+  local handle = spawn({"tar", "-xzf", archive, "-C", temp_dir})
+  local exit_code = handle:wait()
+  if exit_code ~= 0 then
+    unix.rmrf(temp_dir)
+    return nil, "tar failed with exit code " .. exit_code
+  end
+  local ok, err = strip_components(temp_dir, dest_dir, strip)
+  unix.rmrf(temp_dir)
+  return ok, err
+end
+
+local function copy_binary(archive: string, dest_dir: string, module_name: string): boolean, string
+  local bin_dir = path.join(dest_dir, "bin")
+  unix.makedirs(bin_dir)
+  local dest = path.join(bin_dir, module_name)
+  local f = io.open(archive, "rb")
+  if not f then
+    return nil, "failed to open " .. archive
+  end
+  local content = f:read("*a")
+  f:close()
+  local fd = unix.open(dest, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("755", 8))
+  if not fd then
+    return nil, "failed to create " .. dest
+  end
+  unix.write(fd, content)
+  unix.close(fd)
+  return true
+end
+
+local function extract_gz(archive: string, dest_dir: string, module_name: string): boolean, string
+  local bin_dir = path.join(dest_dir, "bin")
+  unix.makedirs(bin_dir)
+  local dest = path.join(bin_dir, module_name)
+  local handle = spawn({"gunzip", "-c", archive})
+  local exit_code, content = handle:read()
+  if not exit_code then
+    return nil, "gunzip failed: " .. tostring(content)
+  end
+  local fd = unix.open(dest, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("755", 8))
+  if not fd then
+    return nil, "failed to create " .. dest
+  end
+  unix.write(fd, content)
+  unix.close(fd)
+  return true
+end
+
+local function install_files(source_dir: string, dest_dir: string, strip_prefix: string): boolean, string
+  local src = source_dir
+  if strip_prefix then
+    src = path.join(source_dir, strip_prefix)
+  end
+  return move_contents(src, dest_dir)
+end
+
+local function find_archive(fetch_dir: string, format: string): string, string
+  if format == "binary" or format == "gz" then
+    return path.join(fetch_dir, "binary")
+  end
+  local ext: string = nil
+  if format == "zip" then
+    ext = ".zip"
+  elseif format == "tar.gz" then
+    ext = ".tar.gz"
+  end
+  local dir = unix.opendir(fetch_dir) as DirHandle
+  if not dir then
+    return nil, "failed to open " .. fetch_dir
+  end
+  while true do
+    local name = dir:read()
+    if not name then break end
+    if name ~= "." and name ~= ".." then
+      if not ext or name:sub(-#ext) == ext then
+        return path.join(fetch_dir, name)
+      end
+    end
+  end
+  return nil, "no archive found in " .. fetch_dir
+end
+
+local function main(version_file: string, platform: string, input: string, output: string): boolean, string
+  if not version_file or not platform or not input or not output then
+    return nil, "usage: stage.lua <version_file> <platform> <input.fetched> <output.staged>"
+  end
+
+  local stage_o = os.getenv("STAGE_O")
+  if not stage_o then
+    return nil, "STAGE_O env var required"
+  end
+
+  local load_ok, spec = pcall(dofile, version_file) as (boolean, VersionSpec)
+  if not load_ok then
+    return nil, "failed to load " .. version_file .. ": " .. tostring(spec)
+  end
+
+  local plat = spec.platforms[platform] or spec.platforms["*"]
+  if not plat then
+    return nil, "unknown platform: " .. platform
+  end
+
+  local format = spec.format or plat.format or "binary"
+  local strip = spec.strip_components or 1
+
+  -- derive module name from output path: o/<module>/.staged
+  local output_dir = path.dirname(output)
+  local module_name = path.basename(output_dir)
+
+  -- input is now a directory; find the archive inside
+  local archive, err = find_archive(input, format)
+  if not archive then
+    return nil, err
+  end
+
+  local version_sha = spec.version .. "-" .. plat.sha
+
+  local stage_dir = path.join(stage_o, module_name, version_sha)
+  local ok_mk, err_mk = unix.makedirs(stage_dir)
+  if not ok_mk then
+    return nil, "makedirs failed for " .. stage_dir .. ": " .. tostring(err_mk)
+  end
+
+  local ok: boolean
+  if format == "zip" then
+    local temp_dir = unix.mkdtemp(path.join(path.dirname(stage_dir), ".stage_XXXXXX"))
+    ok, err = extract_zip(archive, temp_dir, strip)
+    if ok then
+      ok, err = install_files(temp_dir, stage_dir, spec.strip_prefix)
+    end
+    unix.rmrf(temp_dir)
+  elseif format == "tar.gz" then
+    local temp_dir = unix.mkdtemp(path.join(path.dirname(stage_dir), ".stage_XXXXXX"))
+    ok, err = extract_targz(archive, temp_dir, strip)
+    if ok then
+      ok, err = install_files(temp_dir, stage_dir, spec.strip_prefix)
+    end
+    unix.rmrf(temp_dir)
+  elseif format == "binary" then
+    ok, err = copy_binary(archive, stage_dir, module_name)
+  elseif format == "gz" then
+    ok, err = extract_gz(archive, stage_dir, module_name)
+  else
+    return nil, "unknown format: " .. format
+  end
+
+  if not ok then
+    return nil, err
+  end
+
+  -- format: STAGE  module @ version-sha_prefix
+  local sha_prefix = plat.sha:sub(1, 7)
+  io.stderr:write(string.format("□ STAGE  %s @ %s-%s\n", module_name, spec.version, sha_prefix))
+
+  -- create symlink: output -> staged/<module>/<version-sha>
+  -- output is o/<module>/.staged, staged is o/staged/<module>/<ver>-<sha>
+  unix.rmrf(output)
+  unix.makedirs(output_dir)
+  local stage_o_basename = stage_o:match("([^/]+)$")
+  local rel_path = "../" .. stage_o_basename .. "/" .. module_name .. "/" .. version_sha
+  local link_ok, link_err = unix.symlink(rel_path, output)
+  if not link_ok then
+    return nil, "failed to symlink: " .. tostring(link_err)
+  end
+
+  return true
+end
+
+if cosmo.is_main() then
+  local ok, err = main(arg[1], arg[2], arg[3], arg[4])
+  if not ok then
+    io.stderr:write("error: " .. tostring(err) .. "\n")
+    os.exit(1)
+  end
+end

--- a/lib/build/check-update.tl
+++ b/lib/build/check-update.tl
@@ -1,0 +1,236 @@
+#!/usr/bin/env lua
+
+local cosmo = require("cosmo")
+local getopt = require("cosmo.getopt")
+local common = require("checker.common")
+
+local record GithubAsset
+  name: string
+  browser_download_url: string
+end
+
+local record GithubRelease
+  tag_name: string
+  assets: {GithubAsset}
+end
+
+local type PlatformConfig = {string:string}
+
+local record Config
+  version: string
+  format: string
+  strip_components: number
+  strip_prefix: string
+  url: string
+  platforms: {string:PlatformConfig}
+end
+
+local function fetch_json(url: string): any, string
+  local status, _, body = cosmo.Fetch(url, {
+    headers = {["User-Agent"] = "curl/8.0", ["Accept"] = "application/vnd.github+json"},
+  })
+  if status ~= 200 then
+    return nil, "fetch failed: " .. tostring(status)
+  end
+  return cosmo.DecodeJson(body)
+end
+
+local function fetch_text(url: string): string, string
+  local status, _, body = cosmo.Fetch(url, {
+    headers = {["User-Agent"] = "curl/8.0"},
+  })
+  if status ~= 200 then
+    return nil, "fetch failed: " .. tostring(status)
+  end
+  return body
+end
+
+local function extract_github_repo(url: string): string
+  local owner, repo = url:match("github%.com/([^/]+)/([^/]+)")
+  if owner and repo then
+    return string.format("%s/%s", owner, repo)
+  end
+  return nil
+end
+
+local function check_latest_release(config: Config): string, GithubRelease, string
+  local repo = extract_github_repo(config.url)
+  if not repo then
+    return nil, nil, "not a GitHub URL"
+  end
+
+  local api_url = "https://api.github.com/repos/" .. repo .. "/releases/latest"
+  local release_data, err = fetch_json(api_url)
+  if not release_data then
+    return nil, nil, err
+  end
+
+  local release = release_data as GithubRelease
+  local version = release.tag_name
+  local version_clean = version:gsub("^v", "")
+
+  return version_clean, release
+end
+
+local function find_checksum_asset(release: GithubRelease): string
+  for _, asset in ipairs(release.assets or {}) do
+    local name = asset.name:lower()
+    if name:match("checksum") or name:match("sha256") then
+      return asset.browser_download_url
+    end
+  end
+  return nil
+end
+
+local function parse_checksums(text: string): {string:string}
+  local checksums: {string:string} = {}
+  for line in text:gmatch("[^\n]+") do
+    local sha, filename = line:match("^(%x+)%s+(.+)$")
+    if sha and filename then
+      checksums[filename] = sha
+    end
+  end
+  return checksums
+end
+
+local function build_filename(template: string, version: string, platform_config: PlatformConfig): string
+  local filename = template:gsub("{version}", version)
+  for key, value in pairs(platform_config as {string:string}) do
+    filename = filename:gsub("{" .. key .. "}", value)
+  end
+  return filename
+end
+
+local function generate_updated_version(new_version: string, checksums: {string:string}, config: Config): string, string
+  local url_template = config.url
+  local basename_template = url_template:match("/([^/]+)$")
+
+  config.version = new_version
+  for platform, platform_config in pairs(config.platforms) do
+    local filename = build_filename(basename_template, new_version, platform_config)
+    local sha = checksums[filename]
+    if not sha then
+      return nil, string.format("no checksum for %s (platform %s)", filename, platform)
+    end
+    platform_config.sha = sha
+  end
+
+  return "return " .. cosmo.EncodeLua(config as any, {pretty = true}) .. "\n"
+end
+
+local function apply_update(update_ok_file: string, version_file: string): number
+  local content = cosmo.Slurp(update_ok_file)
+  if not content then
+    return 1
+  end
+  if not content:match("^fail:") then
+    return 0
+  end
+  local stdout = content:match("\n## stdout\n\n(.-)\n## stderr")
+  if not stdout or stdout == "" then
+    return 0
+  end
+  local f = io.open(version_file, "w")
+  if not f then
+    return 1
+  end
+  f:write(stdout)
+  f:close()
+  return 0
+end
+
+local function main(...: string): number
+  local args = {...}
+  local apply_file: string = nil
+  local longopts = {{"apply", "required"}}
+  local parser = getopt.new(args, "", longopts)
+
+  while true do
+    local opt, optarg = parser:next()
+    if not opt then break end
+    if opt == "apply" then
+      apply_file = optarg
+    elseif opt == "?" then
+      io.stderr:write("usage: check-update.lua [--apply <update_ok_file>] <version_file>\n")
+      return 1
+    end
+  end
+
+  local remaining = parser:remaining()
+  local version_file = remaining[1]
+
+  if apply_file then
+    if not version_file then
+      io.stderr:write("usage: check-update.lua --apply <update_ok_file> <version_file>\n")
+      return 1
+    end
+    return apply_update(apply_file, version_file)
+  end
+
+  if not version_file then
+    io.stderr:write("usage: check-update.lua <version_file>\n")
+    return 1
+  end
+
+  local content = cosmo.Slurp(version_file)
+  if not content then
+    return common.write_result("fail", "could not read file", "", "", version_file)
+  end
+
+  local _, skip_reason = common.check_first_lines(version_file, {
+    shebangs = {},
+    ignore = "^%-%-%s*update%s+ignore:%s*(.*)",
+  })
+
+  if skip_reason then
+    return common.write_result("skip", skip_reason, "", "", version_file)
+  end
+
+  local chunk, err = load(content, version_file)
+  if not chunk then
+    return common.write_result("fail", "could not parse: " .. tostring(err), "", "", version_file)
+  end
+
+  local ok, config_result = pcall(chunk)
+  if not ok then
+    return common.write_result("fail", "could not load: " .. tostring(config_result), "", "", version_file)
+  end
+
+  local config = config_result as Config
+  local current_version = config.version
+  if not current_version then
+    return common.write_result("fail", "no version field", "", "", version_file)
+  end
+
+  local latest_version, release, check_err = check_latest_release(config)
+
+  if not latest_version then
+    return common.write_result("fail", check_err or "could not check", "", "", version_file)
+  elseif latest_version == current_version then
+    return common.write_result("pass", current_version, "", "", version_file)
+  end
+
+  -- update available - generate updated version.lua
+  local checksum_url = find_checksum_asset(release)
+  if not checksum_url then
+    return common.write_result("fail", current_version .. " -> " .. latest_version .. " (no checksums)", "", "", version_file)
+  end
+
+  local checksum_text, fetch_err = fetch_text(checksum_url)
+  if not checksum_text then
+    return common.write_result("fail", current_version .. " -> " .. latest_version .. " (" .. tostring(fetch_err) .. ")", "", "", version_file)
+  end
+
+  local checksums = parse_checksums(checksum_text)
+  local updated_content, gen_err = generate_updated_version(latest_version, checksums, config)
+  if not updated_content then
+    return common.write_result("fail", current_version .. " -> " .. latest_version .. " (" .. tostring(gen_err) .. ")", "", "", version_file)
+  end
+
+  common.write_result("fail", current_version .. " -> " .. latest_version, updated_content, "", version_file)
+  return 0
+end
+
+if cosmo.is_main() then
+  os.exit(main(...))
+end

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -1,5 +1,7 @@
 modules += build
-build_srcs := $(wildcard lib/build/*.lua)
+build_lua_srcs := $(wildcard lib/build/*.lua)
+build_tl_srcs := $(wildcard lib/build/*.tl)
+build_srcs := $(build_lua_srcs) $(build_tl_srcs)
 build_fetch := $(o)/bin/build-fetch.lua
 build_stage := $(o)/bin/build-stage.lua
 build_check_update := $(o)/bin/check-update.lua

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -1,7 +1,8 @@
 modules += build
 build_lua_srcs := $(wildcard lib/build/*.lua)
-build_tl_srcs := $(wildcard lib/build/*.tl)
-build_srcs := $(build_lua_srcs) $(build_tl_srcs)
+# tl sources exist alongside lua (for reference) but aren't used during build
+# because bootstrap needs lua before tl is staged
+build_srcs := $(build_lua_srcs)
 build_fetch := $(o)/bin/build-fetch.lua
 build_stage := $(o)/bin/build-stage.lua
 build_check_update := $(o)/bin/check-update.lua

--- a/lib/build/make-help.tl
+++ b/lib/build/make-help.tl
@@ -1,0 +1,164 @@
+#!/usr/bin/env cosmic
+-- Parse Makefile targets and extract documentation comments
+
+local cosmo = require("cosmo")
+
+local record Item
+  type: string
+  name: string
+  description: string
+end
+
+local record FormatOptions
+  width: number
+end
+
+-- Parse a makefile and extract documented targets and options
+-- Supports: ## description (line before target or variable)
+local function parse_makefile(content: string): {Item}
+  local items: {Item} = {}
+  local pending_comment: string = nil
+
+  for line in content:gmatch("[^\r\n]+") do
+    local trimmed = line:match("^%s*(.-)%s*$")
+
+    -- Comment line: ## description
+    local comment = trimmed:match("^##%s*(.*)$")
+    if comment then
+      if pending_comment then
+        pending_comment = pending_comment .. " " .. comment
+      else
+        pending_comment = comment
+      end
+      goto continue
+    end
+
+    -- Target line: target: deps
+    local target_match = trimmed:match("^([a-zA-Z_][a-zA-Z0-9_-]*):%s*(.*)$")
+    if target_match then
+      if pending_comment then
+        table.insert(items, {
+          type = "target",
+          name = target_match,
+          description = pending_comment,
+        })
+      end
+      pending_comment = nil
+      goto continue
+    end
+
+    -- Variable assignment: name = value or name := value or name ?= value
+    local var_match = trimmed:match("^([a-zA-Z_][a-zA-Z0-9_-]*)%s*[?:]?=%s*")
+    if var_match then
+      if pending_comment then
+        table.insert(items, {
+          type = "option",
+          name = var_match,
+          description = pending_comment,
+        })
+      end
+      pending_comment = nil
+      goto continue
+    end
+
+    -- Non-comment, non-target line resets pending comment
+    -- But allow common Makefile directives like .PHONY, .PRECIOUS, etc
+    if trimmed ~= "" and not trimmed:match("^#") and not trimmed:match("^%.") then
+      pending_comment = nil
+    end
+
+    ::continue::
+  end
+
+  return items
+end
+
+-- Format help output
+local function format_help(items: {Item}, options?: FormatOptions): string
+  options = options or {}
+  local width = options.width or 20
+
+  local output: {string} = {}
+  local targets: {Item} = {}
+  local vars: {Item} = {}
+
+  -- Separate targets and options
+  for _, item in ipairs(items) do
+    if item.type == "target" then
+      table.insert(targets, item)
+    elseif item.type == "option" then
+      table.insert(vars, item)
+    end
+  end
+
+  table.insert(output, "Usage: make [target] [options]")
+  table.insert(output, "")
+  table.insert(output, "Targets:")
+
+  for _, item in ipairs(targets) do
+    local padding = string.rep(" ", math.max(0, width - #item.name))
+    table.insert(output, "  " .. item.name .. padding .. item.description)
+  end
+
+  -- Add options section if we have any
+  if #vars > 0 then
+    table.insert(output, "")
+    table.insert(output, "Options:")
+    for _, item in ipairs(vars) do
+      local padding = string.rep(" ", math.max(0, width - #item.name))
+      table.insert(output, "  " .. item.name .. padding .. item.description)
+    end
+  end
+
+  return table.concat(output, "\n")
+end
+
+-- Main execution
+local function main(args: {string}): number, string
+  local makefile = args[1] or "Makefile"
+
+  local content, err = cosmo.Slurp(makefile)
+  if not content then
+    return 1, err or ("Failed to read " .. makefile)
+  end
+
+  local targets = parse_makefile(content)
+  print(format_help(targets))
+  return 0
+end
+
+if cosmo.is_main() then
+  local exit_code, err = main(arg)
+  if err then
+    io.stderr:write(err .. "\n")
+  end
+  os.exit(exit_code)
+end
+
+-- Extract all .PHONY targets from makefile content
+local function parse_phony_targets(content: string): {string:boolean}
+  local targets: {string:boolean} = {}
+  for line in content:gmatch("[^\r\n]+") do
+    local phony = line:match("^%.PHONY:%s*(.+)$")
+    if phony then
+      for target in phony:gmatch("%S+") do
+        targets[target] = true
+      end
+    end
+  end
+  return targets
+end
+
+local record MakeHelp
+  parse_makefile: function(content: string): {Item}
+  format_help: function(items: {Item}, options?: FormatOptions): string
+  parse_phony_targets: function(content: string): {string:boolean}
+end
+
+local M: MakeHelp = {
+  parse_makefile = parse_makefile,
+  format_help = format_help,
+  parse_phony_targets = parse_phony_targets,
+}
+
+return M

--- a/lib/build/reporter.tl
+++ b/lib/build/reporter.tl
@@ -1,0 +1,164 @@
+#!/usr/bin/env lua
+
+local cosmo = require("cosmo")
+local getopt = require("cosmo.getopt")
+local common = require("checker.common")
+
+local record CheckResult
+  status: string
+  message: string
+  name: string
+  file: string
+  checker: string
+end
+
+local record CategorizedResults
+  pass: {CheckResult}
+  fail: {CheckResult}
+  skip: {CheckResult}
+  ignore: {CheckResult}
+end
+
+local function extract_checker(filename: string): string
+  local checker = filename:match("%.([^%.]+)%.ok$")
+  return checker
+end
+
+local function main(...: string): number, string
+  local args = {...}
+  local dir: string = nil
+
+  local longopts = {{"dir", "required"}}
+  local parser = getopt.new(args, "", longopts)
+
+  while true do
+    local opt, optarg = parser:next()
+    if not opt then break end
+    if opt == "dir" then
+      dir = optarg
+    elseif opt == "?" then
+      return 1, "usage: reporter.lua --dir DIR FILES..."
+    end
+  end
+
+  local files = parser:remaining()
+  if not files or #files == 0 then
+    return 1, "usage: reporter.lua --dir DIR FILES..."
+  end
+  if not dir then
+    return 1, "error: --dir is required"
+  end
+
+  local function name_transform(file_name: string): string
+    if file_name:sub(1, #dir) == dir and file_name:sub(#dir + 1, #dir + 1) == "/" then
+      return file_name:sub(#dir + 2)
+    end
+    return file_name
+  end
+
+  -- group files by checker type
+  local checker_files: {string:{string}} = {}
+  for _, file in ipairs(files) do
+    local checker = extract_checker(file)
+    if checker then
+      checker_files[checker] = checker_files[checker] or {}
+      table.insert(checker_files[checker], file)
+    end
+  end
+
+  -- get sorted list of checkers
+  local checkers: {string} = {}
+  for checker in pairs(checker_files) do
+    table.insert(checkers, checker)
+  end
+  table.sort(checkers)
+
+  -- collect results for each checker
+  local checker_results: {string:CategorizedResults} = {}
+  local all_results: {CheckResult} = {}
+
+  for _, checker in ipairs(checkers) do
+    local results: CategorizedResults = {pass = {}, fail = {}, skip = {}, ignore = {}}
+    local strip_suffix = "%." .. checker:gsub("%-", "%%-") .. "%.ok$"
+    local show_checker = checker ~= "update"
+
+    local result_files = checker_files[checker]
+    table.sort(result_files)
+
+    for _, file in ipairs(result_files) do
+      local content = cosmo.Slurp(file)
+      if content then
+        local parsed = common.parse_result(content)
+        if parsed then
+          local result: CheckResult = {
+            status = parsed.status,
+            message = parsed.message,
+            name = name_transform(common.strip_prefix(file):gsub(strip_suffix, "")),
+            file = file,
+            checker = show_checker and checker or nil,
+          }
+          local status_list = (results as {string:{CheckResult}})[result.status]
+          if status_list then
+            table.insert(status_list, result)
+          end
+          table.insert(all_results, result)
+        end
+      end
+    end
+
+    checker_results[checker] = results
+  end
+
+  -- sort all results by name, then checker
+  table.sort(all_results, function(a: CheckResult, b: CheckResult): boolean
+    if a.name ~= b.name then return a.name < b.name end
+    return (a.checker or "") < (b.checker or "")
+  end)
+
+  -- build output
+  local parts: {string} = {}
+  local status_icons = common.status_icons()
+  table.insert(parts, common.format_results(all_results as {common.CheckResult}, status_icons))
+
+  -- per-checker summaries
+  local total_passed, total_failed, total_skipped, total_ignored = 0, 0, 0, 0
+
+  for _, checker in ipairs(checkers) do
+    local results = checker_results[checker]
+    local summary = common.format_summary(checker, results as common.CategorizedResults)
+    if summary and summary ~= "" then
+      table.insert(parts, summary)
+    end
+    total_passed = total_passed + #results.pass
+    total_failed = total_failed + #results.fail
+    total_skipped = total_skipped + #results.skip
+    total_ignored = total_ignored + #results.ignore
+  end
+
+  -- total summary (only for multiple checkers)
+  if #checkers > 1 then
+    local total = total_passed + total_failed + total_skipped + total_ignored
+    table.insert(parts, "")
+    table.insert(parts, string.format(
+      "total: %d checks: %d passed, %d failed, %d skipped, %d ignored",
+      total, total_passed, total_failed, total_skipped, total_ignored
+    ))
+  end
+
+  -- failures
+  local failures = common.format_failures(all_results as {common.CheckResult})
+  if failures then
+    table.insert(parts, failures)
+  end
+
+  print(table.concat(parts, "\n"))
+  return total_failed == 0 and 0 or 1, nil
+end
+
+if cosmo.is_main() then
+  local code, err = main(...)
+  if err then
+    io.stderr:write(err .. "\n")
+  end
+  os.exit(code)
+end

--- a/lib/build/test-snap.tl
+++ b/lib/build/test-snap.tl
@@ -1,0 +1,62 @@
+#!/usr/bin/env cosmic
+-- Snapshot testing: compare expected vs actual output
+
+local cosmo = require("cosmo")
+local spawn = require("cosmic.spawn")
+local unix = require("cosmo.unix")
+
+local function run_diff(expected: string, actual: string): number, string
+  local handle = spawn({"diff", "-u", expected, actual})
+  local ok, stdout, exit_code = handle:read()
+  -- diff returns 0 if files match, 1 if different, 2 on error
+  return exit_code, stdout or ""
+end
+
+local function main(args: {string}): number, string
+  if #args < 2 then
+    return 1, "Usage: test-snap.lua <expected.snap> <actual.snap>"
+  end
+
+  local expected = args[1]
+  local actual = args[2]
+
+  -- Check both files exist
+  if not unix.stat(expected) then
+    return 1, string.format("Expected file not found: %s", expected)
+  end
+  if not unix.stat(actual) then
+    return 1, string.format("Actual file not found: %s", actual)
+  end
+
+  local exit_code, stdout = run_diff(expected, actual)
+
+  if exit_code == 0 then
+    -- Files match
+    print("pass")
+    print("")
+    print("## stdout")
+    print("")
+    print("## stderr")
+    return 0
+  elseif exit_code == 1 then
+    -- Files differ
+    print("fail: snapshot mismatch")
+    print("")
+    print("## stdout")
+    print("")
+    print("## stderr")
+    print(stdout)
+    return 1
+  else
+    -- diff command failed
+    return 1, string.format("diff failed with exit code %d", exit_code)
+  end
+end
+
+if cosmo.is_main() then
+  local exit_code, err = main(arg)
+  if err then
+    io.stderr:write(err .. "\n")
+  end
+  os.exit(exit_code)
+end

--- a/lib/cook.mk
+++ b/lib/cook.mk
@@ -17,7 +17,8 @@ o/any/lib/%.lua: lib/%.lua
 	cp $< $@
 
 # compile .tl files to .lua (for o/any/lib, used by standalone modules)
-o/any/lib/%.lua: lib/%.tl $(types_files) | $(tl_staged)
+# tl_staged must be regular prereq (not order-only) for parallel builds
+o/any/lib/%.lua: lib/%.tl $(types_files) $(tl_staged)
 	mkdir -p $(@D)
 	$(tl_gen) -o $@ $<
 


### PR DESCRIPTION
## Summary

Migrate build module scripts to Teal for type safety while keeping .lua files for bootstrap compatibility.

Files:
- `lib/build/build-fetch.tl`
- `lib/build/build-stage.tl`
- `lib/build/check-update.tl`
- `lib/build/make-help.tl`
- `lib/build/reporter.tl`
- `lib/build/test-snap.tl`

Note: Build module keeps both `.lua` and `.tl` files since bootstrap depends on the lua versions before teal is staged.

Part of the Teal migration - PR B per docs/teal-migration.md merge plan.

## Test plan

- [x] `make test -j` passes
- [x] All existing build functionality works