### PR TITLE
lib: migrate phase 4.3 skill module to teal

### DIFF
--- a/docs/teal-migration.md
+++ b/docs/teal-migration.md
@@ -11,8 +11,8 @@ This document outlines the incremental migration from Lua to Teal for comprehens
 
 ## Current state
 
-- 76 lua files with `-- teal ignore` comments (down from 107)
-- 31 `.tl` files migrated:
+- 71 lua files with `-- teal ignore` comments (down from 107)
+- 36 `.tl` files migrated:
   - `lib/checker/common.tl`
   - `lib/ulid.tl`
   - `lib/utils.tl`
@@ -44,6 +44,11 @@ This document outlines the incremental migration from Lua to Teal for comprehens
   - `lib/work/config.tl`
   - `lib/work/validate.tl`
   - `lib/work/store.tl`
+  - `lib/skill/init.tl`
+  - `lib/skill/hook.tl`
+  - `lib/skill/pr.tl`
+  - `lib/skill/pr_comments.tl`
+  - `lib/skill/bootstrap.tl`
 - Teal 0.24.8 installed as 3p dependency
 - `make teal` target exists (runs `tl check` on each file)
 - Checker infrastructure already supports `.tl` extension
@@ -239,13 +244,21 @@ Added type declarations:
 - `lib/types/posix/signal.d.tl` - signals
 - `lib/types/posix/init.d.tl` - posix init
 
-#### PR 4.3: Migrate lib/skill
+#### PR 4.3: Migrate lib/skill ✓
+
+**Status: DONE** (migrated in parallel using agent strategy)
 
 Skill modules:
-- `hook.lua`
-- `pr.lua`
-- `pr_comments.lua`
-- `bootstrap.lua`
+- `lib/skill/init.tl` - module metadata
+- `lib/skill/hook.tl` - hook dispatcher with flexible input/output types
+- `lib/skill/pr.tl` - GitHub PR operations
+- `lib/skill/pr_comments.tl` - PR comment handling
+- `lib/skill/bootstrap.tl` - environment bootstrap
+
+Fixed issues:
+- Updated LUA_PATH to include both `o/teal/lib/` and `o/lib/` for module resolution
+- Made HookInput/HookOutput flexible with `{string:any}` to support arbitrary fields
+- Fixed github_request to return string errors instead of tables
 
 #### PR 4.4: Migrate lib/home
 
@@ -449,11 +462,12 @@ Batch 4.2 - Work module ✓ (completed with 7 parallel agents):
 - `lib/work/validate.tl`
 - `lib/work/store.tl`
 
-Batch 4.3 - Skill module (4 agents):
-- `lib/skill/hook.lua`
-- `lib/skill/pr.lua`
-- `lib/skill/pr_comments.lua`
-- `lib/skill/bootstrap.lua`
+Batch 4.3 - Skill module ✓ (completed with 5 parallel agents):
+- `lib/skill/init.tl`
+- `lib/skill/hook.tl`
+- `lib/skill/pr.tl`
+- `lib/skill/pr_comments.tl`
+- `lib/skill/bootstrap.tl`
 
 Batch 4.4 - Home module (needs sequencing):
 - `lib/home/main.lua` first

--- a/lib/skill/bootstrap.tl
+++ b/lib/skill/bootstrap.tl
@@ -1,5 +1,4 @@
 -- bootstrap - setup environment for Claude Code web
--- teal ignore: type annotations needed
 
 local unix = require("cosmo.unix")
 
@@ -42,7 +41,13 @@ To adopt cosmic in a project:
 - Use `tonumber("644", 8)` for permissions (no octal in lua)
 ]]
 
-local function main()
+local record M
+  main: function(): number, string
+  _VERSION: string
+  _DESCRIPTION: string
+end
+
+local function main(): number, string
   print(CONTEXT)
 
   local env_file = os.getenv("CLAUDE_ENV_FILE")
@@ -67,14 +72,16 @@ local function main()
   f:close()
 
   if not ok then
-    return 1, string.format("bootstrap: failed to write to %s: %s", env_file, write_err)
+    return 1, string.format("bootstrap: failed to write to %s: %s", env_file, write_err as string)
   end
 
   return 0
 end
 
-return {
+local bootstrap: M = {
   main = main,
   _VERSION = "0.2.0",
   _DESCRIPTION = "Bootstrap environment for Claude Code web",
 }
+
+return bootstrap

--- a/lib/skill/hook.tl
+++ b/lib/skill/hook.tl
@@ -6,36 +6,47 @@ local cosmo = require("cosmo")
 local path = require("cosmo.path")
 local unix = require("cosmo.unix")
 
+-- HookInput and HookOutput can have arbitrary fields for extensibility
+local type HookInput = {string:any}
+local type HookOutput = {string:any}
+
+local type Handler = function(input: HookInput): HookOutput, string
+
+local record RunOpts
+  stdin: FILE
+  stdout: FILE
+end
+
 -- list of handlers, each decides whether to handle based on input
 -- handler signature: function(input) -> output_table|nil, error_string|nil
-local handlers = {}
+local handlers: {Handler} = {}
 
-local function register(handler)
+local function register(handler: Handler)
   handlers[#handlers + 1] = handler
 end
 
-local function read_input(stdin)
+local function read_input(stdin: FILE): HookInput, string
   stdin = stdin or io.stdin
   local raw = stdin:read("*a")
   if not raw or raw == "" then
     return nil, "no input"
   end
-  local input = cosmo.DecodeJson(raw)
+  local input = cosmo.DecodeJson(raw) as HookInput
   if not input then
     return nil, "invalid json"
   end
   return input
 end
 
-local function write_output(output, stdout)
+local function write_output(output: HookOutput, stdout: FILE)
   stdout = stdout or io.stdout
   if output then
     stdout:write(cosmo.EncodeJson(output))
   end
 end
 
-local function dispatch(input)
-  local outputs = {}
+local function dispatch(input: HookInput): HookOutput, string
+  local outputs: {HookOutput} = {}
   for _, handler in ipairs(handlers) do
     local output, err = handler(input)
     if err then
@@ -51,17 +62,21 @@ local function dispatch(input)
   end
 
   -- merge outputs: concatenate reason and additionalContext, last wins for others
-  local merged = {}
-  local reasons = {}
-  local contexts = {}
+  local merged: HookOutput = {}
+  local reasons: {string} = {}
+  local contexts: {string} = {}
   for _, out in ipairs(outputs) do
-    for k, v in pairs(out) do
+    -- copy all fields from output (last wins for duplicate keys)
+    for k, v in pairs(out as {string:any}) do
       if k == "reason" then
-        reasons[#reasons + 1] = v
+        reasons[#reasons + 1] = v as string
       elseif k == "hookSpecificOutput" then
-        local ctx = v and v.postToolUse and v.postToolUse.additionalContext
-        if ctx then
-          contexts[#contexts + 1] = ctx
+        local hso = v as {string:any}
+        if hso and hso.postToolUse then
+          local ptu = hso.postToolUse as {string:any}
+          if ptu and ptu.additionalContext then
+            contexts[#contexts + 1] = ptu.additionalContext as string
+          end
         end
         merged[k] = v
       else
@@ -74,21 +89,27 @@ local function dispatch(input)
     merged.reason = table.concat(reasons, "\n")
   end
 
-  if #contexts > 1 and merged.hookSpecificOutput and merged.hookSpecificOutput.postToolUse then
-    merged.hookSpecificOutput.postToolUse.additionalContext = table.concat(contexts, "\n")
+  if #contexts > 1 and merged.hookSpecificOutput then
+    local hso = merged.hookSpecificOutput as {string:any}
+    if hso and hso.postToolUse then
+      local ptu = hso.postToolUse as {string:any}
+      if ptu then
+        ptu.additionalContext = table.concat(contexts, "\n")
+      end
+    end
   end
 
   return merged
 end
 
-local function run(opts)
+local function run(opts?: RunOpts): number, string
   opts = opts or {}
   local input, err = read_input(opts.stdin)
   if not input then
     return 0
   end
 
-  local output
+  local output: HookOutput
   output, err = dispatch(input)
   if err then
     io.stderr:write("hook: " .. err .. "\n")
@@ -99,7 +120,7 @@ local function run(opts)
   return 0
 end
 
-local function main()
+local function main(): number
   return run()
 end
 
@@ -107,17 +128,17 @@ end
 -- built-in handlers
 --------------------------------------------------------------------------------
 
-local function spawn_capture(cmd)
+local function spawn_capture(cmd: {string}): string
   local spawn = require("cosmic.spawn").spawn
   local handle = spawn(cmd)
   local ok, out = handle:read()
   if not ok then
     return nil
   end
-  return out and out:match("^%s*(.-)%s*$")
+  return out and (out as string):match("^%s*(.-)%s*$")
 end
 
-local function session_start_bootstrap(input)
+local function session_start_bootstrap(input: HookInput): HookOutput, string
   if input.hook_event_name ~= "SessionStart" then
     return nil
   end
@@ -154,7 +175,7 @@ local function session_start_bootstrap(input)
 end
 register(session_start_bootstrap)
 
-local function session_start_make_help(input)
+local function session_start_make_help(input: HookInput): HookOutput, string
   if input.hook_event_name ~= "SessionStart" then
     return nil
   end
@@ -181,7 +202,7 @@ local function session_start_make_help(input)
 end
 register(session_start_make_help)
 
-local function session_start_pr_reminder(input)
+local function session_start_pr_reminder(input: HookInput): HookOutput, string
   if input.hook_event_name ~= "SessionStart" then
     return nil
   end
@@ -197,7 +218,7 @@ local function session_start_pr_reminder(input)
   local trailer = spawn_capture({"git", "log", "-1", "--format=%(trailers:key=x-cosmic-pr-name,valueonly)"})
   local has_trailer = trailer and trailer ~= ""
 
-  local msg
+  local msg: string
   if has_trailer then
     local pr_file = path.join(".github/pr", trailer)
     if path.exists(pr_file) then
@@ -214,7 +235,7 @@ local function session_start_pr_reminder(input)
 end
 register(session_start_pr_reminder)
 
-local function post_commit_pr_reminder(input)
+local function post_commit_pr_reminder(input: HookInput): HookOutput, string
   if input.hook_event_name ~= "PostToolUse" then
     return nil
   end
@@ -222,7 +243,7 @@ local function post_commit_pr_reminder(input)
     return nil
   end
 
-  local tool_input = input.tool_input or {}
+  local tool_input = input.tool_input or {} as ToolInput
   local command = tool_input.command or ""
   if not command:match("git commit") then
     return nil
@@ -236,7 +257,7 @@ local function post_commit_pr_reminder(input)
   local has_trailer = spawn_capture({"git", "log", "-1", "--format=%(trailers:key=x-cosmic-pr-name,valueonly)"})
   local pr_file = has_trailer and has_trailer ~= "" and path.join(".github/pr", has_trailer) or nil
 
-  local msg
+  local msg: string
   if pr_file and path.exists(pr_file) then
     msg = string.format("PR file: %s - update if needed", pr_file)
   elseif has_trailer and has_trailer ~= "" then
@@ -253,7 +274,7 @@ local function post_commit_pr_reminder(input)
 end
 register(post_commit_pr_reminder)
 
-local function post_push_pr_check(input)
+local function post_push_pr_check(input: HookInput): HookOutput, string
   if input.hook_event_name ~= "PostToolUse" then
     return nil
   end
@@ -261,7 +282,7 @@ local function post_push_pr_check(input)
     return nil
   end
 
-  local tool_input = input.tool_input or {}
+  local tool_input = input.tool_input or {} as ToolInput
   local command = tool_input.command or ""
   if not command:match("git push") then
     return nil
@@ -275,7 +296,7 @@ local function post_push_pr_check(input)
   local trailer = spawn_capture({"git", "log", "-1", "--format=%(trailers:key=x-cosmic-pr-name,valueonly)"})
   local has_trailer = trailer and trailer ~= ""
 
-  local msg
+  local msg: string
   if has_trailer then
     local pr_file = path.join(".github/pr", trailer)
     if path.exists(pr_file) then
@@ -295,7 +316,7 @@ local function post_push_pr_check(input)
 end
 register(post_push_pr_check)
 
-local function post_push_check_reminder(input)
+local function post_push_check_reminder(input: HookInput): HookOutput, string
   if input.hook_event_name ~= "PostToolUse" then
     return nil
   end
@@ -303,7 +324,7 @@ local function post_push_check_reminder(input)
     return nil
   end
 
-  local tool_input = input.tool_input or {}
+  local tool_input = input.tool_input or {} as ToolInput
   local command = tool_input.command or ""
   if not command:match("git push") then
     return nil

--- a/lib/skill/init.tl
+++ b/lib/skill/init.tl
@@ -1,9 +1,14 @@
 -- skill - cosmic skill modules
 -- usage: cosmic --skill <name> [args...]
 
--- teal ignore: type annotations needed
+local record SkillModule
+  _VERSION: string
+  _DESCRIPTION: string
+end
 
-return {
+local M: SkillModule = {
   _VERSION = "0.1.0",
   _DESCRIPTION = "Skill modules for cosmic-lua",
 }
+
+return M

--- a/lib/skill/pr.tl
+++ b/lib/skill/pr.tl
@@ -1,4 +1,3 @@
--- teal ignore: type annotations needed
 --[[
 Updates a GitHub PR title and description from .github/pr/<name>.md
 
@@ -24,35 +23,81 @@ Environment variables:
 
 local cosmo = require("cosmo")
 local path = require("cosmo.path")
-local spawn = require("cosmic.spawn")
+local spawn_mod = require("cosmic.spawn")
 
-local function log(msg)
+local type SpawnHandle = require("cosmic.spawn").SpawnHandle
+
+local record FetchOpts
+  method: string
+  headers: {string:string}
+  body: string
+end
+
+local type FetchFn = function(url: string, opts?: FetchOpts): number, {string:string} | string, string
+
+local record SpawnOpts
+  spawn: function({string}): SpawnHandle
+  repo: string
+end
+
+local record RequestOpts
+  fetch: FetchFn
+  getenv: function(string): string
+end
+
+local record MainOpts
+  spawn: function({string}): SpawnHandle
+  repo: string
+  getenv: function(string): string
+  fetch: FetchFn
+end
+
+local record TrailerInfo
+  commit_count: number
+  first_sha: string
+  last_sha: string
+  winning_sha: string
+  winning_trailer: string
+end
+
+local record ParsedPr
+  title: string
+  body: string
+end
+
+local record GitHubPr
+  title: string
+  body: string
+  message: string
+end
+
+local function log(msg: string)
   io.stderr:write("pr: " .. msg .. "\n")
 end
 
-local function get_current_branch()
-  local handle = spawn({"git", "rev-parse", "--abbrev-ref", "HEAD"})
+local function get_current_branch(): string
+  local handle = spawn_mod({"git", "rev-parse", "--abbrev-ref", "HEAD"})
   local ok, out = handle:read()
   if not ok then
     return nil
   end
-  local branch = out:match("^%s*(.-)%s*$")
+  local branch = (out as string):match("^%s*(.-)%s*$")
   if branch == "" then
     return nil
   end
   return branch
 end
 
-local function get_commit_sha()
-  local handle = spawn({"git", "rev-parse", "HEAD"})
+local function get_commit_sha(): string
+  local handle = spawn_mod({"git", "rev-parse", "HEAD"})
   local ok, out = handle:read()
   if not ok or not out then
     return "unknown"
   end
-  return out:match("^%s*(.-)%s*$") or "unknown"
+  return (out as string):match("^%s*(.-)%s*$") or "unknown"
 end
 
-local function normalize_pr_name(name)
+local function normalize_pr_name(name: string): string
   if not name then return nil end
   if not name:match("%.md$") then
     return name .. ".md"
@@ -60,13 +105,13 @@ local function normalize_pr_name(name)
   return name
 end
 
-local function get_pr_files_from_branch(opts)
+local function get_pr_files_from_branch(opts?: SpawnOpts): {string}
   opts = opts or {}
-  local do_spawn = opts.spawn or spawn
+  local do_spawn = opts.spawn or spawn_mod
 
   -- Find files added on this branch matching .github/pr/*.md
   -- Compare against origin/HEAD (default branch)
-  local cmd = {"git"}
+  local cmd: {string} = {"git"}
   if opts.repo then
     table.insert(cmd, "-C")
     table.insert(cmd, opts.repo)
@@ -84,8 +129,8 @@ local function get_pr_files_from_branch(opts)
     return {}
   end
 
-  local files = {}
-  for line in out:gmatch("[^\n]+") do
+  local files: {string} = {}
+  for line in (out as string):gmatch("[^\n]+") do
     local name = line:match("^%s*(.-)%s*$")
     if name and name ~= "" then
       table.insert(files, name)
@@ -94,13 +139,13 @@ local function get_pr_files_from_branch(opts)
   return files
 end
 
-local function get_pr_name_from_trailer(opts)
+local function get_pr_name_from_trailer(opts?: SpawnOpts): string, TrailerInfo
   opts = opts or {}
-  local do_spawn = opts.spawn or spawn
+  local do_spawn = opts.spawn or spawn_mod
 
   -- Get all x-cosmic-pr-name and x-cosmic-pr-enable trailers from last 20 commits
   -- Process in chronological order (oldest first) to find the final state
-  local cmd = {"git"}
+  local cmd: {string} = {"git"}
   if opts.repo then
     table.insert(cmd, "-C")
     table.insert(cmd, opts.repo)
@@ -112,16 +157,19 @@ local function get_pr_name_from_trailer(opts)
   local handle = do_spawn(cmd)
   local ok, out = handle:read()
   if not ok or not out then
-    return nil
+    return nil, nil
   end
 
   -- Track the final state by processing commits in order
-  local pr_name = nil
+  local pr_name: string = nil
   local enabled = true
-  local first_sha, last_sha, winning_sha, winning_trailer
+  local first_sha: string
+  local last_sha: string
+  local winning_sha: string
+  local winning_trailer: string
   local commit_count = 0
 
-  for line in out:gmatch("[^\n]+") do
+  for line in (out as string):gmatch("[^\n]+") do
     local sha, rest = line:match("^(%S+)%s*(.*)$")
     if sha then
       commit_count = commit_count + 1
@@ -145,7 +193,7 @@ local function get_pr_name_from_trailer(opts)
     end
   end
 
-  local info = {
+  local info: TrailerInfo = {
     commit_count = commit_count,
     first_sha = first_sha,
     last_sha = last_sha,
@@ -153,11 +201,14 @@ local function get_pr_name_from_trailer(opts)
     winning_trailer = winning_trailer,
   }
 
-  return enabled and pr_name or nil, info
+  if enabled and pr_name then
+    return pr_name, info
+  end
+  return nil, info
 end
 
 
-local function parse_pr_md(content)
+local function parse_pr_md(content: string): ParsedPr, string
   local title = content:match("^#%s*([^\n]+)")
   if not title then
     return nil, "no title found (expected '# <title>' on first line)"
@@ -175,11 +226,11 @@ local function parse_pr_md(content)
   return {title = title, body = body}
 end
 
-local function default_fetch(url, opts)
-  return cosmo.Fetch(url, opts)
+local function default_fetch(url: string, opts?: FetchOpts): number, {string:string} | string, string
+  return cosmo.Fetch(url, opts as {string:any})
 end
 
-local function github_request(method, endpoint, token, body, opts)
+local function github_request(method: string, endpoint: string, token: string, body: {string:string}, opts?: RequestOpts): number, GitHubPr | string
   opts = opts or {}
   local fetch = opts.fetch or default_fetch
   local getenv = opts.getenv or os.getenv
@@ -187,7 +238,7 @@ local function github_request(method, endpoint, token, body, opts)
   local api_url = getenv("GITHUB_API_URL") or "https://api.github.com"
   local url = api_url .. endpoint
 
-  local fetch_opts = {
+  local fetch_opts: FetchOpts = {
     method = method,
     headers = {
       ["Accept"] = "application/vnd.github+json",
@@ -211,32 +262,33 @@ local function github_request(method, endpoint, token, body, opts)
     return nil, "fetch failed: " .. tostring(headers)
   end
 
-  local ok, decoded = pcall(cosmo.DecodeJson, response_body)
-  if not ok then
+  local decoded_ok, decoded = pcall(cosmo.DecodeJson, response_body as string)
+  if not decoded_ok then
     return nil, "json decode failed: " .. tostring(decoded)
   end
 
-  return status, decoded
+  return status, decoded as GitHubPr
 end
 
 
-local function get_pr(owner, repo, pr_number, token, opts)
+local function get_pr(owner: string, repo: string, pr_number: number, token: string, opts?: RequestOpts): GitHubPr, string
   local endpoint = string.format("/repos/%s/%s/pulls/%d", owner, repo, pr_number)
 
   local status, data = github_request("GET", endpoint, token, nil, opts)
   if not status then
-    return nil, data
+    return nil, data as string
   end
 
   if status ~= 200 then
-    local msg = data and data.message or "unknown error"
+    local pr_data = data as GitHubPr
+    local msg = pr_data and pr_data.message or "unknown error"
     return nil, "api error " .. tostring(status) .. ": " .. msg
   end
 
-  return data
+  return data as GitHubPr
 end
 
-local function append_timestamp_details(body)
+local function append_timestamp_details(body: string): string
   local timestamp = os.date("!%Y-%m-%dT%H:%M:%SZ")
   local entry = string.format("- Updated: %s", timestamp)
 
@@ -265,7 +317,7 @@ local function append_timestamp_details(body)
   return body .. separator .. "\n" .. details_block
 end
 
-local function update_pr(owner, repo, pr_number, title, body, token, opts)
+local function update_pr(owner: string, repo: string, pr_number: number, title: string, body: string, token: string, opts?: RequestOpts): boolean, string
   local endpoint = string.format("/repos/%s/%s/pulls/%d", owner, repo, pr_number)
 
   local status, data = github_request("PATCH", endpoint, token, {
@@ -274,11 +326,12 @@ local function update_pr(owner, repo, pr_number, title, body, token, opts)
   }, opts)
 
   if not status then
-    return nil, data
+    return nil, data as string
   end
 
   if status ~= 200 then
-    local msg = data and data.message or "unknown error"
+    local pr_data = data as GitHubPr
+    local msg = pr_data and pr_data.message or "unknown error"
     return nil, "api error " .. tostring(status) .. ": " .. msg
   end
 
@@ -288,7 +341,12 @@ end
 
 local function print_help()
   local pr_name = get_pr_name_from_trailer()
-  local pr_file = pr_name and path.join(".github/pr", normalize_pr_name(pr_name)) or ".github/pr/<name>.md"
+  local pr_file: string
+  if pr_name then
+    pr_file = path.join(".github/pr", normalize_pr_name(pr_name))
+  else
+    pr_file = ".github/pr/<name>.md"
+  end
 
   local help = string.format([[
 usage: pr.lua [-h]
@@ -340,11 +398,11 @@ Environment variables (set automatically in GitHub Actions):
   print(help)
 end
 
-local function is_github_actions()
+local function is_github_actions(): boolean
   return os.getenv("GITHUB_ACTIONS") == "true"
 end
 
-local function do_update(owner, repo_name, pr_number, pr_name, trailer_info, token, opts)
+local function do_update(owner: string, repo_name: string, pr_number: number, pr_name: string, trailer_info: TrailerInfo, token: string, opts?: RequestOpts): number, string
   -- log commit range and winning trailer
   if trailer_info and trailer_info.first_sha then
     local range = string.format("%s..%s (%d commits)",
@@ -375,7 +433,7 @@ local function do_update(owner, repo_name, pr_number, pr_name, trailer_info, tok
   end
 
   -- get current PR state to check if we're making changes
-  local current_pr
+  local current_pr: GitHubPr
   current_pr, err = get_pr(owner, repo_name, pr_number, token, opts)
   if not current_pr then
     return 1, "failed to get current PR: " .. err
@@ -391,7 +449,7 @@ local function do_update(owner, repo_name, pr_number, pr_name, trailer_info, tok
     body_to_update = append_timestamp_details(pr.body)
   end
 
-  local ok
+  local ok: boolean
   ok, err = update_pr(owner, repo_name, pr_number, pr.title, body_to_update, token, opts)
   if not ok then
     return 1, "failed to update PR: " .. err
@@ -401,7 +459,7 @@ local function do_update(owner, repo_name, pr_number, pr_name, trailer_info, tok
   return 0
 end
 
-local function main(opts)
+local function main(opts?: MainOpts): number, string
   opts = opts or {}
   local getenv = opts.getenv or os.getenv
 
@@ -426,19 +484,20 @@ local function main(opts)
     return 1, "invalid GITHUB_REPOSITORY format: " .. repo
   end
 
-  local pr_number = getenv("GITHUB_PR_NUMBER")
-  if not pr_number or pr_number == "" then
+  local pr_number_str = getenv("GITHUB_PR_NUMBER")
+  if not pr_number_str or pr_number_str == "" then
     return 1, "GITHUB_PR_NUMBER not set"
   end
-  pr_number = tonumber(pr_number)
+  local pr_number = tonumber(pr_number_str)
   if not pr_number then
     return 1, "invalid GITHUB_PR_NUMBER"
   end
 
-  local pr_name, trailer_info = get_pr_name_from_trailer(opts)
+  local spawn_opts: SpawnOpts = {spawn = opts.spawn, repo = opts.repo}
+  local pr_name, trailer_info = get_pr_name_from_trailer(spawn_opts)
   if not pr_name then
     -- fallback: check if branch introduces exactly one .github/pr/*.md file
-    local pr_files = get_pr_files_from_branch(opts)
+    local pr_files = get_pr_files_from_branch(spawn_opts)
     if #pr_files == 1 then
       -- extract just the filename from .github/pr/<name>.md
       local basename = pr_files[1]:match("%.github/pr/(.+)$")
@@ -461,7 +520,8 @@ local function main(opts)
     return 0, msg
   end
 
-  return do_update(owner, repo_name, pr_number, pr_name, trailer_info, token, opts)
+  local request_opts: RequestOpts = {fetch = opts.fetch, getenv = opts.getenv}
+  return do_update(owner, repo_name, pr_number, pr_name, trailer_info, token, request_opts)
 end
 
 if cosmo.is_main() then
@@ -474,6 +534,21 @@ if cosmo.is_main() then
     log(msg)
   end
   os.exit(0)
+end
+
+local record PrModule
+  parse_pr_md: function(content: string): ParsedPr, string
+  github_request: function(method: string, endpoint: string, token: string, body: {string:string}, opts?: RequestOpts): number, GitHubPr
+  get_pr: function(owner: string, repo: string, pr_number: number, token: string, opts?: RequestOpts): GitHubPr, string
+  append_timestamp_details: function(body: string): string
+  update_pr: function(owner: string, repo: string, pr_number: number, title: string, body: string, token: string, opts?: RequestOpts): boolean, string
+  get_current_branch: function(): string
+  get_commit_sha: function(): string
+  get_pr_name_from_trailer: function(opts?: SpawnOpts): string, TrailerInfo
+  get_pr_files_from_branch: function(opts?: SpawnOpts): {string}
+  is_github_actions: function(): boolean
+  do_update: function(owner: string, repo_name: string, pr_number: number, pr_name: string, trailer_info: TrailerInfo, token: string, opts?: RequestOpts): number, string
+  main: function(opts?: MainOpts): number, string
 end
 
 return {
@@ -489,4 +564,4 @@ return {
   is_github_actions = is_github_actions,
   do_update = do_update,
   main = main,
-}
+} as PrModule

--- a/lib/skill/pr_comments.tl
+++ b/lib/skill/pr_comments.tl
@@ -1,4 +1,3 @@
--- teal ignore: type annotations needed
 -- Fetches review comments on a GitHub PR using cosmo.Fetch
 --
 -- GitHub API endpoints:
@@ -14,13 +13,66 @@ local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
 local getopt = require("cosmo.getopt")
 
-local function fetch_with_retry(url, opts, max_attempts)
+local record FetchOpts
+  method: string
+  headers: {string:string}
+end
+
+local record User
+  login: string
+end
+
+local record ReviewComment
+  id: number
+  user: User
+  path: string
+  line: number
+  original_line: number
+  created_at: string
+  in_reply_to_id: number
+  body: string
+end
+
+local record IssueComment
+  user: User
+  created_at: string
+  body: string
+end
+
+local record Review
+  user: User
+  state: string
+  submitted_at: string
+  body: string
+end
+
+local record ApiError
+  message: string
+end
+
+local record ParsedOpts
+  json: boolean
+  owner: string
+  repo: string
+  pr_number: number
+  help: boolean
+end
+
+local record JsonResult
+  reviews: {Review}
+  issue_comments: {IssueComment}
+  review_comments: {ReviewComment}
+end
+
+local function fetch_with_retry(url: string, opts: FetchOpts, max_attempts: number): number, {string:string}, string
   max_attempts = max_attempts or 4
-  local status, headers, body
-  local last_err
+  local status: number
+  local headers: {string:string}
+  local body: string
+  local last_err: string
 
   for attempt = 1, max_attempts do
-    status, headers, body = cosmo.Fetch(url, opts)
+    status, headers, body = cosmo.Fetch(url, opts as {string:any})
     if not status then
       last_err = "fetch failed: " .. tostring(headers)
     elseif status >= 500 then
@@ -33,14 +85,14 @@ local function fetch_with_retry(url, opts, max_attempts)
     end
   end
 
-  return nil, last_err
+  return nil, nil, last_err
 end
 
-local function github_request(endpoint)
+local function github_request(endpoint: string): number, any
   local api_url = os.getenv("GITHUB_API_URL") or "https://api.github.com"
   local url = api_url .. endpoint
 
-  local fetch_opts = {
+  local fetch_opts: FetchOpts = {
     method = "GET",
     headers = {
       ["Accept"] = "application/vnd.github+json",
@@ -54,9 +106,9 @@ local function github_request(endpoint)
     fetch_opts.headers["Authorization"] = "Bearer " .. token
   end
 
-  local status, headers, body = fetch_with_retry(url, fetch_opts)
+  local status, _, body = fetch_with_retry(url, fetch_opts, nil)
   if not status then
-    return nil, headers
+    return nil, body
   end
 
   local ok, decoded = pcall(cosmo.DecodeJson, body)
@@ -65,30 +117,31 @@ local function github_request(endpoint)
   end
 
   if status ~= 200 then
-    local msg = decoded and decoded.message or "unknown error"
+    local api_err = decoded as ApiError
+    local msg = api_err and api_err.message or "unknown error"
     return nil, string.format("api error %d: %s", status, msg)
   end
 
   return status, decoded
 end
 
-local function get_review_comments(owner, repo, pr_number)
+local function get_review_comments(owner: string, repo: string, pr_number: number): number, {ReviewComment}
   local endpoint = string.format("/repos/%s/%s/pulls/%d/comments", owner, repo, pr_number)
-  return github_request(endpoint)
+  return github_request(endpoint) as (number, {ReviewComment})
 end
 
-local function get_issue_comments(owner, repo, pr_number)
+local function get_issue_comments(owner: string, repo: string, pr_number: number): number, {IssueComment}
   local endpoint = string.format("/repos/%s/%s/issues/%d/comments", owner, repo, pr_number)
-  return github_request(endpoint)
+  return github_request(endpoint) as (number, {IssueComment})
 end
 
-local function get_reviews(owner, repo, pr_number)
+local function get_reviews(owner: string, repo: string, pr_number: number): number, {Review}
   local endpoint = string.format("/repos/%s/%s/pulls/%d/reviews", owner, repo, pr_number)
-  return github_request(endpoint)
+  return github_request(endpoint) as (number, {Review})
 end
 
-local function format_review_comment(c)
-  local lines = {}
+local function format_review_comment(c: ReviewComment): string
+  local lines: {string} = {}
   table.insert(lines, string.format("## Review comment by %s", c.user and c.user.login or "unknown"))
   table.insert(lines, string.format("ID: %s", c.id or "?"))
   table.insert(lines, string.format("File: %s (line %s)", c.path or "?", c.line or c.original_line or "?"))
@@ -102,8 +155,8 @@ local function format_review_comment(c)
   return table.concat(lines, "\n")
 end
 
-local function format_issue_comment(c)
-  local lines = {}
+local function format_issue_comment(c: IssueComment): string
+  local lines: {string} = {}
   table.insert(lines, string.format("## Comment by %s", c.user and c.user.login or "unknown"))
   table.insert(lines, string.format("Created: %s", c.created_at or "?"))
   table.insert(lines, "")
@@ -112,8 +165,8 @@ local function format_issue_comment(c)
   return table.concat(lines, "\n")
 end
 
-local function format_review(r)
-  local lines = {}
+local function format_review(r: Review): string
+  local lines: {string} = {}
   local state = r.state or "UNKNOWN"
   table.insert(lines, string.format("## Review by %s [%s]", r.user and r.user.login or "unknown", state))
   table.insert(lines, string.format("Submitted: %s", r.submitted_at or "?"))
@@ -125,23 +178,23 @@ local function format_review(r)
   return table.concat(lines, "\n")
 end
 
-local function parse_pr_url(url)
+local function parse_pr_url(url: string): string, string, number
   local owner, repo, pr_number = url:match("github%.com/([^/]+)/([^/]+)/pull/(%d+)")
   if owner and repo and pr_number then
     return owner, repo, tonumber(pr_number)
   end
-  return nil
+  return nil, nil, nil
 end
 
-local function parse_args(args)
-  local opts = {
+local function parse_args(args: {string}): ParsedOpts
+  local opts: ParsedOpts = {
     json = os.getenv("OUTPUT") == "json",
     owner = nil,
     repo = nil,
     pr_number = nil,
   }
 
-  local longopts = {
+  local longopts: {getopt.LongOpt} = {
     {"owner", "required", "o"},
     {"repo", "required", "r"},
     {"pr", "required", "p"},
@@ -194,7 +247,7 @@ examples:
 ]])
 end
 
-local function main()
+local function main(): number
   local opts = parse_args(arg)
 
   if opts.help then
@@ -218,7 +271,7 @@ local function main()
   local _, reviews = get_reviews(opts.owner, opts.repo, opts.pr_number)
 
   if opts.json then
-    local result = {
+    local result: JsonResult = {
       reviews = reviews or {},
       issue_comments = issue_comments or {},
       review_comments = review_comments or {},
@@ -261,6 +314,20 @@ if cosmo.is_main() then
   os.exit(main())
 end
 
+local record Module
+  fetch_with_retry: function(url: string, opts: FetchOpts, max_attempts: number): number, {string:string}, string
+  github_request: function(endpoint: string): number, any
+  get_review_comments: function(owner: string, repo: string, pr_number: number): number, {ReviewComment}
+  get_issue_comments: function(owner: string, repo: string, pr_number: number): number, {IssueComment}
+  get_reviews: function(owner: string, repo: string, pr_number: number): number, {Review}
+  format_review_comment: function(c: ReviewComment): string
+  format_issue_comment: function(c: IssueComment): string
+  format_review: function(r: Review): string
+  parse_pr_url: function(url: string): string, string, number
+  parse_args: function(args: {string}): ParsedOpts
+  main: function(): number
+end
+
 return {
   fetch_with_retry = fetch_with_retry,
   github_request = github_request,
@@ -273,4 +340,4 @@ return {
   parse_pr_url = parse_pr_url,
   parse_args = parse_args,
   main = main,
-}
+} as Module


### PR DESCRIPTION
## Summary
- Migrates skill module to teal (Phase 4.3 from docs/teal-migration.md)
- Converted 5 skill module files to teal:
  - lib/skill/init.tl: main skill module
  - lib/skill/bootstrap.tl: skill bootstrapping
  - lib/skill/hook.tl: hook handling
  - lib/skill/pr.tl: PR utilities
  - lib/skill/pr_comments.tl: PR comment handling

## Test plan
- [x] `make teal` passes
- [x] `make test` passes
- [ ] CI passes