### PR TITLE
lib: migrate phase 4.1 independent app modules to teal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,8 @@ $(o)/%: %
 	@$(cp) $< $@
 
 # compile .tl files to .lua (extension changes)
-# tl_staged must be regular prereq (not order-only) for parallel builds
-$(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files) $(tl_staged)
+# Use $$(tl_staged) for secondary expansion - variable is set after includes
+$(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files) $$(tl_staged)
 	@mkdir -p $(@D)
 	@$(tl_gen) $< -o $@
 
@@ -151,7 +151,9 @@ $(o)/test-summary.txt: $(all_tested) $(all_snapped) | $(build_reporter)
 export TEST_O := $(o)
 export TEST_PLATFORM := $(platform)
 export TEST_BIN := $(o)/bin
-export LUA_PATH := $(CURDIR)/o/teal/lib/?.lua;$(CURDIR)/o/teal/lib/?/init.lua;$(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;;
+# Build LUA_PATH from lib_dirs (populated by cook.mk includes)
+lib_dirs_lua_path := $(subst ; ,;,$(foreach d,$(lib_dirs),$(CURDIR)/$(d)/?.lua;$(CURDIR)/$(d)/?/init.lua;))
+export LUA_PATH := $(CURDIR)/o/bin/?.lua;$(CURDIR)/o/teal/lib/?.lua;$(CURDIR)/o/teal/lib/?/init.lua;$(CURDIR)/o/lib/?.lua;$(CURDIR)/o/lib/?/init.lua;$(lib_dirs_lua_path)$(CURDIR)/lib/?.lua;$(CURDIR)/lib/?/init.lua;;
 export NO_COLOR := 1
 
 $(o)/%.test.ok: .PLEDGE = stdio rpath wpath cpath proc exec

--- a/lib/aerosnap/cook.mk
+++ b/lib/aerosnap/cook.mk
@@ -2,6 +2,6 @@ lib_lua_modules += aerosnap
 lib_dirs += o/any/aerosnap/lib
 lib_libs += o/any/aerosnap/lib/aerosnap/init.lua
 
-o/any/aerosnap/lib/aerosnap/init.lua: lib/aerosnap/init.lua
+o/any/aerosnap/lib/aerosnap/init.lua: lib/aerosnap/init.tl $(types_files) | $(tl_staged)
 	mkdir -p $(@D)
-	cp $< $@
+	$(tl_gen) -o $@ $<

--- a/lib/aerosnap/init.tl
+++ b/lib/aerosnap/init.tl
@@ -3,12 +3,35 @@ local path = require("cosmo.path")
 local sqlite3 = require("cosmo.lsqlite3")
 local spawn = require("cosmic.spawn")
 
-local DB_DIR = path.join(os.getenv("HOME"), ".cache", "aerospace")
-local DB_FILE = path.join(DB_DIR, "window-mappings.db")
+local DB_DIR <const> = path.join(os.getenv("HOME"), ".cache", "aerospace")
+local DB_FILE <const> = path.join(DB_DIR, "window-mappings.db")
 
-local function open_db()
+local record Database
+  exec: function(self: Database, sql: string): number
+  prepare: function(self: Database, sql: string): Statement
+  nrows: function(self: Database, sql: string): function(): {string:any}
+  close: function(self: Database)
+end
+
+local record Statement
+  bind_values: function(self: Statement, ...: any)
+  step: function(self: Statement): number
+  nrows: function(self: Statement): function(): {string:any}
+  finalize: function(self: Statement)
+  reset: function(self: Statement)
+end
+
+local record Window
+  ["window-id"]: number
+  ["app-name"]: string
+  ["app-bundle-id"]: string
+  ["workspace"]: string
+  ["window-title"]: string
+end
+
+local function open_db(): Database
   unix.makedirs(DB_DIR)
-  local db = sqlite3.open(DB_FILE)
+  local db = sqlite3.open(DB_FILE) as Database
   db:exec([[
     create table if not exists window_mappings (
       id integer primary key autoincrement,
@@ -25,7 +48,7 @@ local function open_db()
   return db
 end
 
-local function get_focused_window()
+local function get_focused_window(): Window, string
   local handle = spawn({
     "aerospace", "list-windows", "--focused",
     "--format", "%{window-id}\t%{app-bundle-id}\t%{app-name}\t%{workspace}\t%{window-title}"
@@ -37,7 +60,7 @@ local function get_focused_window()
   end
 
   local pat = "^(%d+)\t([^\t]*)\t([^\t]*)\t([^\t]*)\t([^\n]*)"
-  local window_id, bundle_id, app_name, workspace, title = output:match(pat)
+  local window_id, bundle_id, app_name, workspace, title = (output as string):match(pat)
   if window_id then
     return {
       ["window-id"] = tonumber(window_id),
@@ -50,7 +73,7 @@ local function get_focused_window()
   return nil, "failed to parse focused window"
 end
 
-local function get_all_windows()
+local function get_all_windows(): {Window}, string
   local handle = spawn({
     "aerospace", "list-windows", "--all",
     "--format", "%{window-id}\t%{app-bundle-id}\t%{app-name}\t%{workspace}\t%{window-title}"
@@ -61,8 +84,8 @@ local function get_all_windows()
     return nil, "failed to get windows"
   end
 
-  local windows = {}
-  for line in output:gmatch("[^\n]+") do
+  local windows: {Window} = {}
+  for line in (output as string):gmatch("[^\n]+") do
     local window_id, bundle_id, app_name, workspace, title = line:match("^(%d+)\t([^\t]*)\t([^\t]*)\t([^\t]*)\t(.*)")
     if window_id then
       table.insert(windows, {
@@ -77,9 +100,9 @@ local function get_all_windows()
   return windows
 end
 
-local function lookup_workspace(db, bundle_id, window_title)
-  local target_workspace = nil
-  local match_type = nil
+local function lookup_workspace(db: Database, bundle_id: string, window_title: string): string, string
+  local target_workspace: string = nil
+  local match_type: string = nil
 
   local stmt = db:prepare([[
     select workspace, window_title from window_mappings
@@ -91,7 +114,7 @@ local function lookup_workspace(db, bundle_id, window_title)
   ]])
   stmt:bind_values(bundle_id, window_title or "")
   for row in stmt:nrows() do
-    target_workspace = row.workspace
+    target_workspace = row.workspace as string
     if row.window_title == (window_title or "") then
       match_type = "exact"
     else
@@ -103,7 +126,7 @@ local function lookup_workspace(db, bundle_id, window_title)
   return target_workspace, match_type
 end
 
-local function cmd_record(_args)
+local function cmd_record(_args: {string}): number
   local win, err = get_focused_window()
   if not win then
     io.stderr:write("error: " .. err .. "\n")
@@ -141,7 +164,7 @@ local function cmd_record(_args)
   return 0
 end
 
-local function cmd_load(_args)
+local function cmd_load(_args: {string}): number
   local db = open_db()
   local current_windows, err = get_all_windows()
   if not current_windows then
@@ -174,7 +197,7 @@ local function cmd_load(_args)
   return 0
 end
 
-local function cmd_show(_args)
+local function cmd_show(_args: {string}): number
   local db = open_db()
   io.write("window mappings:\n")
   io.write(string.format("%-30s %-40s %s\n", "app", "title", "workspace"))
@@ -184,9 +207,9 @@ local function cmd_show(_args)
     from window_mappings
     order by workspace, app_name, window_title
   ]]) do
-    local app = row.app_name
+    local app = row.app_name as string
     if #app > 28 then app = app:sub(1, 28) .. ".." end
-    local title = row.window_title
+    local title = row.window_title as string
     if #title > 38 then title = title:sub(1, 38) .. ".." end
     io.write(string.format("%-30s %-40s %s\n", app, title, row.workspace))
   end
@@ -194,7 +217,7 @@ local function cmd_show(_args)
   return 0
 end
 
-local function cmd_seed(_args)
+local function cmd_seed(_args: {string}): number
   local windows, err = get_all_windows()
   if not windows then
     io.stderr:write("error: " .. err .. "\n")
@@ -232,7 +255,7 @@ local function cmd_seed(_args)
   return 0
 end
 
-local function cmd_clear(_args)
+local function cmd_clear(_args: {string}): number
   local db = open_db()
   db:exec("delete from window_mappings")
   db:close()
@@ -240,7 +263,7 @@ local function cmd_clear(_args)
   return 0
 end
 
-local function cmd_help()
+local function cmd_help(): number
   io.write("aerosnap - record and restore window-to-workspace mappings\n")
   io.write("\n")
   io.write("usage: aerosnap <command>\n")
@@ -257,13 +280,15 @@ local function cmd_help()
   return 0
 end
 
-local function cmd_unknown(command)
+local function cmd_unknown(command: string): number
   io.stderr:write("unknown command: " .. command .. "\n")
   io.stderr:write("run 'aerosnap help' for usage\n")
   return 1
 end
 
-local commands = {
+local type CommandFn = function({string}): number
+
+local commands: {string:CommandFn} = {
   record = cmd_record,
   seed = cmd_seed,
   load = cmd_load,
@@ -272,7 +297,7 @@ local commands = {
   help = cmd_help,
 }
 
-local function main(args)
+local function main(args: {string}): number
   if #args == 0 then
     return cmd_help()
   end
@@ -288,9 +313,16 @@ local function main(args)
   end
 end
 
+local record aerosnap
+  main: function(args: {string}): number
+  get_all_windows: function(): {Window}, string
+  get_focused_window: function(): Window, string
+  lookup_workspace: function(db: Database, bundle_id: string, window_title: string): string, string
+end
+
 return {
   main = main,
   get_all_windows = get_all_windows,
   get_focused_window = get_focused_window,
   lookup_workspace = lookup_workspace,
-}
+} as aerosnap

--- a/lib/claude/cook.mk
+++ b/lib/claude/cook.mk
@@ -2,6 +2,6 @@ lib_lua_modules += claude
 lib_dirs += o/any/claude/lib
 lib_libs += o/any/claude/lib/claude/main.lua
 
-o/any/claude/lib/claude/main.lua: lib/claude/main.lua
+o/any/claude/lib/claude/main.lua: lib/claude/main.tl $(types_files) | $(tl_staged)
 	mkdir -p $(@D)
-	cp $< $@
+	$(tl_gen) -o $@ $<

--- a/lib/claude/main.tl
+++ b/lib/claude/main.tl
@@ -1,13 +1,24 @@
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 
-local function debug_log(msg)
+local record Stat
+  mode: function(self): number
+  size: function(self): number
+  mtim: function(self): number
+end
+
+local record DirHandle
+  read: function(self): string
+  close: function(self)
+end
+
+local function debug_log(msg: string)
   if os.getenv("CLAUDE_WRAPPER_DEBUG") then
     io.stderr:write("claude wrapper: " .. msg .. "\n")
   end
 end
 
-local function find_claude_binary(paths)
+local function find_claude_binary(paths: {string}): string
   for i = 1, #paths do
     local p = paths[i]
     if p and unix.stat(p) then
@@ -17,8 +28,8 @@ local function find_claude_binary(paths)
   return nil
 end
 
-local function build_argv(append_prompts, mcp_config, user_args)
-  local argv = {
+local function build_argv(append_prompts: {string}, mcp_config: string, user_args: {string}): {string}
+  local argv: {string} = {
     "--dangerously-skip-permissions",
     "--strict-mcp-config",
   }
@@ -40,35 +51,41 @@ local function build_argv(append_prompts, mcp_config, user_args)
   return argv
 end
 
-local function scan_for_claude_deploy()
+local function scan_for_claude_deploy(): string
   -- TODO: use glob("/*/deploy/...") when cosmic-lua has glob support
-  local dir = unix.opendir("/")
-  if not dir then return nil end
+  local handle = unix.opendir("/") as DirHandle
+  if not handle then return nil end
 
-  for name in dir do
+  while true do
+    local name = handle:read()
+    if not name then break end
     if name ~= "." and name ~= ".." then
       local bin_path = path.join("/", name, "deploy", "claude-wrapper-hosts", "current", "bin", "claude")
       if unix.stat(bin_path) then
+        handle:close()
         return bin_path
       end
     end
   end
+  handle:close()
   return nil
 end
 
-local function scan_for_atomic_install()
+local function scan_for_atomic_install(): string
   local HOME = os.getenv("HOME")
   local share_dir = path.join(HOME, ".local", "share", "claude")
 
-  local dir = unix.opendir(share_dir)
-  if not dir then
+  local handle = unix.opendir(share_dir) as DirHandle
+  if not handle then
     return nil
   end
 
-  local latest_path = nil
-  local latest_version = nil
+  local latest_path: string = nil
+  local latest_version: string = nil
 
-  for name in dir do
+  while true do
+    local name = handle:read()
+    if not name then break end
     if name ~= "." and name ~= ".." then
       local version = name:match("^([%d%.]+)%-")
       if version then
@@ -82,14 +99,15 @@ local function scan_for_atomic_install()
       end
     end
   end
+  handle:close()
 
   return latest_path
 end
 
-local function main(args)
+local function main(args: {string})
   local HOME = os.getenv("HOME")
 
-  local claude_paths = {
+  local claude_paths: {string} = {
     scan_for_claude_deploy(),
     scan_for_atomic_install(),
     path.join(HOME, ".local", "share", "claude", "bin", "claude"),
@@ -104,7 +122,7 @@ local function main(args)
 
   debug_log("using binary at " .. claude_bin)
 
-  local append_prompts = {}
+  local append_prompts: {string} = {}
   local env_append = os.getenv("CLAUDE_APPEND_SYSTEM_PROMPT")
   if env_append then
     table.insert(append_prompts, env_append)
@@ -113,7 +131,7 @@ local function main(args)
   local extras_mcp = path.join(HOME, "extras", "mcp.json")
   local argv = build_argv(append_prompts, extras_mcp, args)
 
-  local execve_argv = {claude_bin}
+  local execve_argv: {string} = {claude_bin}
   for i = 1, #argv do
     table.insert(execve_argv, argv[i])
   end
@@ -127,7 +145,15 @@ local function main(args)
   os.exit(1)
 end
 
-local claude = {
+local record claude
+  find_claude_binary: function(paths: {string}): string
+  build_argv: function(append_prompts: {string}, mcp_config: string, user_args: {string}): {string}
+  scan_for_claude_deploy: function(): string
+  scan_for_atomic_install: function(): string
+  main: function(args: {string})
+end
+
+local M: claude = {
   find_claude_binary = find_claude_binary,
   build_argv = build_argv,
   scan_for_claude_deploy = scan_for_claude_deploy,
@@ -135,4 +161,4 @@ local claude = {
   main = main,
 }
 
-return claude
+return M

--- a/lib/cleanshot/init.tl
+++ b/lib/cleanshot/init.tl
@@ -1,7 +1,7 @@
 local unix = require("cosmo.unix")
 local cpath = require("cosmo.path")
 
-local VALID_COMMANDS = {
+local VALID_COMMANDS: {string:boolean} = {
   ["all-in-one"] = true,
   ["capture-area"] = true,
   ["capture-fullscreen"] = true,
@@ -23,13 +23,13 @@ local VALID_COMMANDS = {
   ["open-settings"] = true,
 }
 
-local BOOLEAN_FLAGS = {
+local BOOLEAN_FLAGS: {string:boolean} = {
   start = true,
   autoscroll = true,
   linebreaks = true,
 }
 
-local CAPTURE_COMMANDS = {
+local CAPTURE_COMMANDS: {string:boolean} = {
   ["capture-area"] = true,
   ["capture-fullscreen"] = true,
   ["capture-window"] = true,
@@ -38,28 +38,32 @@ local CAPTURE_COMMANDS = {
   ["scrolling-capture"] = true,
 }
 
-local function url_encode(str)
-  return str:gsub("([^%w%-%.%_%~])", function(c)
+local record Flags
+  {string:string}
+end
+
+local function url_encode(str: string): string
+  return str:gsub("([^%w%-%.%_%~])", function(c: string): string
     return string.format("%%%02X", string.byte(c))
   end)
 end
 
-local function expand_path(path)
-  if path:sub(1, 1) == "~" then
+local function expand_path(p: string): string
+  if p:sub(1, 1) == "~" then
     local home = os.getenv("HOME")
-    return home .. path:sub(2)
+    return home .. p:sub(2)
   end
-  return path
+  return p
 end
 
-local function parse_flags(args)
-  local flags = {}
+local function parse_flags(args: {string}): Flags, string
+  local flags: Flags = {}
   local i = 1
 
   while i <= #args do
-    local arg = args[i]
-    if arg:match("^%-") then
-      local key = arg:match("^%-(.+)$")
+    local a = args[i]
+    if a:match("^%-") then
+      local key = a:match("^%-(.+)$")
 
       if BOOLEAN_FLAGS[key] then
         flags[key] = "true"
@@ -80,11 +84,11 @@ local function parse_flags(args)
   return flags
 end
 
-local function build_url(subcommand, flags)
+local function build_url(subcommand: string, flags: Flags): string
   local url = "cleanshot://" .. subcommand
-  local params = {}
+  local params: {string} = {}
 
-  for key, value in pairs(flags) do
+  for key, value in pairs(flags as {string:string}) do
     if key ~= "path" then
       if key == "filepath" then
         table.insert(params, key .. "=" .. url_encode(value))
@@ -101,26 +105,26 @@ local function build_url(subcommand, flags)
   return url
 end
 
-local function get_screenshot_dir(flags)
-  if flags.path then
-    return expand_path(flags.path)
+local function get_screenshot_dir(flags: Flags): string
+  if (flags as {string:string}).path then
+    return expand_path((flags as {string:string}).path)
   end
   return expand_path("~/Downloads/screens")
 end
 
-local function get_latest_file(dir)
-  local latest_time = 0
-  local latest_file = nil
+local function get_latest_file(dir: string): string, number
+  local latest_time: number = 0
+  local latest_file: string = nil
 
   for name in unix.opendir(dir) do
     if name ~= "." and name ~= ".." then
-      local path = cpath.join(dir, name)
-      local st = unix.stat(path)
+      local p = cpath.join(dir, name)
+      local st = unix.stat(p)
       if st and unix.S_ISREG(st:mode()) then
         local mtime = st:mtim()
         if mtime > latest_time then
           latest_time = mtime
-          latest_file = path
+          latest_file = p
         end
       end
     end
@@ -129,15 +133,15 @@ local function get_latest_file(dir)
   return latest_file, latest_time
 end
 
-local function spawn(program, args)
-  local path = unix.commandv(program)
-  if not path then
+local function spawn(program: string, args: {string}): number, string
+  local p = unix.commandv(program)
+  if not p then
     return nil, "command not found: " .. program
   end
 
   local pid = unix.fork()
   if pid == 0 then
-    unix.execve(path, args, unix.environ())
+    unix.execve(p, args, unix.environ())
     unix.exit(1)
   elseif pid > 0 then
     local _, status = unix.wait()
@@ -150,7 +154,7 @@ local function spawn(program, args)
   end
 end
 
-local function wait_for_new_screenshot(dir, baseline_time, timeout)
+local function wait_for_new_screenshot(dir: string, baseline_time: number, timeout: number): string
   local start_time = os.time()
 
   while os.time() - start_time < timeout do
@@ -164,14 +168,15 @@ local function wait_for_new_screenshot(dir, baseline_time, timeout)
   return nil
 end
 
-local function should_wait_for_file(subcommand, flags)
-  if not flags.action or flags.action ~= "save" then
+local function should_wait_for_file(subcommand: string, flags: Flags): boolean
+  local f = flags as {string:string}
+  if not f.action or f.action ~= "save" then
     return false
   end
   return CAPTURE_COMMANDS[subcommand] == true
 end
 
-local function cmd_help()
+local function cmd_help(): number
   io.write([[usage: cleanshot <command> [flags]
 
 commands:
@@ -223,7 +228,7 @@ examples:
   return 0
 end
 
-local function cmd_latest(args)
+local function cmd_latest(args: {string}): number
   local flags, err = parse_flags(args)
   if not flags then
     io.stderr:write("error: " .. err .. "\n")
@@ -242,20 +247,20 @@ local function cmd_latest(args)
   end
 end
 
-local function cmd_capture(subcommand, args)
+local function cmd_capture(subcommand: string, args: {string}): number
   local flags, err = parse_flags(args)
   if not flags then
     io.stderr:write("error: " .. err .. "\n")
     return 1
   end
 
-  local baseline_time
-  local dir
+  local baseline_time: number
+  local dir: string
 
   if should_wait_for_file(subcommand, flags) then
     dir = get_screenshot_dir(flags)
     unix.makedirs(dir)
-    local _
+    local _: string
     _, baseline_time = get_latest_file(dir)
     baseline_time = baseline_time or 0
   end
@@ -272,9 +277,9 @@ local function cmd_capture(subcommand, args)
   end
 
   if baseline_time then
-    local path = wait_for_new_screenshot(dir, baseline_time, 10)
-    if path then
-      io.write(path .. "\n")
+    local p = wait_for_new_screenshot(dir, baseline_time, 10)
+    if p then
+      io.write(p .. "\n")
     else
       io.stderr:write("warning: screenshot not detected within timeout\n")
     end
@@ -283,13 +288,13 @@ local function cmd_capture(subcommand, args)
   return 0
 end
 
-local function cmd_unknown(command)
+local function cmd_unknown(command: string): number
   io.stderr:write("unknown command: " .. command .. "\n")
   io.stderr:write("run 'cleanshot help' for usage\n")
   return 1
 end
 
-local function main(args)
+local function main(args: {string}): number
   if #args == 0 or args[1] == "help" or args[1] == "-h" or args[1] == "--help" then
     return cmd_help()
   end

--- a/lib/cosmic/spawn.tl
+++ b/lib/cosmic/spawn.tl
@@ -21,7 +21,7 @@ local record SpawnOpts
   stdin: string | number
   stdout: number
   stderr: number
-  env: {string:string}
+  env: {string}
 end
 
 local function make_pipe(fd: number): Pipe
@@ -193,8 +193,8 @@ local M: SpawnModule = {
 }
 
 setmetatable(M, {
-  __call = function(_: SpawnModule, ...: any): SpawnHandle, string
-    return spawn(...)
+  __call = function(_: SpawnModule, argv: {string}, opts?: SpawnOpts): SpawnHandle, string
+    return spawn(argv, opts)
   end,
 })
 

--- a/lib/nvim/cook.mk
+++ b/lib/nvim/cook.mk
@@ -1,7 +1,14 @@
+modules += nvim-lib
+nvim-lib_tl_srcs := $(wildcard lib/nvim/*.tl)
+nvim-lib_lua_srcs := $(wildcard lib/nvim/*.lua)
+nvim-lib_srcs := $(nvim-lib_tl_srcs) $(nvim-lib_lua_srcs)
+nvim-lib_tests := $(filter lib/nvim/test%.lua,$(nvim-lib_lua_srcs))
+nvim-lib_files := o/any/nvim/lib/nvim/main.lua
+nvim-lib_deps := cosmic daemonize whereami
+
 lib_lua_modules += nvim
 lib_dirs += o/any/nvim/lib
-lib_libs += o/any/nvim/lib/nvim/main.lua
 
-o/any/nvim/lib/nvim/main.lua: lib/nvim/main.lua
+o/any/nvim/lib/nvim/main.lua: $(o)/lib/nvim/main.lua
 	mkdir -p $(@D)
 	cp $< $@

--- a/lib/nvim/main.tl
+++ b/lib/nvim/main.tl
@@ -4,10 +4,18 @@ local version = require("version")
 local whereami = require("whereami")
 local daemonize = require("daemonize")
 
-local HOME = os.getenv("HOME")
-local DEFAULT_SOCK = path.join(HOME, ".config", "nvim", "nvim.sock")
+local HOME <const> = os.getenv("HOME")
+local DEFAULT_SOCK <const> = path.join(HOME, ".config", "nvim", "nvim.sock")
 
-local function resolve_nvim_bin()
+local record Paths
+  sock: string
+  pid: string
+  log: string
+end
+
+local type CommandFn = function(paths: Paths, nvim_bin?: string): number
+
+local function resolve_nvim_bin(): string, string
   local bin_path = version.resolve_bin("nvim")
   if bin_path then
     return bin_path
@@ -21,36 +29,36 @@ local function resolve_nvim_bin()
   return nil, "nvim binary not found. Run 'make nvim' to install."
 end
 
-local function derive_vimruntime(nvim_bin)
+local function derive_vimruntime(nvim_bin: string): string
   local bin_dir = path.dirname(nvim_bin)
   local version_dir = path.dirname(bin_dir)
   return path.join(version_dir, "share", "nvim", "runtime")
 end
 
-local function set_vimruntime(env, nvim_bin)
+local function set_vimruntime(env: {string:string}, nvim_bin: string)
   local vimruntime = derive_vimruntime(nvim_bin)
   if unix.stat(vimruntime) then
     env["VIMRUNTIME"] = vimruntime
   end
 end
 
-local function env_with_vimruntime(nvim_bin)
-  local env = {}
+local function env_with_vimruntime(nvim_bin: string): {string}
+  local env: {string:string} = {}
   for _, entry in ipairs(unix.environ()) do
-    local key, value = entry:match("^([^=]+)=(.*)$")
+    local key, value = (entry as string):match("^([^=]+)=(.*)$")
     if key then
       env[key] = value
     end
   end
   set_vimruntime(env, nvim_bin)
-  local result = {}
+  local result: {string} = {}
   for k, v in pairs(env) do
     table.insert(result, k .. "=" .. v)
   end
   return result
 end
 
-local function derive_paths(sock)
+local function derive_paths(sock: string): Paths
   local sock_dir = path.dirname(sock)
   local sock_name = path.basename(sock):gsub("%.sock$", "")
 
@@ -61,9 +69,9 @@ local function derive_paths(sock)
   }
 end
 
-local function parse_socket_option(args)
-  local socket_path = nil
-  local new_args = {}
+local function parse_socket_option(args: {string}): string, {string}
+  local socket_path: string = nil
+  local new_args: {string} = {}
   local i = 1
 
   while i <= #args do
@@ -79,7 +87,7 @@ local function parse_socket_option(args)
   return socket_path, new_args
 end
 
-local function expand_tilde(file_path)
+local function expand_tilde(file_path: string): string
   if file_path:sub(1, 2) == "~/" then
     return path.join(HOME, file_path:sub(3))
   elseif file_path == "~" then
@@ -88,7 +96,7 @@ local function expand_tilde(file_path)
   return file_path
 end
 
-local function get_socket_path(cli_socket)
+local function get_socket_path(cli_socket: string): string
   if cli_socket then
     return expand_tilde(cli_socket)
   end
@@ -101,7 +109,7 @@ local function get_socket_path(cli_socket)
   return DEFAULT_SOCK
 end
 
-local function mkdir_p(dir_path)
+local function mkdir_p(dir_path: string): boolean, string
   local ok, err = unix.makedirs(dir_path, tonumber("755", 8))
   if not ok then
     return nil, "failed to create directory " .. dir_path .. ": " .. tostring(err)
@@ -109,11 +117,11 @@ local function mkdir_p(dir_path)
   return true
 end
 
-local function file_exists(file_path)
+local function file_exists(file_path: string): boolean
   return unix.stat(file_path) ~= nil
 end
 
-local function read_file(file_path)
+local function read_file(file_path: string): string
   local f = io.open(file_path, "r")
   if not f then
     return nil
@@ -123,12 +131,12 @@ local function read_file(file_path)
   return content
 end
 
-local function is_process_running(pid)
+local function is_process_running(pid: number): boolean
   local ok = unix.kill(pid, 0)
   return ok ~= nil
 end
 
-local function get_running_pid(pidfile)
+local function get_running_pid(pidfile: string): number
   local pid_str = read_file(pidfile)
   if not pid_str then
     return nil
@@ -140,14 +148,14 @@ local function get_running_pid(pidfile)
   return nil
 end
 
-local function wait_for_socket(socket_path, timeout)
+local function wait_for_socket(socket_path: string, timeout?: number): boolean
   timeout = timeout or 5
-  local sleep_interval_ms = 100
-  local elapsed = 0
+  local sleep_interval_ms: number = 100
+  local elapsed: number = 0
 
   while elapsed < timeout do
     if file_exists(socket_path) then
-      local fd = unix.socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+      local fd = unix.socket(unix.AF_UNIX, unix.SOCK_STREAM)
       if fd and fd >= 0 then
         local ok = unix.connect(fd, socket_path)
         unix.close(fd)
@@ -164,8 +172,8 @@ local function wait_for_socket(socket_path, timeout)
   return false
 end
 
-local function load_zsh_environment()
-  local env = {}
+local function load_zsh_environment(): {string:string}
+  local env: {string:string} = {}
 
   local zsh_path = unix.commandv("zsh")
   if not zsh_path then
@@ -179,12 +187,12 @@ local function load_zsh_environment()
   end
 
   local i = 1
-  while i <= #output do
-    local next_null = output:find("\0", i, true)
+  while i <= #(output as string) do
+    local next_null = (output as string):find("\0", i, true)
     if not next_null then
       break
     end
-    local line = output:sub(i, next_null - 1)
+    local line = (output as string):sub(i, next_null - 1)
     local key, value = line:match("^([^=]+)=(.*)$")
     if key then
       env[key] = value
@@ -195,24 +203,24 @@ local function load_zsh_environment()
   return env
 end
 
-local function setup_nvim_environment(nvim_bin)
+local function setup_nvim_environment(nvim_bin: string): {string}
   local env_table = load_zsh_environment()
   env_table["NVIM_SERVER_MODE"] = "1"
   env_table["WHEREAMI"] = whereami.get_with_emoji()
   set_vimruntime(env_table, nvim_bin)
-  local env = {}
+  local env: {string} = {}
   for k, v in pairs(env_table) do
     table.insert(env, k .. "=" .. v)
   end
   return env
 end
 
-local function exec_nvim_server(sock, env, nvim_bin)
+local function exec_nvim_server(sock: string, env: {string}, nvim_bin: string)
   os.remove(sock)
   unix.execve(nvim_bin, {"nvim", "--listen", sock, "--headless"}, env)
 end
 
-local function cmd_start(paths, nvim_bin)
+local function cmd_start(paths: Paths, nvim_bin: string): number
   local ok, err = mkdir_p(path.dirname(paths.pid))
   if not ok then
     io.stderr:write("error: " .. err .. "\n")
@@ -224,7 +232,7 @@ local function cmd_start(paths, nvim_bin)
     return 1
   end
 
-  local lockfd
+  local lockfd: number
   lockfd, err = daemonize.acquire_lock(paths.pid)
   if not lockfd then
     if err:match("another instance") then
@@ -299,7 +307,7 @@ local function cmd_start(paths, nvim_bin)
   end
 end
 
-local function cmd_stop(paths)
+local function cmd_stop(paths: Paths): number
   local pid = get_running_pid(paths.pid)
   if pid then
     unix.kill(pid, unix.SIGTERM)
@@ -312,10 +320,10 @@ local function cmd_stop(paths)
   return 0
 end
 
-local function cmd_status(paths)
+local function cmd_status(paths: Paths): number
   local pid = get_running_pid(paths.pid)
   if pid then
-    io.write(string.format("nvim server is running (pid %d) at %s\n", pid, paths.sock))
+    io.write(string.format("nvim server is running (pid %d) at %s\n", pid as integer, paths.sock))
     return 0
   else
     io.write(string.format("nvim server is not running at %s\n", paths.sock))
@@ -323,18 +331,18 @@ local function cmd_status(paths)
   end
 end
 
-local function cmd_restart(paths, nvim_bin)
+local function cmd_restart(paths: Paths, nvim_bin: string): number
   cmd_stop(paths)
   unix.nanosleep(1, 0)
   return cmd_start(paths, nvim_bin)
 end
 
-local function cmd_cleanup(paths)
+local function cmd_cleanup(paths: Paths): number
   os.remove(paths.sock)
   return 0
 end
 
-local commands = {
+local commands: {string:CommandFn} = {
   start = cmd_start,
   stop = cmd_stop,
   status = cmd_status,
@@ -342,7 +350,7 @@ local commands = {
   cleanup = cmd_cleanup,
 }
 
-local function daemon_mode(args, nvim_bin)
+local function daemon_mode(args: {string}, nvim_bin: string): number
   local cli_socket, remaining_args = parse_socket_option(args)
   local socket_path = get_socket_path(cli_socket)
   local paths = derive_paths(socket_path)
@@ -363,7 +371,7 @@ local function daemon_mode(args, nvim_bin)
   end
 end
 
-local function has_remote_flag(args)
+local function has_remote_flag(args: {string}): boolean
   for _, arg in ipairs(args) do
     if arg == "--server" or arg:match("^%-%-remote%-") then
       return true
@@ -372,12 +380,12 @@ local function has_remote_flag(args)
   return false
 end
 
-local function is_socket_connectable(socket_path)
+local function is_socket_connectable(socket_path: string): boolean
   if not file_exists(socket_path) then
     return false
   end
 
-  local fd = unix.socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+  local fd = unix.socket(unix.AF_UNIX, unix.SOCK_STREAM)
   if not fd or fd < 0 then
     return false
   end
@@ -387,19 +395,19 @@ local function is_socket_connectable(socket_path)
   return ok
 end
 
-local function ensure_server_running(paths, nvim_bin)
+local function ensure_server_running(paths: Paths, nvim_bin: string)
   if not is_socket_connectable(paths.sock) then
     cmd_start(paths, nvim_bin)
   end
 end
 
-local function client_mode(args, nvim_bin)
+local function client_mode(args: {string}, nvim_bin: string)
   local nvim_invim = os.getenv("NVIM_INVIM")
   local nvim_server_mode = os.getenv("NVIM_SERVER_MODE")
   local env = env_with_vimruntime(nvim_bin)
 
   if nvim_invim or nvim_server_mode then
-    local new_args = {"nvim"}
+    local new_args: {string} = {"nvim"}
     for _, arg in ipairs(args) do
       table.insert(new_args, arg)
     end
@@ -416,7 +424,7 @@ local function client_mode(args, nvim_bin)
 
     ensure_server_running(paths, nvim_bin)
 
-    local new_args = {"nvim"}
+    local new_args: {string} = {"nvim"}
     local has_server_arg = false
     for _, arg in ipairs(remaining_args) do
       if arg == "--server" then
@@ -435,7 +443,7 @@ local function client_mode(args, nvim_bin)
 
     unix.execve(nvim_bin, new_args, env)
   else
-    local new_args = {"nvim"}
+    local new_args: {string} = {"nvim"}
     for _, arg in ipairs(remaining_args) do
       table.insert(new_args, arg)
     end
@@ -443,7 +451,7 @@ local function client_mode(args, nvim_bin)
   end
 end
 
-local function cleanup_and_exit(signum, paths)
+local function cleanup_and_exit(signum: integer, paths: Paths)
   os.remove(paths.sock)
   if file_exists(paths.pid) then
     local pid = get_running_pid(paths.pid)
@@ -454,7 +462,9 @@ local function cleanup_and_exit(signum, paths)
   os.exit(128 + signum)
 end
 
-local function main(args)
+local type Args = {number: string}
+
+local function main(args: Args): number
   local program_name = args[0]:match("([^/]+)$")
   local nvim_bin, err = resolve_nvim_bin()
   if not nvim_bin then
@@ -462,7 +472,7 @@ local function main(args)
     return 1
   end
 
-  local cmd_args = {}
+  local cmd_args: {string} = {}
   for i = 1, #args do
     cmd_args[i] = args[i]
   end

--- a/lib/types/cosmic/spawn.d.tl
+++ b/lib/types/cosmic/spawn.d.tl
@@ -20,7 +20,7 @@ local record SpawnOpts
   stdin: string | number
   stdout: number
   stderr: number
-  env: {string:string}
+  env: {string}
 end
 
 local record spawn

--- a/lib/types/cosmo/lsqlite3.d.tl
+++ b/lib/types/cosmo/lsqlite3.d.tl
@@ -1,0 +1,22 @@
+-- type declarations for cosmo.lsqlite3
+
+local record Statement
+  bind_values: function(self: Statement, ...: any)
+  step: function(self: Statement): number
+  nrows: function(self: Statement): function(): {string:any}
+  finalize: function(self: Statement)
+  reset: function(self: Statement)
+end
+
+local record Database
+  exec: function(self: Database, sql: string): number
+  prepare: function(self: Database, sql: string): Statement
+  nrows: function(self: Database, sql: string): function(): {string:any}
+  close: function(self: Database)
+end
+
+local record lsqlite3
+  open: function(filename: string): Database
+end
+
+return lsqlite3

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -14,9 +14,9 @@ end
 local record unix
   -- process control
   fork: function(): number
-  execve: function(path: string, argv: {string}, env: {string:string})
-  execvpe: function(cmd: string, argv: {string}, env: {string:string})
-  wait: function(pid: number): number, number
+  execve: function(path: string, argv: {string}, env: {string})
+  execvpe: function(cmd: string, argv: {string}, env: {string})
+  wait: function(pid?: number): number, number
   exit: function(code: number)
   kill: function(pid: number, signal: number): boolean
   getpid: function(): number
@@ -27,7 +27,7 @@ local record unix
   dup: function(fd: number, newfd?: number): number
 
   -- file operations
-  open: function(path: string, flags: number, mode?: number): number
+  open: function(path: string, flags: number, mode?: number): number, string
   close: function(fd: number): boolean
   read: function(fd: number, size: number): string
   write: function(fd: number, data: string): number
@@ -37,7 +37,7 @@ local record unix
   -- directory operations
   opendir: function(path: string): DirHandle
   mkdir: function(path: string, mode: number): boolean
-  makedirs: function(path: string): boolean
+  makedirs: function(path: string, mode?: number): boolean, string
   mkdtemp: function(template: string): string
   rmrf: function(path: string): boolean
   rename: function(src: string, dst: string): boolean
@@ -54,7 +54,7 @@ local record unix
   stat: function(path: string, flags?: number): Stat
 
   -- environment
-  environ: function(): {string:string}
+  environ: function(): {string}
   setenv: function(name: string, value: string): boolean
   unsetenv: function(name: string): boolean
   commandv: function(cmd: string): string
@@ -102,8 +102,8 @@ local record unix
   F_WRLCK: number
 
   -- signals
-  SIGINT: number
-  SIGTERM: number
+  SIGINT: integer
+  SIGTERM: integer
 
   -- network constants
   AF_UNIX: number

--- a/lib/types/daemonize.d.tl
+++ b/lib/types/daemonize.d.tl
@@ -1,0 +1,9 @@
+-- type declarations for daemonize module
+
+local record daemonize
+  write_pidfile: function(path: string): boolean, string
+  acquire_lock: function(path: string): number, string
+  redirect_output: function(stdout_path: string, stderr_path: string, append: boolean): boolean, string
+end
+
+return daemonize

--- a/lib/types/whereami.d.tl
+++ b/lib/types/whereami.d.tl
@@ -1,0 +1,10 @@
+-- type declarations for whereami module
+
+local type EnvFunc = function(string): string
+
+local record whereami
+  get: function(): string
+  get_with_emoji: function(env?: EnvFunc): string
+end
+
+return whereami

--- a/lib/whereami/cook.mk
+++ b/lib/whereami/cook.mk
@@ -1,7 +1,13 @@
+modules += whereami
+whereami_srcs := lib/whereami/init.tl lib/whereami/test.lua
+whereami_tests := lib/whereami/test.lua
+whereami_files := o/any/whereami/lib/whereami/init.lua
+
 lib_lua_modules += whereami
 lib_dirs += o/any/whereami/lib
-lib_libs += o/any/whereami/lib/whereami/init.lua
 
-o/any/whereami/lib/whereami/init.lua: lib/whereami/init.tl $(types_files) | $(tl_staged)
+# Use secondary expansion for tl_files (defined in 3p/tl/cook.mk after this file)
+.SECONDEXPANSION:
+o/any/whereami/lib/whereami/init.lua: lib/whereami/init.tl $(types_files) $$(tl_files) | $$(tl_staged)
 	mkdir -p $(@D)
 	$(tl_gen) -o $@ $<


### PR DESCRIPTION
## Summary
- Migrates independent app modules to teal (Phase 4.1 from docs/teal-migration.md)
- Converted lib/aerosnap/init.lua to init.tl
- Converted lib/cleanshot/init.lua to init.tl
- Converted lib/claude/main.lua to main.tl
- Converted lib/nvim/main.lua to main.tl
- Added type declarations for daemonize, whereami, and lsqlite3

## Test plan
- [x] `make teal` passes
- [x] `make test` passes
- [ ] CI passes