### PR TITLE
3p: migrate phase 5 checker runners to teal

### DIFF
--- a/3p/ast-grep/run-astgrep.tl
+++ b/3p/ast-grep/run-astgrep.tl
@@ -1,43 +1,74 @@
 #!/usr/bin/env lua
--- teal ignore: type annotations needed
 
 local cosmo = require("cosmo")
-local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local spawn = require("cosmic.spawn")
 local common = require("checker.common")
 
-local supported_extensions = {
+local record Issue
+  line: integer
+  column: integer
+  rule_id: string
+  message: string
+  note: string
+end
+
+local record AstGrepRange
+  start: AstGrepPosition
+end
+
+local record AstGrepPosition
+  line: integer
+  column: integer
+end
+
+local record AstGrepResult
+  ruleId: string
+  range: AstGrepRange
+  message: string
+  note: string
+end
+
+local supported_extensions: {string: boolean} = {
   [".lua"] = true,
   [".tl"] = true,
 }
 
-local supported_patterns = {
+local record CheckPatterns
+  shebangs: {string: boolean}
+  ignore: string
+end
+
+local supported_patterns: CheckPatterns = {
   shebangs = {
     ["lua"] = true,
   },
   ignore = "ast%-grep%s+ignore%s*:?%s*(.*)",
 }
 
-local function parse_json_stream(stdout)
-  local issues = {}
+local function parse_json_stream(stdout: string): {Issue}
+  local issues: {Issue} = {}
   for line in (stdout or ""):gmatch("[^\n]+") do
     local ok, obj = pcall(cosmo.DecodeJson, line)
-    if ok and obj and obj.ruleId then
-      table.insert(issues, {
-        line = (obj.range and obj.range.start and obj.range.start.line or 0) + 1,
-        column = (obj.range and obj.range.start and obj.range.start.column or 0) + 1,
-        rule_id = obj.ruleId,
-        message = obj.message,
-        note = obj.note,
-      })
+    if ok and obj then
+      local result = obj as AstGrepResult
+      if result.ruleId then
+        local issue: Issue = {
+          line = (result.range and result.range.start and result.range.start.line or 0) + 1,
+          column = (result.range and result.range.start and result.range.start.column or 0) + 1,
+          rule_id = result.ruleId,
+          message = result.message,
+          note = result.note,
+        }
+        table.insert(issues, issue)
+      end
     end
   end
   return issues
 end
 
-local function format_issues(issues, source)
-  local lines = {}
+local function format_issues(issues: {Issue}, source: string): string
+  local lines: {string} = {}
   for _, issue in ipairs(issues) do
     table.insert(lines, string.format("%s:%d:%d: [%s] %s",
       source,
@@ -50,7 +81,7 @@ local function format_issues(issues, source)
 end
 
 
-local function main(source)
+local function main(source: string): integer, string
   if not source then
     return 1, "usage: run-astgrep.lua <source>"
   end
@@ -70,7 +101,7 @@ local function main(source)
   local handle = spawn({ sg, "scan", "--json=stream", source })
   local _, stdout, _ = handle:read()
 
-  local issues = parse_json_stream(stdout)
+  local issues = parse_json_stream(stdout as string)
 
   if #issues > 0 then
     local issue_text = format_issues(issues, source)

--- a/3p/luacheck/run-luacheck.tl
+++ b/3p/luacheck/run-luacheck.tl
@@ -1,25 +1,31 @@
 #!/usr/bin/env lua
--- teal ignore: type annotations needed
 
 local cosmo = require("cosmo")
-local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local spawn = require("cosmic.spawn")
 local common = require("checker.common")
 
-local supported_extensions = {
+local record Issue
+  line: integer
+  column: integer
+  end_column: integer
+  code: string
+  message: string
+end
+
+local supported_extensions: {string: boolean} = {
   [".lua"] = true,
 }
 
-local supported_patterns = {
+local supported_patterns: common.CheckPatterns = {
   shebangs = {
     ["lua"] = true,
   },
   ignore = "luacheck%s+ignore%s*:?%s*(.*)",
 }
 
-local function parse_plain(stdout)
-  local issues = {}
+local function parse_plain(stdout: string): {Issue}
+  local issues: {Issue} = {}
   for line in (stdout or ""):gmatch("[^\n]+") do
     local _, ln, col, endcol, code, msg = line:match("^(.+):(%d+):(%d+)-(%d+): %(([WE]%d+)%) (.+)$")
     if not ln then
@@ -27,9 +33,9 @@ local function parse_plain(stdout)
     end
     if ln then
       table.insert(issues, {
-        line = tonumber(ln),
-        column = tonumber(col),
-        end_column = endcol and tonumber(endcol),
+        line = tonumber(ln) as integer,
+        column = tonumber(col) as integer,
+        end_column = endcol and tonumber(endcol) as integer,
         code = code,
         message = msg,
       })
@@ -38,8 +44,8 @@ local function parse_plain(stdout)
   return issues
 end
 
-local function format_issues(issues, source)
-  local lines = {}
+local function format_issues(issues: {Issue}, source: string): string
+  local lines: {string} = {}
   for _, issue in ipairs(issues) do
     table.insert(lines, string.format("%s:%d:%d: (%s) %s",
       source,
@@ -52,7 +58,7 @@ local function format_issues(issues, source)
 end
 
 
-local function main(source)
+local function main(source: string): integer, string
   if not source then
     return 1, "usage: run-luacheck.lua <source>"
   end
@@ -67,7 +73,7 @@ local function main(source)
     return common.write_result("skip", skip_reason, "", "")
   end
 
-  local luacheck_bin = path.join(os.getenv("LUACHECK_BIN"), "luacheck")
+  local luacheck_bin = path.join(os.getenv("LUACHECK_BIN") as string, "luacheck")
 
   local source_content = cosmo.Slurp(source)
   local handle = spawn({
@@ -81,7 +87,7 @@ local function main(source)
 
   local _, stdout, _ = handle:read()
 
-  local issues = parse_plain(stdout)
+  local issues = parse_plain(stdout as string)
 
   if #issues > 0 then
     local issue_text = format_issues(issues, source)

--- a/3p/tl/run-teal.tl
+++ b/3p/tl/run-teal.tl
@@ -1,27 +1,37 @@
 #!/usr/bin/env lua
--- teal ignore: type annotations needed
 
 local cosmo = require("cosmo")
-local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local spawn = require("cosmic.spawn")
 local common = require("checker.common")
 
-local supported_extensions = {
+local record Issue
+  line: integer
+  column: integer
+  severity: string
+  message: string
+end
+
+local record CheckPatterns
+  shebangs: {string: boolean}
+  ignore: string
+end
+
+local supported_extensions: {string: boolean} = {
   [".lua"] = true,
   [".tl"] = true,
 }
 
-local supported_patterns = {
+local supported_patterns: CheckPatterns = {
   shebangs = {
     ["lua"] = true,
   },
   ignore = "teal%s+ignore%s*:?%s*(.*)",
 }
 
-local function parse_output(stderr)
-  local issues = {}
-  local current_severity = nil
+local function parse_output(stderr: string): {Issue}
+  local issues: {Issue} = {}
+  local current_severity: string = nil
 
   for line in (stderr or ""):gmatch("[^\n]+") do
     if line:match("^%d+ warnings?:$") then
@@ -34,8 +44,8 @@ local function parse_output(stderr)
       local file, ln, col, msg = line:match("^(.+):(%d+):(%d+): (.+)$")
       if ln then
         table.insert(issues, {
-          line = tonumber(ln),
-          column = tonumber(col),
+          line = tonumber(ln) as integer,
+          column = tonumber(col) as integer,
           severity = current_severity,
           message = msg,
         })
@@ -45,8 +55,8 @@ local function parse_output(stderr)
   return issues
 end
 
-local function format_issues(issues, source)
-  local lines = {}
+local function format_issues(issues: {Issue}, source: string): string
+  local lines: {string} = {}
   for _, issue in ipairs(issues) do
     table.insert(lines, string.format("%s:%d:%d: [%s] %s",
       source,
@@ -59,7 +69,7 @@ local function format_issues(issues, source)
 end
 
 
-local function main(source)
+local function main(source: string): integer, string
   if not source then
     return 1, "usage: run-teal.lua <source>"
   end

--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,15 @@ $(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files) $$(tl_staged)
 
 # bin scripts: o/bin/X.lua from lib/*/X.lua and 3p/*/X.lua
 vpath %.lua lib/build lib/test 3p/ast-grep 3p/luacheck 3p/tl
+vpath %.tl 3p/ast-grep 3p/luacheck 3p/tl
 $(o)/bin/%.lua: %.lua
 	@mkdir -p $(@D)
 	@$(cp) $< $@
+
+# bin scripts from teal: o/bin/X.lua from 3p/*/X.tl (vpath finds X.tl)
+$(o)/bin/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files) | $(tl_staged)
+	@mkdir -p $(@D)
+	@$(tl_gen) $< -o $@
 
 # files are produced in o/
 all_files += $(call filter-only,$(foreach x,$(modules),$($(x)_files)))

--- a/docs/teal-migration.md
+++ b/docs/teal-migration.md
@@ -11,8 +11,8 @@ This document outlines the incremental migration from Lua to Teal for comprehens
 
 ## Current state
 
-- 25 lua files with `-- teal ignore` comments (down from 107)
-- 82 `.tl` files migrated:
+- 22 lua files with `-- teal ignore` comments (down from 107)
+- 85 `.tl` files migrated:
   - `lib/checker/common.tl`
   - `lib/ulid.tl`
   - `lib/utils.tl`
@@ -54,6 +54,9 @@ This document outlines the incremental migration from Lua to Teal for comprehens
   - `lib/home/gen-platforms.tl`
   - `lib/home/setup/*.tl` (13 files)
   - `lib/home/mac/*.tl` (30 files)
+  - `3p/tl/run-teal.tl`
+  - `3p/luacheck/run-luacheck.tl`
+  - `3p/ast-grep/run-astgrep.tl`
 - Teal 0.24.8 installed as 3p dependency
 - `make teal` target exists (runs `tl check` on each file)
 - Checker infrastructure already supports `.tl` extension
@@ -284,11 +287,15 @@ Key type definitions:
 
 ### Phase 5: Third-party runners
 
-#### PR 5.1: Migrate 3p checker runners
+#### PR 5.1: Migrate 3p checker runners ✓
 
-- `3p/tl/run-teal.lua`
-- `3p/luacheck/run-luacheck.lua`
-- `3p/ast-grep/run-astgrep.lua`
+**Status: DONE** (migrated in parallel using agent strategy)
+
+- `3p/tl/run-teal.tl` - teal checker runner with Issue record type
+- `3p/luacheck/run-luacheck.tl` - luacheck runner with Issue record type
+- `3p/ast-grep/run-astgrep.tl` - ast-grep runner with AstGrepResult, Issue types
+
+Updated Makefile with vpath for .tl files and pattern rule for compiling to o/bin/.
 
 ### Phase 6: Tests
 
@@ -476,10 +483,10 @@ Batch 4.4 - Home module ✓ (completed with 4 parallel agents):
 - `lib/home/mac/*.tl` (30 files)
 - `lib/home/gen-*.tl` (2 files)
 
-**Phase 5: 3p runners** (3 agents):
-- `3p/tl/run-teal.lua`
-- `3p/luacheck/run-luacheck.lua`
-- `3p/ast-grep/run-astgrep.lua`
+**Phase 5: 3p runners** ✓ (completed with 3 parallel agents):
+- `3p/tl/run-teal.tl`
+- `3p/luacheck/run-luacheck.tl`
+- `3p/ast-grep/run-astgrep.tl`
 
 ### Best practices for agent prompts
 


### PR DESCRIPTION
## Summary
- Migrates 3p checker runners to teal (Phase 5 from docs/teal-migration.md)
- Converted 3 checker runner files:
  - 3p/ast-grep/run-astgrep.tl
  - 3p/luacheck/run-luacheck.tl
  - 3p/tl/run-teal.tl

## Test plan
- [x] `make teal` passes
- [x] `make test` passes
- [ ] CI passes