### PR TITLE
tests: migrate phase 6.1 test files to teal

### DIFF
--- a/3p/argparse/test_argparse.tl
+++ b/3p/argparse/test_argparse.tl
@@ -1,0 +1,30 @@
+#!/usr/bin/env run-test.lua
+-- ast-grep ignore: test file needs package.path manipulation
+
+local path = require("cosmo.path")
+
+global TEST_DIR: string
+
+-- add staged dir to package.path
+package.path = path.join(TEST_DIR, "?.lua") .. ";" .. package.path
+
+local record Parser
+  argument: function(self: Parser, name: string, desc: string): Parser
+  parse: function(self: Parser, args: {string}): {string: any}
+end
+
+local argparse = require("argparse") as function(name: string, desc: string): Parser
+
+local function test_create_parser()
+  local parser = argparse("test", "A test program")
+  assert(parser, "failed to create parser")
+end
+test_create_parser()
+
+local function test_parse_args()
+  local parser = argparse("test", "A test program")
+  parser:argument("input", "Input file")
+  local args = parser:parse({ "foo.txt" })
+  assert(args.input == "foo.txt", "expected 'foo.txt', got: " .. tostring(args.input))
+end
+test_parse_args()

--- a/3p/ast-grep/test_ast-grep.tl
+++ b/3p/ast-grep/test_ast-grep.tl
@@ -1,0 +1,42 @@
+#!/usr/bin/env run-test.lua
+
+local cosmo = require("cosmo")
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+global TEST_DIR: string
+global TEST_TMPDIR: string
+
+local bin = path.join(TEST_DIR, "bin", "sg")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "sg --version failed")
+  local want = "ast-grep"
+  assert((got as string):find(want, 1, true), "checking ast-grep, want: " .. want .. " got: " .. (got as string))
+end
+test_version()
+
+local function test_rule_main_guard()
+  local rule = ".ast-grep/rules/use-cosmo-is-main.yml"
+
+  -- debug.getlocal pattern should trigger
+  local bad1 = path.join(TEST_TMPDIR, "bad1.lua")
+  cosmo.Barf(bad1, 'if not pcall(debug.getlocal, 4, 1) then main() end')
+  local ok, out = spawn({ bin, "scan", "--rule", rule, bad1 }):read()
+  assert(not ok, "rule should trigger on debug.getlocal pattern")
+  assert((out as string):find("use%-cosmo%-is%-main"), "should report rule id")
+
+  -- arg[0]:match pattern should trigger
+  local bad2 = path.join(TEST_TMPDIR, "bad2.lua")
+  cosmo.Barf(bad2, 'if arg[0]:match("main.lua$") then main() end')
+  ok, out = spawn({ bin, "scan", "--rule", rule, bad2 }):read()
+  assert(not ok, "rule should trigger on arg[0]:match pattern")
+
+  -- good code should not trigger
+  local good = path.join(TEST_TMPDIR, "good.lua")
+  cosmo.Barf(good, 'if cosmo.is_main() then main() end')
+  ok, out = spawn({ bin, "scan", "--rule", rule, good }):read()
+  assert(ok, "rule should not trigger on good code: " .. tostring(out))
+end
+test_rule_main_guard()

--- a/3p/biome/test_biome.tl
+++ b/3p/biome/test_biome.tl
@@ -1,0 +1,16 @@
+#!/usr/bin/env run-test.lua
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+global TEST_DIR: string
+
+local bin = path.join(TEST_DIR, "bin", "biome")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "SKIP biome not executable on this platform")
+  local got_str = got as string
+  assert(got_str:match("Version:") or got_str:match("%d+%.%d+%.%d+"), "checking biome version, got: " .. got_str)
+end
+test_version()

--- a/3p/comrak/test_comrak.tl
+++ b/3p/comrak/test_comrak.tl
@@ -1,0 +1,16 @@
+#!/usr/bin/env run-test.lua
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+global TEST_DIR: string
+
+local bin = path.join(TEST_DIR, "bin", "comrak")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "SKIP comrak not executable on this platform")
+  local want = "comrak"
+  assert((got as string):find(want, 1, true), "checking comrak, want: " .. want .. " got: " .. (got as string))
+end
+test_version()

--- a/3p/cosmos/test_cosmos.tl
+++ b/3p/cosmos/test_cosmos.tl
@@ -1,0 +1,24 @@
+#!/usr/bin/env run-test.lua
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+global TEST_DIR: string
+
+local function test_lua()
+  local bin = path.join(TEST_DIR, "lua")
+  local ok, got = spawn({ bin, "-v" }):read()
+  assert(ok, "lua -v failed")
+  local want = "Lua"
+  assert((got as string):find(want, 1, true), "expected '" .. want .. "' in output, got: " .. (got as string))
+end
+test_lua()
+
+local function test_zip()
+  local bin = path.join(TEST_DIR, "zip")
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "zip --version failed")
+  local want = "Zip"
+  assert((got as string):find(want, 1, true), "expected '" .. want .. "' in output, got: " .. (got as string))
+end
+test_zip()

--- a/3p/delta/test_delta.tl
+++ b/3p/delta/test_delta.tl
@@ -1,0 +1,16 @@
+#!/usr/bin/env run-test.lua
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+global TEST_DIR: string
+
+local bin = path.join(TEST_DIR, "bin", "delta")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "delta --version failed")
+  local want = "delta"
+  assert((got as string):find(want, 1, true), "checking delta, want: " .. want .. " got: " .. (got as string))
+end
+test_version()

--- a/3p/duckdb/test_duckdb.tl
+++ b/3p/duckdb/test_duckdb.tl
@@ -1,0 +1,16 @@
+#!/usr/bin/env run-test.lua
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+global TEST_DIR: string
+
+local bin = path.join(TEST_DIR, "bin", "duckdb")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "duckdb --version failed")
+  local want = "v1."
+  assert((got as string):find(want, 1, true), "checking duckdb, want: " .. want .. " got: " .. (got as string))
+end
+test_version()

--- a/3p/gh/test_gh.tl
+++ b/3p/gh/test_gh.tl
@@ -1,0 +1,16 @@
+#!/usr/bin/env run-test.lua
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+global TEST_DIR: string
+
+local bin = path.join(TEST_DIR, "bin", "gh")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "gh --version failed")
+  local want = "gh version"
+  assert((got as string):find(want, 1, true), "checking gh, want: " .. want .. " got: " .. (got as string))
+end
+test_version()

--- a/3p/lua/test_release.tl
+++ b/3p/lua/test_release.tl
@@ -1,0 +1,43 @@
+--test:false
+-- test release artifact requirements
+local lu = require("luaunit")
+local unix = require("cosmo.unix")
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+global TEST_BIN_DIR: string
+
+local lua_bin = path.join(os.getenv("TEST_BIN_DIR") as string, "bin", "lua.dist")
+
+global function test_lua_binary_exists()
+  local st = unix.stat(lua_bin)
+  lu.assertNotNil(st, lua_bin .. " should exist")
+end
+
+global function test_lua_binary_runs()
+  local handle = spawn({lua_bin, "-e", "print('hello')"})
+  local ok, output, exit_code = handle:read()
+  lu.assertTrue(ok, "lua should run successfully: exit=" .. tostring(exit_code))
+  lu.assertStrContains(output or "", "hello")
+end
+
+global function test_lua_binary_has_bundled_modules()
+  -- test that key modules can be required
+  -- the test runner unveils things so LUA_PATH from env won't interfere
+  local test_modules: {string} = {
+    "argparse",
+    "luacheck",
+    "luaunit",
+    "lfs",
+    "spawn",
+    "version",
+    "platform",
+  }
+
+  for _, mod in ipairs(test_modules) do
+    local script = string.format("require('%s')", mod)
+    local handle = spawn({lua_bin, "-e", script})
+    local _, output, exit_code = handle:read()
+    lu.assertEquals(exit_code, 0, "should require " .. mod .. ": " .. (output or ""))
+  end
+end

--- a/3p/luacheck/test_luacheck.tl
+++ b/3p/luacheck/test_luacheck.tl
@@ -1,0 +1,44 @@
+#!/usr/bin/env run-test.lua
+-- ast-grep ignore: test file needs package.path manipulation
+
+local path = require("cosmo.path")
+
+global TEST_DIR: string
+
+-- add staged src to package.path
+package.path = path.join(TEST_DIR, "src", "?.lua") .. ";"
+  .. path.join(TEST_DIR, "src", "?", "init.lua") .. ";"
+  .. package.path
+
+local record LuacheckReport
+  {LuacheckWarning}
+end
+
+local record LuacheckWarning
+  code: string
+  line: integer
+  column: integer
+  end_column: integer
+  message: string
+end
+
+local record Luacheck
+  check_strings: function(strings: {string}): {LuacheckReport}
+end
+
+local luacheck = require("luacheck") as Luacheck
+
+local function test_load_library()
+  assert(luacheck, "failed to load luacheck")
+  assert(type(luacheck.check_strings) == "function", "expected check_strings function")
+end
+test_load_library()
+
+local function test_check_string()
+  local reports = luacheck.check_strings({"local x = 1"})
+  assert(#reports == 1, "expected one report")
+  -- reports[1] is an array of warnings/errors
+  assert(type(reports[1]) == "table", "expected table")
+  assert(#reports[1] >= 1, "expected at least one warning for unused variable")
+end
+test_check_string()

--- a/3p/luaunit/test_luaunit.tl
+++ b/3p/luaunit/test_luaunit.tl
@@ -1,0 +1,7 @@
+#!/usr/bin/env run-test.lua
+-- ast-grep ignore: test file needs package.path manipulation
+
+global TEST_DIR: string
+
+package.path = TEST_DIR .. "/?.lua;" .. package.path
+assert(require("luaunit"))

--- a/3p/marksman/test_marksman.tl
+++ b/3p/marksman/test_marksman.tl
@@ -1,0 +1,16 @@
+#!/usr/bin/env run-test.lua
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+global TEST_DIR: string
+
+local bin = path.join(TEST_DIR, "bin", "marksman")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "SKIP marksman not executable on this platform")
+  -- version output is just version number like "1.0.0-8299f11+..."
+  assert((got as string):match("%d+%.%d+%.%d+"), "checking marksman version, got: " .. (got as string))
+end
+test_version()

--- a/3p/nvim/test_nvim.tl
+++ b/3p/nvim/test_nvim.tl
@@ -1,0 +1,16 @@
+#!/usr/bin/env run-test.lua
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+global TEST_DIR: string
+
+local bin = path.join(TEST_DIR, "bin", "nvim")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "nvim --version failed")
+  local want = "NVIM"
+  assert((got as string):find(want, 1, true), "checking nvim, want: " .. want .. " got: " .. (got as string))
+end
+test_version()

--- a/3p/nvim/test_packpath.tl
+++ b/3p/nvim/test_packpath.tl
@@ -1,0 +1,72 @@
+#!/usr/bin/env run-test.lua
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+
+global TEST_DIR: string
+global TEST_TMPDIR: string
+
+local bin = path.join(TEST_DIR, "bin", "nvim")
+local bundled_site = path.join(TEST_DIR, "share", "nvim", "site")
+
+-- test: bundled plugins exist
+local function test_bundled_plugins_exist()
+  local plugins: {string} = { "mini.nvim", "nvim-lspconfig", "conform.nvim", "nvim-treesitter" }
+  for _, plugin in ipairs(plugins) do
+    local plugin_path = path.join(bundled_site, "pack", "core", "opt", plugin)
+    assert(unix.stat(plugin_path), "bundled " .. plugin .. " should exist at: " .. plugin_path)
+  end
+end
+test_bundled_plugins_exist()
+
+-- test: bundled plugins load via packadd
+local function test_bundled_plugins_load()
+  local test_init = path.join(TEST_TMPDIR, "init.lua")
+  local f = io.open(test_init, "w")
+  if not f then
+    error("failed to open " .. test_init)
+  end
+  f:write([[
+local version_dir = vim.fn.fnamemodify(vim.v.progpath, ":h:h")
+local bundled_site = version_dir .. "/share/nvim/site"
+vim.opt.packpath:prepend(bundled_site)
+
+-- load bundled plugins
+vim.cmd.packadd('mini.nvim')
+vim.cmd.packadd('nvim-lspconfig')
+vim.cmd.packadd('conform.nvim')
+vim.cmd.packadd('nvim-treesitter')
+
+-- verify plugins loaded
+local results = {}
+results.mini = pcall(require, 'mini.bufremove')
+results.lspconfig = pcall(require, 'lspconfig')
+results.conform = pcall(require, 'conform')
+results.treesitter = pcall(require, 'nvim-treesitter')
+
+local result_file = io.open(vim.env.TEST_RESULT_FILE, "w")
+for name, ok in pairs(results) do
+  result_file:write(name .. "=" .. tostring(ok) .. "\n")
+end
+result_file:close()
+]])
+  f:close()
+
+  local result_file = path.join(TEST_TMPDIR, "result.txt")
+  local env = unix.environ()
+  table.insert(env, "TEST_RESULT_FILE=" .. result_file)
+  local ok = spawn({ bin, "--headless", "-u", test_init, "+qa" }, { env = env }):wait()
+  assert(ok, "nvim failed to run")
+
+  local result = io.open(result_file, "r")
+  assert(result, "result file not created")
+  local content = result:read("*a")
+  result:close()
+
+  local expected: {string} = { "mini", "lspconfig", "conform", "treesitter" }
+  for _, name in ipairs(expected) do
+    assert(content:find(name .. "=true"), name .. " plugin should load. Result:\n" .. content)
+  end
+end
+test_bundled_plugins_load()

--- a/3p/nvim/test_treesitter.tl
+++ b/3p/nvim/test_treesitter.tl
@@ -1,0 +1,57 @@
+#!/usr/bin/env run-test.lua
+
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+
+global TEST_DIR: string
+
+-- debug: show TEST_DIR value
+io.stderr:write(string.format("test_treesitter: TEST_DIR=%s\n", tostring(TEST_DIR)))
+
+local site_dir = path.join(TEST_DIR, "share", "nvim", "site")
+local pack_dir = path.join(site_dir, "pack", "core", "opt")
+
+local function test_plugins_installed()
+  local expected: {string} = {"conform.nvim", "mini.nvim", "nvim-lspconfig", "nvim-treesitter"}
+  for _, name in ipairs(expected) do
+    local plugin_dir = path.join(pack_dir, name)
+    local st = unix.stat(plugin_dir)
+    assert(st, "plugin not found: " .. name)
+  end
+end
+test_plugins_installed()
+
+local function test_nvim_treesitter_has_init()
+  local init_lua = path.join(pack_dir, "nvim-treesitter", "lua", "nvim-treesitter", "init.lua")
+  local st = unix.stat(init_lua)
+  assert(st, "nvim-treesitter init.lua not found")
+end
+test_nvim_treesitter_has_init()
+
+local function test_parsers_installed()
+  local parser_dir = path.join(site_dir, "parser")
+  local st = unix.stat(parser_dir)
+  assert(st, "parser directory not found")
+
+  -- check a subset of parsers from .config/nvim/parsers.lua
+  local expected: {string} = {"lua", "python", "bash", "json"}
+  for _, name in ipairs(expected) do
+    local parser = path.join(parser_dir, name .. ".so")
+    st = unix.stat(parser)
+    assert(st, name .. ".so parser not found")
+  end
+end
+test_parsers_installed()
+
+local function test_helptags_generated()
+  local doc_dir = path.join(pack_dir, "nvim-treesitter", "doc")
+  local st = unix.stat(doc_dir)
+  if not st then
+    -- doc dir may not exist for all plugins
+    return
+  end
+  local tags = path.join(doc_dir, "tags")
+  st = unix.stat(tags)
+  -- helptags are optional, just check doc dir exists
+end
+test_helptags_generated()

--- a/3p/rg/test_rg.tl
+++ b/3p/rg/test_rg.tl
@@ -1,0 +1,16 @@
+#!/usr/bin/env run-test.lua
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+global TEST_DIR: string
+
+local bin = path.join(TEST_DIR, "rg")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "rg --version failed")
+  local want = "ripgrep"
+  assert((got as string):find(want, 1, true), "checking ripgrep, want: " .. want .. " got: " .. (got as string))
+end
+test_version()

--- a/3p/ruff/test_ruff.tl
+++ b/3p/ruff/test_ruff.tl
@@ -1,0 +1,16 @@
+#!/usr/bin/env run-test.lua
+
+global TEST_DIR: string
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+local bin: string = path.join(TEST_DIR, "bin", "ruff")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "ruff --version failed")
+  local want = "ruff"
+  assert((got as string):find(want, 1, true), "checking ruff, want: " .. want .. " got: " .. (got as string))
+end
+test_version()

--- a/3p/shfmt/test_shfmt.tl
+++ b/3p/shfmt/test_shfmt.tl
@@ -1,0 +1,16 @@
+#!/usr/bin/env run-test.lua
+
+global TEST_DIR: string
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+local bin: string = path.join(TEST_DIR, "bin", "shfmt")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "shfmt --version failed")
+  local want = "v3"
+  assert((got as string):find(want, 1, true), "checking shfmt, want: " .. want .. " got: " .. (got as string))
+end
+test_version()

--- a/3p/sqruff/test_sqruff.tl
+++ b/3p/sqruff/test_sqruff.tl
@@ -1,0 +1,16 @@
+#!/usr/bin/env run-test.lua
+
+global TEST_DIR: string
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+local bin: string = path.join(TEST_DIR, "sqruff")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "sqruff --version failed")
+  local want = "sqruff"
+  assert((got as string):find(want, 1, true), "checking sqruff, want: " .. want .. " got: " .. (got as string))
+end
+test_version()

--- a/3p/stylua/test_stylua.tl
+++ b/3p/stylua/test_stylua.tl
@@ -1,0 +1,16 @@
+#!/usr/bin/env run-test.lua
+
+global TEST_DIR: string
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+local bin: string = path.join(TEST_DIR, "stylua")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "stylua --version failed")
+  local want = "stylua"
+  assert((got as string):find(want, 1, true), "checking stylua, want: " .. want .. " got: " .. (got as string))
+end
+test_version()

--- a/3p/superhtml/test_superhtml.tl
+++ b/3p/superhtml/test_superhtml.tl
@@ -1,0 +1,14 @@
+#!/usr/bin/env run-test.lua
+
+global TEST_DIR: string
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+local bin: string = path.join(TEST_DIR, "superhtml")
+
+local function test_version()
+  local exit_code: number = spawn({ bin, "version" }):wait()
+  assert(exit_code == 0, "superhtml version failed with exit code: " .. tostring(exit_code))
+end
+test_version()

--- a/3p/tree-sitter/test_tree-sitter.tl
+++ b/3p/tree-sitter/test_tree-sitter.tl
@@ -1,0 +1,16 @@
+#!/usr/bin/env run-test.lua
+
+global TEST_DIR: string
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+local bin: string = path.join(TEST_DIR, "bin", "tree-sitter")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "tree-sitter --version failed")
+  local want = "tree-sitter"
+  assert((got as string):find(want, 1, true), "checking tree-sitter, want: " .. want .. " got: " .. (got as string))
+end
+test_version()

--- a/3p/uv/test_uv.tl
+++ b/3p/uv/test_uv.tl
@@ -1,0 +1,16 @@
+#!/usr/bin/env run-test.lua
+
+global TEST_DIR: string
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+local bin: string = path.join(TEST_DIR, "uv")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "uv --version failed")
+  local want = "uv"
+  assert((got as string):find(want, 1, true), "checking uv, want: " .. want .. " got: " .. (got as string))
+end
+test_version()

--- a/lib/build/test_help.tl
+++ b/lib/build/test_help.tl
@@ -1,0 +1,154 @@
+#!/usr/bin/env run-test.lua
+-- Test the Makefile help system
+
+local cosmo = require("cosmo")
+local help = require("build.make-help")
+
+local record HelpItem
+  type: string
+  name: string
+  description: string
+end
+
+local function test_parse_multiline_comment()
+  local content = [[
+## Run all tests
+.PHONY: test
+test:
+	@echo "testing"
+
+## Remove build artifacts
+.PHONY: clean
+clean:
+	@rm -rf o
+]]
+
+  local items = help.parse_makefile(content) as {HelpItem}
+  assert(#items == 2, "expected 2 items")
+  assert(items[1].type == "target", "expected target type")
+  assert(items[1].name == "test", "expected test target")
+  assert(items[1].description == "Run all tests", "expected test description")
+  assert(items[2].type == "target", "expected target type")
+  assert(items[2].name == "clean", "expected clean target")
+  assert(items[2].description == "Remove build artifacts", "expected clean description")
+end
+test_parse_multiline_comment()
+
+local function test_parse_multiline_continued()
+  local content = [[
+## Run all tests
+## with coverage enabled
+.PHONY: test
+test:
+	@echo "testing"
+]]
+
+  local items = help.parse_makefile(content) as {HelpItem}
+  assert(#items == 1, "expected 1 item")
+  assert(items[1].type == "target", "expected target type")
+  assert(items[1].name == "test", "expected test target")
+  assert(items[1].description == "Run all tests with coverage enabled", "expected combined description")
+end
+test_parse_multiline_continued()
+
+local function test_undocumented_targets_ignored()
+  local content = [[
+## This target is documented
+.PHONY: documented
+documented:
+	@echo "documented"
+
+.PHONY: undocumented
+undocumented:
+	@echo "undocumented"
+]]
+
+  local items = help.parse_makefile(content) as {HelpItem}
+  assert(#items == 1, "expected 1 item")
+  assert(items[1].type == "target", "expected target type")
+  assert(items[1].name == "documented", "expected documented target")
+end
+test_undocumented_targets_ignored()
+
+local function test_parse_variables()
+  local content = [[
+## Filter targets by pattern
+filter-only = $(if $(only),$(foreach f,$1,$(if $(findstring $(only),$(f)),$(f))),$1)
+
+## Set output directory
+o := output
+]]
+
+  local items = help.parse_makefile(content) as {HelpItem}
+  assert(#items == 2, "expected 2 items")
+  assert(items[1].type == "option", "expected option type")
+  assert(items[1].name == "filter-only", "expected filter-only option")
+  assert(items[1].description == "Filter targets by pattern", "expected filter description")
+  assert(items[2].type == "option", "expected option type")
+  assert(items[2].name == "o", "expected o option")
+end
+test_parse_variables()
+
+local function test_format_help()
+  local items: {HelpItem} = {
+    { type = "target", name = "test", description = "Run all tests" },
+    { type = "target", name = "clean", description = "Remove build artifacts" },
+    { type = "option", name = "only", description = "Filter by pattern" },
+  }
+
+  local output = help.format_help(items)
+  assert(output:find("Usage:"), "expected usage line")
+  assert(output:find("Targets:"), "expected targets header")
+  assert(output:find("test"), "expected test target")
+  assert(output:find("clean"), "expected clean target")
+  assert(output:find("Options:"), "expected options header")
+  assert(output:find("only"), "expected only option")
+end
+test_format_help()
+
+local function test_parse_phony_targets()
+  local content = [[
+.PHONY: test clean
+test:
+	@echo "testing"
+
+.PHONY: build
+build:
+	@echo "building"
+]]
+
+  local targets = help.parse_phony_targets(content) as {string:boolean}
+  assert(targets["test"], "expected test target")
+  assert(targets["clean"], "expected clean target")
+  assert(targets["build"], "expected build target")
+  assert(not targets["foo"], "unexpected foo target")
+end
+test_parse_phony_targets()
+
+local function test_all_phony_targets_documented()
+  local content, err = cosmo.Slurp("Makefile")
+  assert(content, err or "failed to read Makefile")
+
+  local phony = help.parse_phony_targets(content) as {string:boolean}
+  local items = help.parse_makefile(content) as {HelpItem}
+
+  local documented: {string:boolean} = {}
+  for _, item in ipairs(items) do
+    if item.type == "target" then
+      documented[item.name] = true
+    end
+  end
+
+  local missing: {string} = {}
+  for target in pairs(phony) do
+    if not documented[target] then
+      table.insert(missing, target)
+    end
+  end
+
+  if #missing > 0 then
+    table.sort(missing)
+    error("phony targets missing documentation: " .. table.concat(missing, ", "))
+  end
+end
+test_all_phony_targets_documented()

--- a/lib/build/test_reporter.tl
+++ b/lib/build/test_reporter.tl
@@ -1,0 +1,193 @@
+#!/usr/bin/env run-test.lua
+
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+local cosmo = require("cosmo")
+
+local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
+
+local function write_result_file(filepath: string, status: string, message: string, stdout: string, stderr: string)
+  local content = status
+  if message then
+    content = content .. ": " .. message
+  end
+  content = content .. "\n\n## stdout\n"
+  if stdout then
+    content = content .. stdout
+  end
+  content = content .. "\n\n## stderr\n"
+  if stderr then
+    content = content .. stderr
+  end
+  local dir = path.dirname(filepath)
+  if dir and dir ~= "" and dir ~= "." then
+    unix.makedirs(dir)
+  end
+  cosmo.Barf(filepath, content)
+end
+
+local record SpawnHandle
+  stderr: FILE
+  read: function(self: SpawnHandle): boolean, string, integer
+end
+
+local function run_reporter(...: string): integer, string, string
+  local test_bin = os.getenv("TEST_BIN") or ""
+  local reporter = path.join(test_bin, "reporter.lua")
+  local spawn = require("cosmic.spawn").spawn
+  local args: {string} = {path.join(test_bin, "cosmic"), "--", reporter}
+  local varargs: {string} = {...}
+  for _, arg in ipairs(varargs) do
+    table.insert(args, arg)
+  end
+
+  local lua_path = os.getenv("LUA_PATH") or ""
+  local new_lua_path = "o/lib/?.lua;o/lib/?/init.lua;;" .. lua_path
+  unix.setenv("LUA_PATH", new_lua_path, true)
+
+  local handle = spawn(args) as SpawnHandle
+  local stderr_content = handle.stderr and handle.stderr:read("*a") or ""
+  local ok, stdout, exit_code = handle:read()
+  return exit_code, stdout or "", stderr_content
+end
+
+-- test single checker mode (test)
+local function test_single_checker_mode()
+  local test_dir = path.join(tmpdir, "single-checker")
+  unix.makedirs(test_dir)
+
+  write_result_file(path.join(test_dir, "test1.test.ok"), "pass", nil, "", "")
+  write_result_file(path.join(test_dir, "test2.test.ok"), "fail", "assertion failed", "", "expected true")
+
+  local code, stdout, stderr = run_reporter(
+    "--dir", test_dir,
+    path.join(test_dir, "test1.test.ok"),
+    path.join(test_dir, "test2.test.ok")
+  )
+
+  assert(code == 1, "expected exit code 1 for failures, got: " .. tostring(code))
+  assert(stdout:match("PASS"), "expected PASS in output")
+  assert(stdout:match("FAIL"), "expected FAIL in output")
+  assert(stdout:match("test: 2 checks: 1 passed, 1 failed"), "expected test summary")
+  assert(stdout:match("FAILURES"), "expected failures section")
+end
+test_single_checker_mode()
+
+-- test multi-checker mode (check)
+local function test_multi_checker_mode()
+  local test_dir = path.join(tmpdir, "multi-checker")
+  unix.makedirs(test_dir)
+
+  write_result_file(path.join(test_dir, "file1.ast-grep.ok"), "pass", nil, "", "")
+  write_result_file(path.join(test_dir, "file1.luacheck.ok"), "pass", nil, "", "")
+  write_result_file(path.join(test_dir, "file2.teal.ok"), "fail", "type error", "", "Expected string")
+
+  local code, stdout, stderr = run_reporter(
+    "--dir", test_dir,
+    path.join(test_dir, "file1.ast-grep.ok"),
+    path.join(test_dir, "file1.luacheck.ok"),
+    path.join(test_dir, "file2.teal.ok")
+  )
+
+  assert(code == 1, "expected exit code 1 for failures")
+  assert(stdout:match("ast%-grep: 1 checks"), "expected ast-grep summary")
+  assert(stdout:match("luacheck: 1 checks"), "expected luacheck summary")
+  assert(stdout:match("teal: 1 checks"), "expected teal summary")
+  assert(stdout:match("total: 3 checks: 2 passed, 1 failed"), "expected total summary")
+end
+test_multi_checker_mode()
+
+-- test update mode custom summary
+local function test_update_mode_summary()
+  local test_dir = path.join(tmpdir, "update-mode")
+  unix.makedirs(test_dir)
+
+  write_result_file(path.join(test_dir, "v1.update.ok"), "pass", "1.0.0", "", "")
+  write_result_file(path.join(test_dir, "v2.update.ok"), "skip", "1.0.0 -> 2.0.0", "", "")
+
+  local code, stdout, stderr = run_reporter(
+    "--dir", test_dir,
+    path.join(test_dir, "v1.update.ok"),
+    path.join(test_dir, "v2.update.ok")
+  )
+
+  assert(code == 0, "expected exit code 0 for updates")
+  assert(stdout:match("update: 2 checks: 1 passed, 0 failed, 1 skipped"), "expected update summary format")
+  assert(stdout:match("SKIP.*1%.0%.0 %-> 2%.0%.0"), "expected skip with version info")
+end
+test_update_mode_summary()
+
+-- test directory stripping
+local function test_directory_stripping()
+  local test_dir = path.join(tmpdir, "dir-strip")
+  unix.makedirs(test_dir)
+
+  write_result_file(path.join(test_dir, "subdir", "file.test.ok"), "pass", nil, "", "")
+
+  local code, stdout, stderr = run_reporter(
+    "--dir", test_dir,
+    path.join(test_dir, "subdir", "file.test.ok")
+  )
+
+  assert(code == 0, "expected exit code 0")
+  assert(stdout:match("subdir/file"), "expected directory to be stripped")
+  assert(not stdout:match(test_dir), "expected tmpdir not in output")
+end
+test_directory_stripping()
+
+-- test skip and ignore statuses
+local function test_skip_and_ignore()
+  local test_dir = path.join(tmpdir, "skip-ignore")
+  unix.makedirs(test_dir)
+
+  write_result_file(path.join(test_dir, "t1.test.ok"), "pass", nil, "", "")
+  write_result_file(path.join(test_dir, "t2.test.ok"), "skip", "not implemented", "", "")
+  write_result_file(path.join(test_dir, "t3.test.ok"), "ignore", "unsupported", "", "")
+
+  local code, stdout, stderr = run_reporter(
+    "--dir", test_dir,
+    path.join(test_dir, "t1.test.ok"),
+    path.join(test_dir, "t2.test.ok"),
+    path.join(test_dir, "t3.test.ok")
+  )
+
+  assert(code == 0, "expected exit code 0")
+  assert(stdout:match("test: 3 checks: 1 passed, 0 failed, 1 skipped, 1 ignored"), "expected correct counts")
+  assert(not stdout:match("FAILURES"), "expected no failures section")
+end
+test_skip_and_ignore()
+
+-- test missing --dir flag
+local function test_missing_dir_flag()
+  local code, stdout, stderr = run_reporter("file.test.ok")
+
+  assert(code == 1, "expected exit code 1")
+  assert(stderr:match("%-%-dir is required"), "expected error about --dir")
+end
+test_missing_dir_flag()
+
+-- test no files specified
+local function test_no_files()
+  local code, stdout, stderr = run_reporter("--dir", tmpdir)
+
+  assert(code == 1, "expected exit code 1")
+  assert(stderr:match("usage:"), "expected usage error")
+end
+test_no_files()
+
+-- test auto-detection of checker types
+local function test_checker_auto_detection()
+  local test_dir = path.join(tmpdir, "auto-detect")
+  unix.makedirs(test_dir)
+
+  write_result_file(path.join(test_dir, "file.custom-checker.ok"), "pass", nil, "", "")
+
+  local code, stdout, stderr = run_reporter(
+    "--dir", test_dir,
+    path.join(test_dir, "file.custom-checker.ok")
+  )
+
+  assert(code == 0, "expected exit code 0")
+  assert(stdout:match("custom%-checker: 1 checks"), "expected custom checker to be auto-detected")
+end
+test_checker_auto_detection()

--- a/lib/checker/test_common.tl
+++ b/lib/checker/test_common.tl
@@ -1,0 +1,240 @@
+#!/usr/bin/env run-test.lua
+
+local common = require("checker.common")
+local path = require("cosmo.path")
+local cosmo = require("cosmo")
+
+local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+
+local record CheckResult
+  status: string
+  message: string
+  stdout: string
+  stderr: string
+end
+
+local record StatusIcons
+  pass: string
+  fail: string
+  skip: string
+  ignore: string
+end
+
+local record CategorizedResults
+  pass: {CheckResult}
+  fail: {CheckResult}
+  skip: {CheckResult}
+  ignore: {CheckResult}
+end
+
+local function test_format_output()
+  local output = common.format_output("pass", nil, "", "")
+  assert(output:match("^pass\n"), "should format status without message")
+  assert(output:match("## stdout"), "should include stdout section")
+  assert(output:match("## stderr"), "should include stderr section")
+
+  local output2 = common.format_output("fail", "3 issues", "", "error details")
+  assert(output2:match("^fail: 3 issues"), "should format status with message")
+  assert(output2:match("## stderr\n\nerror details"), "should include stderr content")
+end
+test_format_output()
+
+local function test_parse_result()
+  local content = [[pass
+
+## stdout
+
+test output
+## stderr
+
+]]
+  local result = common.parse_result(content) as CheckResult
+  assert(result.status == "pass", "should parse status")
+  assert(result.message == nil, "should parse nil message")
+  assert(result.stdout == "test output", "should parse stdout")
+  assert(result.stderr == "", "should parse empty stderr")
+
+  local content2 = [[fail: 2 issues
+
+## stdout
+
+
+## stderr
+
+file.lua:10:5: error message]]
+  local result2 = common.parse_result(content2) as CheckResult
+  assert(result2.status == "fail", "should parse fail status")
+  assert(result2.message == "2 issues", "should parse message")
+  assert(result2.stderr:match("error message"), "should parse stderr")
+end
+test_parse_result()
+
+local function test_strip_prefix()
+  local real_getenv = os.getenv
+
+  -- test with "o" prefix
+  os.getenv = function(name: string): string
+    if name == "TEST_O" then return "o" end
+    return real_getenv(name)
+  end
+
+  local result = common.strip_prefix("o/lib/test.lua")
+  assert(result == "lib/test.lua", "should strip o/ prefix")
+
+  local result2 = common.strip_prefix("lib/test.lua")
+  assert(result2 == "lib/test.lua", "should not strip if no prefix match")
+
+  -- test with custom prefix to confirm no hardcoded o/
+  os.getenv = function(name: string): string
+    if name == "TEST_O" then return "custom_output" end
+    return real_getenv(name)
+  end
+
+  local result4 = common.strip_prefix("custom_output/lib/test.lua")
+  assert(result4 == "lib/test.lua", "should strip custom_output/ prefix")
+
+  local result5 = common.strip_prefix("o/lib/test.lua")
+  assert(result5 == "o/lib/test.lua", "should not strip o/ when TEST_O is custom_output")
+
+  -- test with nil TEST_O
+  os.getenv = function(name: string): string
+    if name == "TEST_O" then return nil end
+    return real_getenv(name)
+  end
+
+  local result3 = common.strip_prefix("o/lib/test.lua")
+  assert(result3 == "o/lib/test.lua", "should not strip if TEST_O not set")
+
+  os.getenv = real_getenv
+end
+test_strip_prefix()
+
+local function test_status_icons()
+  local icons = common.status_icons() as StatusIcons
+  assert(icons.pass == "\226\156\147", "should have pass icon")
+  assert(icons.fail == "\226\156\151", "should have fail icon")
+  assert(icons.skip == "\226\134\146", "should have skip icon")
+  assert(icons.ignore == "\226\151\139", "should have ignore icon")
+end
+test_status_icons()
+
+local function test_has_extension()
+  local extensions: {string:boolean} = { [".lua"] = true, [".tl"] = true }
+  assert(common.has_extension("test.lua", extensions), "should match .lua extension")
+  assert(common.has_extension("test.tl", extensions), "should match .tl extension")
+  assert(not common.has_extension("test.py", extensions), "should not match .py extension")
+  assert(not common.has_extension("test", extensions), "should not match no extension")
+end
+test_has_extension()
+
+local function test_check_first_lines()
+  local test_file = path.join(TEST_TMPDIR, "test.lua")
+
+  cosmo.Barf(test_file, [[#!/usr/bin/env lua
+-- some comment
+-- checker ignore: test reason
+local x = 1
+]])
+
+  local has_shebang, skip_reason = common.check_first_lines(test_file, {
+    shebangs = { lua = true },
+    ignore = "checker%s+ignore%s*:?%s*(.*)"
+  })
+  assert(has_shebang == true, "should detect shebang")
+  assert(skip_reason == "test reason", "should detect skip reason")
+
+  local test_file2 = path.join(TEST_TMPDIR, "test2.lua")
+  cosmo.Barf(test_file2, [[-- regular file
+local x = 1
+]])
+
+  local has_shebang2, skip_reason2 = common.check_first_lines(test_file2, {
+    shebangs = { lua = true },
+    ignore = "checker%s+ignore%s*:?%s*(.*)"
+  })
+  assert(has_shebang2 == false, "should not detect shebang")
+  assert(skip_reason2 == nil, "should not detect skip reason")
+
+  local test_file3 = path.join(TEST_TMPDIR, "test3.lua")
+  cosmo.Barf(test_file3, [[#!/usr/bin/env lua
+-- checker ignore
+local x = 1
+]])
+
+  local has_shebang3, skip_reason3 = common.check_first_lines(test_file3, {
+    shebangs = { lua = true },
+    ignore = "checker%s+ignore%s*:?%s*(.*)"
+  })
+  assert(has_shebang3 == true, "should detect shebang")
+  assert(skip_reason3 == "directive", "should use default skip reason")
+end
+test_check_first_lines()
+
+local function test_categorize_results()
+  local results_list: {CheckResult} = {
+    { status = "pass", name = "test1" } as CheckResult,
+    { status = "fail", name = "test2" } as CheckResult,
+    { status = "pass", name = "test3" } as CheckResult,
+    { status = "skip", name = "test4" } as CheckResult,
+    { status = "ignore", name = "test5" } as CheckResult,
+  }
+
+  local results = common.categorize_results(results_list) as CategorizedResults
+  assert(#results.pass == 2, "should categorize pass results")
+  assert(#results.fail == 1, "should categorize fail results")
+  assert(#results.skip == 1, "should categorize skip results")
+  assert(#results.ignore == 1, "should categorize ignore results")
+end
+test_categorize_results()
+
+local function test_format_results()
+  local icons = common.status_icons() as StatusIcons
+  local results: {CheckResult} = {
+    { status = "pass", name = "test1" } as CheckResult,
+    { status = "fail", name = "test2", message = "error", checker = "luacheck" } as CheckResult,
+  }
+
+  local output = common.format_results(results, icons)
+  assert(output:match("PASS%s+test1"), "should format pass result")
+  assert(output:match("FAIL%s+luacheck%s+test2 %(error%)"), "should format fail result with checker")
+end
+test_format_results()
+
+local function test_format_summary()
+  local results: CategorizedResults = {
+    pass = {{} as CheckResult, {} as CheckResult},
+    fail = {{} as CheckResult},
+    skip = {},
+    ignore = {{} as CheckResult},
+  }
+
+  local output = common.format_summary("test-checker", results)
+  assert(output:match("test%-checker: 4 checks"), "should include checker name and total")
+  assert(output:match("2 passed"), "should include pass count")
+  assert(output:match("1 failed"), "should include fail count")
+  assert(output:match("0 skipped"), "should include skip count")
+  assert(output:match("1 ignored"), "should include ignore count")
+
+  local empty_output = common.format_summary("empty", { pass = {}, fail = {}, skip = {}, ignore = {} })
+  assert(empty_output == "", "should return empty string for no results")
+end
+test_format_summary()
+
+local function test_format_failures()
+  local results: {CheckResult} = {
+    { status = "pass", name = "test1" } as CheckResult,
+    { status = "fail", name = "test2", message = "error msg", stderr = "details" } as CheckResult,
+    { status = "fail", name = "test3", checker = "teal", message = "type error" } as CheckResult,
+  }
+
+  local output = common.format_failures(results)
+  assert(output:match("FAILURES:"), "should include failures header")
+  assert(output:match("test2"), "should include failed test name")
+  assert(output:match("error msg"), "should include message")
+  assert(output:match("details"), "should include stderr")
+  assert(output:match("test3 %(teal%)"), "should include checker name")
+
+  local no_failures = common.format_failures({ { status = "pass", name = "test1" } as CheckResult })
+  assert(no_failures == nil, "should return nil for no failures")
+end
+test_format_failures()

--- a/lib/cosmic/test_args.tl
+++ b/lib/cosmic/test_args.tl
@@ -1,0 +1,201 @@
+#!/usr/bin/env run-test.lua
+-- test cosmic script argument passing (varargs and arg table)
+
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
+local spawn = require("cosmic.spawn")
+local cosmo = require("cosmo")
+
+local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local tmpdir = os.getenv("TEST_TMPDIR")
+
+-- Test script that uses only varargs (...)
+local function test_varargs_only()
+  local script = path.join(tmpdir, "varargs.lua")
+  cosmo.Barf(script, [[
+local args = {...}
+print("varargs_count=" .. #args)
+for i, v in ipairs(args) do
+  print("vararg[" .. i .. "]=" .. tostring(v))
+end
+]])
+
+  local ok, out = spawn({cosmic, script, "foo", "bar", "baz"}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("varargs_count=3"), "should have 3 varargs")
+  assert((out as string):find("vararg%[1%]=foo"), "vararg[1] should be foo")
+  assert((out as string):find("vararg%[2%]=bar"), "vararg[2] should be bar")
+  assert((out as string):find("vararg%[3%]=baz"), "vararg[3] should be baz")
+end
+test_varargs_only()
+
+-- Test script that uses only global arg table
+local function test_arg_table_only()
+  local script = path.join(tmpdir, "argtable.lua")
+  cosmo.Barf(script, [[
+print("arg_count=" .. #arg)
+print("arg[0]=" .. tostring(arg[0]))
+for i = 1, #arg do
+  print("arg[" .. i .. "]=" .. tostring(arg[i]))
+end
+]])
+
+  local ok, out = spawn({cosmic, script, "alpha", "beta"}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("arg_count=2"), "should have 2 args")
+  assert((out as string):find("arg%[0%]=" .. script:gsub("[%-%.]", "%%%1")), "arg[0] should be script path")
+  assert((out as string):find("arg%[1%]=alpha"), "arg[1] should be alpha")
+  assert((out as string):find("arg%[2%]=beta"), "arg[2] should be beta")
+end
+test_arg_table_only()
+
+-- Test that both varargs and arg table work together and match
+local function test_varargs_and_arg_table()
+  local script = path.join(tmpdir, "both.lua")
+  cosmo.Barf(script, [[
+local varargs = {...}
+print("varargs_count=" .. #varargs)
+print("arg_count=" .. #arg)
+print("match=" .. tostring(#varargs == #arg))
+for i = 1, #arg do
+  print("match[" .. i .. "]=" .. tostring(arg[i] == varargs[i]))
+end
+]])
+
+  local ok, out = spawn({cosmic, script, "x", "y", "z"}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("varargs_count=3"), "varargs should have 3 elements")
+  assert((out as string):find("arg_count=3"), "arg should have 3 elements")
+  assert((out as string):find("match=true"), "varargs and arg counts should match")
+  assert((out as string):find("match%[1%]=true"), "arg[1] should match varargs[1]")
+  assert((out as string):find("match%[2%]=true"), "arg[2] should match varargs[2]")
+  assert((out as string):find("match%[3%]=true"), "arg[3] should match varargs[3]")
+end
+test_varargs_and_arg_table()
+
+-- Test the common pattern: function main(...) os.exit(main(...))
+local function test_main_function_with_varargs()
+  local script = path.join(tmpdir, "main_varargs.lua")
+  cosmo.Barf(script, [[
+local function main(...)
+  local args = {...}
+  print("main_varargs_count=" .. #args)
+  for i, v in ipairs(args) do
+    print("main_arg[" .. i .. "]=" .. tostring(v))
+  end
+  return 0
+end
+
+os.exit(main(...))
+]])
+
+  local ok, out = spawn({cosmic, script, "one", "two"}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("main_varargs_count=2"), "main should receive 2 varargs")
+  assert((out as string):find("main_arg%[1%]=one"), "main_arg[1] should be one")
+  assert((out as string):find("main_arg%[2%]=two"), "main_arg[2] should be two")
+end
+test_main_function_with_varargs()
+
+-- Test function main(param) with single optional parameter
+local function test_main_function_with_single_param()
+  local script = path.join(tmpdir, "main_param.lua")
+  cosmo.Barf(script, [[
+local function main(dir)
+  dir = dir or "default"
+  print("param=" .. dir)
+  return 0
+end
+
+os.exit(main(...))
+]])
+
+  -- Test with argument
+  local ok, out = spawn({cosmic, script, "custom"}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("param=custom"), "param should be custom")
+
+  -- Test with no argument (should use default)
+  ok, out = spawn({cosmic, script}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("param=default"), "param should be default")
+end
+test_main_function_with_single_param()
+
+-- Test script with no arguments
+local function test_no_arguments()
+  local script = path.join(tmpdir, "noargs.lua")
+  cosmo.Barf(script, [[
+local args = {...}
+print("varargs_count=" .. #args)
+print("arg_count=" .. #arg)
+print("arg[0]=" .. tostring(arg[0]))
+]])
+
+  local ok, out = spawn({cosmic, script}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("varargs_count=0"), "varargs should be empty")
+  assert((out as string):find("arg_count=0"), "arg should be empty")
+  assert((out as string):find("arg%[0%]="), "arg[0] should be set")
+end
+test_no_arguments()
+
+-- Test arguments containing spaces
+local function test_arguments_with_spaces()
+  local script = path.join(tmpdir, "spaces.lua")
+  cosmo.Barf(script, [[
+local args = {...}
+for i, v in ipairs(args) do
+  print("arg[" .. i .. "]=" .. v)
+end
+]])
+
+  local ok, out = spawn({cosmic, script, "hello world", "foo bar"}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("arg%[1%]=hello world"), "should preserve spaces in arg[1]")
+  assert((out as string):find("arg%[2%]=foo bar"), "should preserve spaces in arg[2]")
+end
+test_arguments_with_spaces()
+
+-- Test arguments with special characters (use -- to separate from cosmic options)
+local function test_arguments_with_special_chars()
+  local script = path.join(tmpdir, "special.lua")
+  cosmo.Barf(script, [[
+local args = {...}
+for i, v in ipairs(args) do
+  print("arg[" .. i .. "]=" .. v)
+end
+]])
+
+  local ok, out = spawn({cosmic, script, "--", "--flag", "-x", "value=123"}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("arg%[1%]=%-%-flag"), "should handle --flag")
+  assert((out as string):find("arg%[2%]=%-x"), "should handle -x")
+  assert((out as string):find("arg%[3%]=value=123"), "should handle value=123")
+end
+test_arguments_with_special_chars()
+
+-- Test that cosmo.is_main() still works with new varargs approach
+local function test_cosmo_is_main_compatibility()
+  local script = path.join(tmpdir, "is_main.lua")
+  cosmo.Barf(script, [[
+local cosmo = require("cosmo")
+
+local function main(...)
+  local args = {...}
+  print("main_called=true")
+  print("args_count=" .. #args)
+  return 0
+end
+
+if cosmo.is_main() then
+  os.exit(main(...))
+end
+]])
+
+  local ok, out = spawn({cosmic, script, "test1", "test2"}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("main_called=true"), "main should be called")
+  assert((out as string):find("args_count=2"), "main should receive 2 args")
+end
+test_cosmo_is_main_compatibility()

--- a/lib/cosmic/test_binary.tl
+++ b/lib/cosmic/test_binary.tl
@@ -1,0 +1,95 @@
+#!/usr/bin/env run-test.lua
+-- test cosmic bundled binary
+
+local lu = require("luaunit")
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
+local spawn = require("cosmic.spawn")
+
+local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+
+-- helper to create clean environment without LUA_PATH
+-- this ensures we test the bundled libraries, not the repo
+local function clean_env(): {string}
+  local env: {string} = {}
+  for _, line in ipairs(unix.environ()) do
+    if not line:match("^LUA_PATH=") and not line:match("^LUA_CPATH=") then
+      env[#env + 1] = line
+    end
+  end
+  return env
+end
+
+global TestCosmicBinary: {string: function()}
+
+TestCosmicBinary = {}
+
+function TestCosmicBinary.test_cosmic_spawn()
+  local ok, out = spawn({cosmic, "-e", "local s = require('cosmic.spawn'); print(s and 'ok' or 'fail')"}, {env = clean_env()}):read()
+  lu.assertTrue(ok, "cosmic exited with error")
+  lu.assertStrContains(out as string, "ok")
+end
+
+function TestCosmicBinary.test_cosmic_walk()
+  local ok, out = spawn({cosmic, "-e", "local w = require('cosmic.walk'); print(w and 'ok' or 'fail')"}, {env = clean_env()}):read()
+  lu.assertTrue(ok, "cosmic exited with error")
+  lu.assertStrContains(out as string, "ok")
+end
+
+function TestCosmicBinary.test_cosmic_help()
+  local ok, out = spawn({cosmic, "-e", "require('cosmic.help')"}, {env = clean_env()}):read()
+  lu.assertTrue(ok, "cosmic exited with error")
+  lu.assertStrContains(out as string, "cosmic")
+  lu.assertStrContains(out as string, "cosmic.spawn")
+end
+
+function TestCosmicBinary.test_luaunit_bundled()
+  local ok, out = spawn({cosmic, "-e", "local lu = require('luaunit'); print(lu and 'ok' or 'fail')"}, {env = clean_env()}):read()
+  lu.assertTrue(ok, "cosmic exited with error")
+  lu.assertStrContains(out as string, "ok")
+end
+
+function TestCosmicBinary.test_argparse_bundled()
+  local ok, out = spawn({cosmic, "-e", "local ap = require('argparse'); print(ap and 'ok' or 'fail')"}, {env = clean_env()}):read()
+  lu.assertTrue(ok, "cosmic exited with error")
+  lu.assertStrContains(out as string, "ok")
+end
+
+function TestCosmicBinary.test_lfs_bundled()
+  local ok, out = spawn({cosmic, "-e", "local lfs = require('lfs'); print(lfs and 'ok' or 'fail')"}, {env = clean_env()}):read()
+  lu.assertTrue(ok, "cosmic exited with error")
+  lu.assertStrContains(out as string, "ok")
+end
+
+function TestCosmicBinary.test_warnings_flag()
+  -- -W should convert warnings to errors
+  local ok, out, code = spawn({cosmic, "-W", "-e", "warn('test warning')"}, {env = clean_env()}):read()
+  lu.assertFalse(ok, "cosmic should fail with -W when warning is issued")
+  lu.assertStrContains(out as string, "warning: test warning")
+  lu.assertEquals(code, 1)
+end
+
+function TestCosmicBinary.test_warnings_without_flag()
+  -- without -W, warnings should not cause errors
+  local ok, out = spawn({cosmic, "-e", "warn('test warning'); print('ok')"}, {env = clean_env()}):read()
+  lu.assertTrue(ok, "cosmic should succeed without -W")
+  lu.assertStrContains(out as string, "ok")
+end
+
+function TestCosmicBinary.test_interactive_mode()
+  -- -i should enter interactive mode (REPL)
+  local proc = spawn({cosmic, "-i"}, {env = clean_env(), stdin = "print('hello')\ncont\n"})
+  local ok, out = proc:read()
+  lu.assertTrue(ok, "cosmic -i should succeed")
+  lu.assertStrContains(out as string, "Lua 5.4")
+  lu.assertStrContains(out as string, "hello")
+end
+
+function TestCosmicBinary.test_repl_no_args()
+  -- no args should enter REPL
+  local proc = spawn({cosmic}, {env = clean_env(), stdin = "print('repl test')\ncont\n"})
+  local ok, out = proc:read()
+  lu.assertTrue(ok, "cosmic with no args should enter REPL")
+  lu.assertStrContains(out as string, "Lua 5.4")
+  lu.assertStrContains(out as string, "repl test")
+end

--- a/lib/cosmic/test_cosmic.tl
+++ b/lib/cosmic/test_cosmic.tl
@@ -1,0 +1,76 @@
+#!/usr/bin/env run-test.lua
+local lu = require("luaunit")
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
+
+global TEST_DEPS: {string}
+
+global TestCosmic: {string: function(self: TestCosmic)}
+
+TestCosmic = {}
+
+function TestCosmic:test_deps_passed()
+  lu.assertNotNil(TEST_DEPS)
+  lu.assertTrue(#TEST_DEPS > 0, "expected deps to be passed")
+end
+
+function TestCosmic:test_env_vars()
+  lu.assertNotNil(os.getenv("TEST_O"))
+  lu.assertNotNil(os.getenv("TEST_PLATFORM"))
+end
+
+function TestCosmic:test_lib_files_exist()
+  local test_o = os.getenv("TEST_O")
+  for _, dep in ipairs(TEST_DEPS) do
+    if dep:match("%.lua$") then
+      local stat = unix.stat(dep)
+      lu.assertNotNil(stat, "expected " .. dep .. " to exist")
+    end
+  end
+end
+
+function TestCosmic:test_require_cosmic()
+  local cosmic = require("cosmic")
+  lu.assertNotNil(cosmic)
+  lu.assertEquals(cosmic._VERSION, "0.1.0")
+end
+
+function TestCosmic:test_require_cosmic_spawn()
+  local spawn_mod = require("cosmic.spawn")
+  lu.assertNotNil(spawn_mod)
+  lu.assertNotNil(spawn_mod.spawn)
+end
+
+function TestCosmic:test_require_cosmic_walk()
+  local walk = require("cosmic.walk")
+  lu.assertNotNil(walk)
+  lu.assertNotNil(walk.walk)
+  lu.assertNotNil(walk.collect)
+  lu.assertNotNil(walk.collect_all)
+end
+
+function TestCosmic:test_require_cosmic_help()
+  -- help module prints on load, but should still return a table
+  local help = require("cosmic.help")
+  lu.assertNotNil(help)
+  lu.assertNotNil(help.modules)
+  lu.assertNotNil(help.print_help)
+end
+
+function TestCosmic:test_cosmic_main_exists()
+  local cosmic = require("cosmic")
+  lu.assertNotNil(cosmic.main)
+  lu.assertEquals(type(cosmic.main), "function")
+end
+
+function TestCosmic:test_cosmic_main_returns_when_not_main()
+  local cosmic = require("cosmic")
+  local called = false
+  local function app(): number
+    called = true
+    return 0
+  end
+  -- when required (not main), cosmic.main should return without calling fn
+  cosmic.main(app as function({string}, any): number, string)
+  lu.assertFalse(called)
+end

--- a/lib/cosmic/test_skill_pr.tl
+++ b/lib/cosmic/test_skill_pr.tl
@@ -1,0 +1,59 @@
+#!/usr/bin/env run-test.lua
+-- test skill module integration with cosmic binary
+
+local lu = require("luaunit")
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
+local spawn = require("cosmic.spawn")
+
+local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+
+-- helper to create clean environment without LUA_PATH
+-- this ensures we test the bundled libraries, not the repo
+local function clean_env(): {string}
+  local env: {string} = {}
+  for _, line in ipairs(unix.environ()) do
+    if not line:match("^LUA_PATH=") and not line:match("^LUA_CPATH=") then
+      env[#env + 1] = line
+    end
+  end
+  return env
+end
+
+global TestSkill: {string: function()}
+
+TestSkill = {}
+
+function TestSkill.test_skill_loads()
+  local ok, out = spawn({cosmic, "-l", "skill", "-e", "print('loaded')"}, {env = clean_env()}):read()
+  lu.assertTrue(ok, "cosmic -l skill failed to load")
+  lu.assertStrContains(out as string, "loaded")
+end
+
+function TestSkill.test_skill_update_pr_outside_actions()
+  -- when not in GitHub Actions, should show help
+  local env = clean_env()
+  env[#env + 1] = "GITHUB_ACTIONS=false"
+
+  local ok, out = spawn({cosmic, "-l", "skill", "update-pr"}, { env = env }):read()
+  lu.assertTrue(ok, "skill update-pr should not error outside GitHub Actions")
+  lu.assertStrContains(out as string, "Updates PR title and description")
+end
+
+function TestSkill.test_skill_update_pr_requires_token()
+  -- in GitHub Actions without token, should fail
+  local env = clean_env()
+  env[#env + 1] = "GITHUB_ACTIONS=true"
+  env[#env + 1] = "GITHUB_REPOSITORY=owner/repo"
+  env[#env + 1] = "GITHUB_PR_NUMBER=123"
+  -- explicitly unset GITHUB_TOKEN if it exists
+  for i = #env, 1, -1 do
+    if env[i]:match("^GITHUB_TOKEN=") then
+      table.remove(env, i)
+    end
+  end
+
+  local ok, out, exit_code = spawn({cosmic, "-l", "skill", "update-pr"}, { env = env }):read()
+  lu.assertFalse(ok, "skill update-pr should fail without GITHUB_TOKEN")
+  lu.assertEquals(exit_code, 1)
+end

--- a/lib/cosmic/test_spawn.tl
+++ b/lib/cosmic/test_spawn.tl
@@ -1,0 +1,91 @@
+#!/usr/bin/env run-test.lua
+local lu = require("luaunit")
+local cosmo = require("cosmo")
+local path = require("cosmo.path")
+local spawn = require("cosmic.spawn")
+
+local lua_bin = path.join(os.getenv("TEST_BIN"), "cosmic")
+
+global TEST_TMPDIR: string
+
+global TestSpawn: {string: function(self: TestSpawn)}
+
+TestSpawn = {}
+
+function TestSpawn:test_simple_command()
+	local handle = spawn({lua_bin, "-e", "print('hello')"})
+	lu.assertNotNil(handle)
+	local ok, out = handle:read()
+	lu.assertTrue(ok)
+	lu.assertEquals(out, "hello\n")
+end
+
+function TestSpawn:test_command_not_found()
+	local handle, err = spawn({"nonexistent_command_12345"})
+	lu.assertNil(handle)
+	lu.assertStrContains(err, "command not found")
+end
+
+function TestSpawn:test_wait_returns_exit_code()
+	local handle = spawn({lua_bin, "-e", "os.exit(0)"})
+	lu.assertNotNil(handle)
+	local exit_code = handle:wait()
+	lu.assertEquals(exit_code, 0)
+
+	handle = spawn({lua_bin, "-e", "os.exit(1)"})
+	lu.assertNotNil(handle)
+	exit_code = handle:wait()
+	lu.assertEquals(exit_code, 1)
+end
+
+function TestSpawn:test_wait_drains_stdout_to_avoid_sigpipe()
+	local tmp_file = path.join(TEST_TMPDIR, "checkfile")
+	local tmp_target = path.join(TEST_TMPDIR, "target")
+
+	local f = io.open(tmp_target, "w")
+	f:write("test content\n")
+	f:close()
+
+	-- compute sha256 using cosmo (returns hex)
+	local content = "test content\n"
+	local expected_sha = cosmo.EncodeHex(cosmo.Sha256(content))
+
+	f = io.open(tmp_file, "w")
+	f:write(expected_sha .. "  " .. tmp_target .. "\n")
+	f:close()
+
+	-- verify using lua script that reads file and computes hash
+	local script = string.format([[
+		local cosmo = require("cosmo")
+		local f = io.open(%q, "r")
+		local content = f:read("*a")
+		f:close()
+		local hash = cosmo.EncodeHex(cosmo.Sha256(content))
+		f = io.open(%q, "r")
+		local expected = f:read("*l"):match("^(%%x+)")
+		f:close()
+		if hash == expected then os.exit(0) else os.exit(1) end
+	]], tmp_target, tmp_file)
+
+	local handle = spawn({lua_bin, "-e", script})
+	lu.assertNotNil(handle)
+
+	local exit_code, err = handle:wait()
+	lu.assertEquals(exit_code, 0, "sha check should exit 0, got: " .. tostring(err))
+end
+
+function TestSpawn:test_stdin_string()
+	local handle = spawn({lua_bin, "-e", "io.write(io.read('*a'))"}, {stdin = "hello from stdin"})
+	lu.assertNotNil(handle)
+	local ok, out = handle:read()
+	lu.assertTrue(ok)
+	lu.assertEquals(out, "hello from stdin")
+end
+
+function TestSpawn:test_read_captures_output()
+	local handle = spawn({lua_bin, "-e", [[io.write("line1\nline2\n")]]})
+	lu.assertNotNil(handle)
+	local ok, out = handle:read()
+	lu.assertTrue(ok)
+	lu.assertEquals(out, "line1\nline2\n")
+end

--- a/lib/cosmic/test_walk.tl
+++ b/lib/cosmic/test_walk.tl
@@ -1,0 +1,113 @@
+#!/usr/bin/env run-test.lua
+local lu = require("luaunit")
+local walk = require("cosmic.walk")
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
+
+global TEST_TMPDIR: string
+
+local record Stat
+  mode: function(self): number
+  size: function(self): number
+  mtim: function(self): number
+end
+
+local record WalkContext
+  count: number
+  dirs: number
+end
+
+local record TestWalkClass
+  test_dir: string
+  setUp: function(self: TestWalkClass)
+  tearDown: function(self: TestWalkClass)
+  test_collect_finds_lua_files: function(self: TestWalkClass)
+  test_collect_finds_nested_files: function(self: TestWalkClass)
+  test_walk_with_visitor: function(self: TestWalkClass)
+  test_collect_all: function(self: TestWalkClass)
+  test_walk_empty_directory: function(self: TestWalkClass)
+end
+
+global TestWalk: TestWalkClass
+
+TestWalk = {} as TestWalkClass
+
+function TestWalk:setUp()
+  self.test_dir = path.join(TEST_TMPDIR, "walk_test")
+  unix.makedirs(path.join(self.test_dir, "subdir"))
+  unix.makedirs(path.join(self.test_dir, "subdir/nested"))
+
+  local function touch(filepath: string)
+    local fd = unix.open(filepath, unix.O_WRONLY | unix.O_CREAT, tonumber("644", 8))
+    unix.close(fd)
+  end
+
+  touch(path.join(self.test_dir, "file1.lua"))
+  touch(path.join(self.test_dir, "file2.txt"))
+  touch(path.join(self.test_dir, "subdir/file3.lua"))
+  touch(path.join(self.test_dir, "subdir/nested/file4.lua"))
+end
+
+function TestWalk:tearDown()
+  if self.test_dir then
+    unix.rmrf(self.test_dir)
+  end
+end
+
+function TestWalk:test_collect_finds_lua_files()
+  local files = walk.collect(self.test_dir, "%.lua$")
+
+  lu.assertEquals(#files, 3)
+
+  local found: {string:boolean} = {}
+  for _, f in ipairs(files) do
+    local name = path.basename(f)
+    found[name] = true
+  end
+
+  lu.assertTrue(found["file1.lua"])
+  lu.assertTrue(found["file3.lua"])
+  lu.assertTrue(found["file4.lua"])
+  lu.assertNil(found["file2.txt"])
+end
+
+function TestWalk:test_collect_finds_nested_files()
+  local files = walk.collect(self.test_dir, "%.txt$")
+  lu.assertEquals(#files, 1)
+  lu.assertEquals(path.basename(files[1]), "file2.txt")
+end
+
+function TestWalk:test_walk_with_visitor()
+  local ctx: WalkContext = { count = 0, dirs = 0 }
+
+  walk.walk(self.test_dir, function(_full_path: string, _entry: string, stat: Stat, c: WalkContext): boolean
+    c.count = c.count + 1
+    if unix.S_ISDIR(stat:mode()) then
+      c.dirs = c.dirs + 1
+    end
+    return true
+  end, ctx)
+
+  lu.assertTrue(ctx.count > 0)
+  lu.assertEquals(ctx.dirs, 2)
+end
+
+function TestWalk:test_collect_all()
+  local files = walk.collect_all(self.test_dir)
+
+  lu.assertNotNil(files["file1.lua"])
+  lu.assertNotNil(files["file2.txt"])
+  lu.assertNotNil(files["subdir/file3.lua"])
+  lu.assertNotNil(files["subdir/nested/file4.lua"])
+
+  lu.assertNotNil(files["file1.lua"].mode)
+  lu.assertNil(files["subdir"])
+end
+
+function TestWalk:test_walk_empty_directory()
+  local empty_dir = path.join(TEST_TMPDIR, "walk_empty")
+  unix.makedirs(empty_dir)
+  local files = walk.collect(empty_dir, "%.lua$")
+  lu.assertEquals(#files, 0)
+  unix.rmrf(empty_dir)
+end

--- a/lib/home/test_main.tl
+++ b/lib/home/test_main.tl
@@ -1,0 +1,199 @@
+#!/usr/bin/env run-test.lua
+-- ast-grep ignore: test file uses temp path concatenation
+
+local cosmo = require("cosmo")
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
+local spawn = require("cosmic.spawn")
+
+local home = require("home.main")
+
+local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+
+local record Args
+  cmd: string
+  dest: string
+  force: boolean
+end
+
+local record CapturedOutput
+  stderr: string
+  stdout: string
+  stderr_obj: FILE
+  stdout_obj: FILE
+end
+
+local record Manifest
+  files: {string:any}
+  version: string
+end
+
+local record SpawnHandle
+  read: function(self: SpawnHandle): boolean, string
+end
+
+-- Test built binary has valid manifest
+local home_bin = path.join(os.getenv("TEST_BIN") or "", "home")
+local ok, manifest_content = (spawn({"unzip", "-p", home_bin, "manifest.lua"}) as SpawnHandle):read()
+assert(ok, "failed to extract manifest.lua from built binary")
+assert(manifest_content and #manifest_content > 0, "manifest.lua is empty in built binary")
+local chunk, err = load(manifest_content)
+assert(chunk, "manifest.lua is not valid lua: " .. tostring(err))
+local manifest = chunk() as Manifest
+assert(type(manifest) == "table", "manifest.lua does not return a table")
+assert(manifest.files, "manifest.lua missing files key")
+assert(next(manifest.files), "manifest.lua has empty files")
+
+-- Test parse_args
+local args = home.parse_args({ "unpack", "/tmp/dest" }) as Args
+assert(args.cmd == "unpack", "parse_args cmd")
+assert(args.dest == "/tmp/dest", "parse_args dest")
+assert(not args.force, "parse_args force default")
+
+args = home.parse_args({ "unpack", "--force", "/tmp/dest" }) as Args
+assert(args.force, "parse_args --force")
+
+args = home.parse_args({}) as Args
+assert(args.cmd == "help", "parse_args default help")
+
+-- Test copy_file
+local src = path.join(TEST_TMPDIR, "source.txt")
+local dst = path.join(TEST_TMPDIR, "dest.txt")
+cosmo.Barf(src, "hello world")
+
+local copy_ok, copy_err = home.copy_file(src, dst)
+assert(copy_ok, "copy_file: " .. tostring(copy_err))
+
+local f = io.open(dst, "r")
+assert(f, "copy_file destination exists")
+local content = f:read("*a")
+f:close()
+assert(content == "hello world", "copy_file content")
+
+-- Test copy_file no overwrite
+cosmo.Barf(dst, "existing")
+copy_ok, copy_err = home.copy_file(src, dst, nil, false)
+assert(not copy_ok, "copy_file should fail without overwrite")
+assert(copy_err:find("already exists"), "copy_file error message")
+
+-- Test copy_file with overwrite
+copy_ok, copy_err = home.copy_file(src, dst, nil, true)
+assert(copy_ok, "copy_file overwrite: " .. tostring(copy_err))
+
+-- Test read_file
+local data: string
+data, err = home.read_file(src)
+assert(data == "hello world", "read_file content")
+
+data, err = home.read_file("/nonexistent/path")
+assert(not data, "read_file nonexistent should fail")
+
+-- Test format_mode
+assert(home.format_mode(tonumber("644", 8), false) == "-rw-r--r--", "format_mode 644")
+assert(home.format_mode(tonumber("755", 8), false) == "-rwxr-xr-x", "format_mode 755")
+assert(home.format_mode(tonumber("755", 8), true) == "drwxr-xr-x", "format_mode dir")
+
+-- Test detect_platform
+local platform = home.detect_platform()
+assert(platform, "detect_platform returns value")
+assert(
+  platform == "darwin-arm64" or platform == "linux-arm64" or platform == "linux-x86_64",
+  "detect_platform valid: " .. platform
+)
+
+-- Test cmd_unpack with invalid manifests
+local function capture_output(): CapturedOutput
+  local out: CapturedOutput = { stderr = "", stdout = "" }
+  out.stderr_obj = {
+    write = function(_: any, s: string): boolean out.stderr = out.stderr .. s return true end,
+  } as FILE
+  out.stdout_obj = {
+    write = function(_: any, s: string): boolean out.stdout = out.stdout .. s return true end,
+  } as FILE
+  return out
+end
+
+-- Empty manifest (nil) should fail
+local out = capture_output()
+local ret = home.cmd_unpack(TEST_TMPDIR, false, {
+  manifest = nil,
+  stderr = out.stderr_obj,
+  stdout = out.stdout_obj,
+})
+assert(ret == 1, "cmd_unpack nil manifest should return 1")
+assert(out.stderr:find("failed to load manifest"), "nil manifest error message")
+
+-- Empty table manifest should fail
+out = capture_output()
+ret = home.cmd_unpack(TEST_TMPDIR, false, {
+  manifest = {},
+  stderr = out.stderr_obj,
+  stdout = out.stdout_obj,
+})
+assert(ret == 1, "cmd_unpack empty manifest should return 1")
+assert(out.stderr:find("failed to load manifest"), "empty manifest error message")
+
+-- Manifest without files key should fail
+out = capture_output()
+ret = home.cmd_unpack(TEST_TMPDIR, false, {
+  manifest = { version = "1.0.0" },
+  stderr = out.stderr_obj,
+  stdout = out.stdout_obj,
+})
+assert(ret == 1, "cmd_unpack manifest without files should return 1")
+assert(out.stderr:find("failed to load manifest"), "missing files error message")
+
+-- Valid manifest with empty files should succeed
+out = capture_output()
+ret = home.cmd_unpack(TEST_TMPDIR, false, {
+  manifest = { version = "1.0.0", files = {} },
+  stderr = out.stderr_obj,
+  stdout = out.stdout_obj,
+})
+assert(ret == 0, "cmd_unpack valid manifest should return 0, got: " .. ret)
+
+-- Valid manifest with file entry should work
+local test_file = path.join(TEST_TMPDIR, "manifest_test.txt")
+cosmo.Barf(test_file, "test content")
+out = capture_output()
+ret = home.cmd_unpack(TEST_TMPDIR, false, {
+  manifest = {
+    version = "1.0.0",
+    files = {
+      ["test.txt"] = { mode = tonumber("644", 8) },
+    },
+  },
+  zip_root = TEST_TMPDIR .. "/",
+  stderr = out.stderr_obj,
+  stdout = out.stdout_obj,
+  verbose = true,
+})
+-- This will fail because test.txt doesn't exist in zip_root, but that's fine
+-- The point is it gets past manifest validation
+
+-- Test cmd_list with invalid manifests
+out = capture_output()
+ret = home.cmd_list({
+  manifest = nil,
+  stderr = out.stderr_obj,
+  stdout = out.stdout_obj,
+})
+assert(ret == 1, "cmd_list nil manifest should return 1")
+assert(out.stderr:find("failed to load manifest"), "cmd_list nil manifest error message")
+
+out = capture_output()
+ret = home.cmd_list({
+  manifest = {},
+  stderr = out.stderr_obj,
+  stdout = out.stdout_obj,
+})
+assert(ret == 1, "cmd_list empty manifest should return 1")
+assert(out.stderr:find("failed to load manifest"), "cmd_list empty manifest error message")
+
+out = capture_output()
+ret = home.cmd_list({
+  manifest = { version = "1.0.0", files = {} },
+  stderr = out.stderr_obj,
+  stdout = out.stdout_obj,
+})
+assert(ret == 0, "cmd_list valid manifest should return 0")

--- a/lib/home/test_release.tl
+++ b/lib/home/test_release.tl
@@ -1,0 +1,91 @@
+#!/usr/bin/env run-test.lua
+-- ast-grep ignore: test file
+
+-- This test is slow and only needed for release validation
+assert(os.getenv("TEST_RELEASE"), "IGNORE: release validation test")
+
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+local spawn = require("cosmic.spawn")
+
+local record SpawnHandle
+  stdout: FILE
+  stderr: FILE
+  read: function(self: SpawnHandle): boolean, string
+  wait: function(self: SpawnHandle): integer
+end
+
+local home_bin = path.join(os.getenv("TEST_BIN") or "", "home")
+local cosmic_bin = path.join(os.getenv("TEST_BIN") or "", "cosmic")
+local cosmos_zip = unix.realpath(path.join(os.getenv("TEST_O") or "", "cosmos/.staged/zip"))
+
+local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+
+-- Create a release-like home binary with platform metadata
+local release_dir = path.join(TEST_TMPDIR, "release")
+local platforms_dir = path.join(release_dir, "platforms")
+local test_home = path.join(release_dir, "home")
+local test_asset = path.join(release_dir, "home-linux-x86_64")
+
+unix.makedirs(platforms_dir)
+
+-- Copy home binary (once as main, once as platform asset)
+local ok, err = (spawn({ "cp", home_bin, test_home }) as SpawnHandle):wait()
+assert(ok == 0, "failed to copy home binary: " .. tostring(err))
+ok, err = (spawn({ "cp", home_bin, test_asset }) as SpawnHandle):wait()
+assert(ok == 0, "failed to copy home asset: " .. tostring(err))
+
+-- Generate platform metadata (compiled from Teal)
+local gen_platforms = path.join(os.getenv("TEST_O") or "", "lib/home/gen-platforms.lua")
+
+-- Build env with LUA_PATH prepended (unix.environ returns array of "K=V" strings)
+local env: {string} = { "LUA_PATH=lib/home/?.lua;;" }
+for _, entry in ipairs(unix.environ() as {string}) do
+  if not entry:match("^LUA_PATH=") then
+    table.insert(env, entry)
+  end
+end
+
+local output: string
+local proc = spawn({
+  cosmic_bin, gen_platforms,
+  platforms_dir, "https://example.com/releases/test", "test-tag",
+  test_asset,
+}, { env = env }) as SpawnHandle
+local stdout = proc.stdout:read("*a")
+local stderr = proc.stderr:read("*a")
+local exit_code = proc:wait()
+ok = exit_code == 0
+assert(ok, "gen-platforms failed (exit " .. tostring(exit_code) .. "): " .. tostring(stderr))
+
+-- Verify platforms.lua was generated
+local platforms_lua = path.join(platforms_dir, "platforms.lua")
+assert(unix.stat(platforms_lua), "platforms.lua not generated")
+
+-- Embed platforms.lua into test home binary
+local read_ok: boolean
+read_ok, output = (spawn({ cosmos_zip, "-j", test_home, platforms_lua }) as SpawnHandle):read()
+assert(read_ok, "failed to embed platforms.lua: " .. tostring(output))
+
+-- Embed manifests directory (need to cd first since zip stores relative paths)
+proc = spawn({ "sh", "-c", "cd " .. platforms_dir .. " && " .. cosmos_zip .. " -r " .. test_home .. " manifests" }) as SpawnHandle
+stdout = proc.stdout:read("*a")
+stderr = proc.stderr:read("*a")
+exit_code = proc:wait()
+ok = exit_code == 0
+assert(ok, "failed to embed manifests (exit " .. tostring(exit_code) .. "): " .. tostring(stderr) .. " | " .. tostring(stdout))
+
+-- Verify platforms.lua is in the binary
+read_ok, output = (spawn({ "unzip", "-l", test_home }) as SpawnHandle):read()
+assert(read_ok, "failed to list zip contents")
+assert(output:find("platforms%.lua"), "platforms.lua not found in binary")
+assert(output:find("manifests/"), "manifests/ not found in binary")
+
+-- Verify --with-platform works (dry-run)
+-- Use --platform to override detection since we only embedded linux-x86_64 metadata
+read_ok, output = (spawn({ test_home, "unpack", "--with-platform", "--platform", "linux-x86_64", "--dry-run", TEST_TMPDIR }) as SpawnHandle):read()
+assert(read_ok, "--with-platform failed: " .. tostring(output))
+
+-- Verify original binary without platform metadata fails
+read_ok, output = (spawn({ home_bin, "unpack", "--with-platform", "--dry-run", TEST_TMPDIR }) as SpawnHandle):read()
+assert(not read_ok, "original binary should fail with --with-platform")

--- a/lib/home/test_versioned.tl
+++ b/lib/home/test_versioned.tl
@@ -1,0 +1,210 @@
+#!/usr/bin/env run-test.lua
+-- ast-grep ignore: test file
+
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
+local spawn = require("cosmic.spawn")
+local version = require("version")
+
+local TEST_TMPDIR = os.getenv("TEST_TMPDIR") or "/tmp"
+
+local record SpawnHandle
+  read: function(self: SpawnHandle): boolean, string
+  wait: function(self: SpawnHandle): integer
+end
+
+local record VersionInfo
+  version: string
+  sha: string
+  path: string
+  dir: string
+end
+
+local record StatResult
+  mode: function(self: StatResult): integer
+end
+
+local home_bin = path.join(os.getenv("TEST_BIN") or "", "home")
+
+-- Test 1: Built binary contains versioned directories for 3p tools
+local ok, list_output = (spawn({home_bin, "list"}) as SpawnHandle):read()
+assert(ok, "home list failed")
+
+-- Check gh has versioned directory
+local gh_versioned = list_output:match("%.local/share/gh/([%d%.%-]+%-%x+)/")
+assert(gh_versioned, "gh should have versioned directory in home binary")
+assert(gh_versioned:match("^%d+%.%d+%.%d+%-%x+$"), "gh version format: " .. gh_versioned)
+
+-- Check nvim has versioned directory
+local nvim_versioned = list_output:match("%.local/share/nvim/([^/]+)/")
+assert(nvim_versioned, "nvim should have versioned directory in home binary")
+assert(nvim_versioned:match("%-%x+$"), "nvim has sha suffix: " .. nvim_versioned)
+
+-- Check delta has versioned directory
+local delta_versioned = list_output:match("%.local/share/delta/([%d%.%-]+%-%x+)/")
+assert(delta_versioned, "delta should have versioned directory in home binary")
+
+-- Test 2: Unpack preserves versioned directory structure
+local test_home = path.join(TEST_TMPDIR, "versioned_test")
+unix.makedirs(test_home)
+
+ok = (spawn({home_bin, "unpack", test_home}) as SpawnHandle):wait() == 0
+assert(ok, "home unpack failed")
+
+-- Verify gh versioned directory exists
+local gh_share = path.join(test_home, ".local", "share", "gh")
+local gh_dir = unix.opendir(gh_share)
+assert(gh_dir, "gh share directory should exist")
+
+local gh_versions: {string} = {}
+for entry in gh_dir do
+  if entry ~= "." and entry ~= ".." and version.is_version_dir(entry) then
+    table.insert(gh_versions, entry)
+  end
+end
+assert(#gh_versions == 1, "should have exactly one gh version, got " .. #gh_versions)
+assert(gh_versions[1]:match("^%d+%.%d+%.%d+%-%x+$"), "gh version dir format: " .. gh_versions[1])
+
+-- Verify gh binary exists in versioned directory
+local gh_bin = path.join(gh_share, gh_versions[1], "bin", "gh")
+local gh_stat = unix.stat(gh_bin) as StatResult
+assert(gh_stat, "gh binary should exist at: " .. gh_bin)
+assert(not unix.S_ISDIR(gh_stat:mode()), "gh binary should be a file")
+
+-- Verify nvim versioned directory exists
+local nvim_share = path.join(test_home, ".local", "share", "nvim")
+local nvim_dir_obj = unix.opendir(nvim_share)
+assert(nvim_dir_obj, "nvim share directory should exist")
+
+local nvim_versions: {string} = {}
+for entry in nvim_dir_obj do
+  if entry ~= "." and entry ~= ".." and version.is_version_dir(entry) then
+    table.insert(nvim_versions, entry)
+  end
+end
+assert(#nvim_versions == 1, "should have exactly one nvim version, got " .. #nvim_versions)
+assert(nvim_versions[1]:match("%-%x+$"), "nvim version has sha: " .. nvim_versions[1])
+
+-- Verify nvim binary exists in versioned directory
+local nvim_bin = path.join(nvim_share, nvim_versions[1], "bin", "nvim")
+local nvim_stat = unix.stat(nvim_bin) as StatResult
+assert(nvim_stat, "nvim binary should exist at: " .. nvim_bin)
+assert(not unix.S_ISDIR(nvim_stat:mode()), "nvim binary should be a file")
+
+-- Verify symlinks to versioned directories
+local gh_bin_link = path.join(gh_share, "bin")
+local gh_link_stat = unix.stat(gh_bin_link, unix.AT_SYMLINK_NOFOLLOW) as StatResult
+assert(gh_link_stat, "gh bin symlink should exist")
+assert(unix.S_ISLNK(gh_link_stat:mode()), "gh bin should be a symlink")
+local gh_link_target = unix.readlink(gh_bin_link, 1024)
+assert(gh_link_target == gh_versions[1] .. "/bin", "gh bin symlink target: " .. gh_link_target)
+
+local nvim_bin_link = path.join(nvim_share, "bin")
+local nvim_link_stat = unix.stat(nvim_bin_link, unix.AT_SYMLINK_NOFOLLOW) as StatResult
+assert(nvim_link_stat, "nvim bin symlink should exist")
+assert(unix.S_ISLNK(nvim_link_stat:mode()), "nvim bin should be a symlink")
+local nvim_link_target = unix.readlink(nvim_bin_link, 1024)
+assert(nvim_link_target == nvim_versions[1] .. "/bin", "nvim bin symlink target: " .. nvim_link_target)
+
+local nvim_share_link = path.join(nvim_share, "share")
+local nvim_share_stat = unix.stat(nvim_share_link, unix.AT_SYMLINK_NOFOLLOW) as StatResult
+assert(nvim_share_stat, "nvim share symlink should exist")
+assert(unix.S_ISLNK(nvim_share_stat:mode()), "nvim share should be a symlink")
+
+-- Test 3: version.find_latest() works with unpacked structure
+local nvim_latest = version.find_latest("nvim", path.join(test_home, ".local", "share")) as VersionInfo
+assert(nvim_latest, "version.find_latest should find nvim")
+assert(nvim_latest.version, "nvim latest should have version")
+assert(nvim_latest.sha, "nvim latest should have sha")
+assert(nvim_latest.path, "nvim latest should have path")
+assert(nvim_latest.dir, "nvim latest should have dir")
+assert(nvim_latest.path == nvim_bin, "nvim path should match: " .. nvim_latest.path .. " vs " .. nvim_bin)
+
+-- Test 4: version.scan_versions() returns versioned info
+local nvim_all = version.scan_versions("nvim", path.join(test_home, ".local", "share")) as {VersionInfo}
+assert(#nvim_all == 1, "should find one nvim version, got " .. #nvim_all)
+assert(nvim_all[1].version, "scanned version has version field")
+assert(nvim_all[1].sha, "scanned version has sha field")
+assert(nvim_all[1].path, "scanned version has path field")
+assert(nvim_all[1].dir, "scanned version has dir field")
+
+-- Test 5: Verify all bundled tools have versioned directories
+local tools: {string} = {
+  "ast-grep", "biome", "comrak", "delta", "duckdb", "gh",
+  "luacheck", "marksman", "rg", "ruff", "shfmt", "sqruff",
+  "stylua", "superhtml", "tree-sitter", "uv"
+}
+
+for _, tool in ipairs(tools) do
+  local tool_share = path.join(test_home, ".local", "share", tool)
+  local tool_dir = unix.opendir(tool_share)
+  assert(tool_dir, tool .. " share directory should exist")
+
+  local tool_versions: {string} = {}
+  for entry in tool_dir do
+    if entry ~= "." and entry ~= ".." and version.is_version_dir(entry) then
+      table.insert(tool_versions, entry)
+    end
+  end
+
+  assert(#tool_versions == 1, tool .. " should have exactly one version, got " .. #tool_versions)
+  assert(tool_versions[1]:match("%-%x+$"), tool .. " version has sha: " .. tool_versions[1])
+
+  -- Verify symlinks exist for items in versioned directory
+  local versioned_path = path.join(tool_share, tool_versions[1])
+  local versioned_dir = unix.opendir(versioned_path)
+  assert(versioned_dir, tool .. " versioned directory should be openable")
+
+  -- Check if bin directory exists in versioned dir
+  local has_bin = false
+  for item in versioned_dir do
+    if item == "bin" then
+      local item_path = path.join(versioned_path, item)
+      local item_stat = unix.stat(item_path) as StatResult
+      if item_stat and unix.S_ISDIR(item_stat:mode()) then
+        has_bin = true
+      end
+    end
+  end
+
+  -- If versioned dir has bin/, verify bin symlink exists at tool root
+  if has_bin then
+    local bin_link = path.join(tool_share, "bin")
+    local bin_stat = unix.stat(bin_link, unix.AT_SYMLINK_NOFOLLOW) as StatResult
+    assert(bin_stat, tool .. " bin symlink should exist")
+    assert(unix.S_ISLNK(bin_stat:mode()), tool .. " bin should be a symlink")
+    local bin_target = unix.readlink(bin_link, 1024)
+    assert(bin_target == tool_versions[1] .. "/bin", tool .. " bin symlink target: " .. bin_target)
+  end
+end
+
+-- Test 6: Multiple versions side-by-side (simulate)
+local multi_home = path.join(TEST_TMPDIR, "multi_version_test")
+unix.makedirs(path.join(multi_home, ".local", "share", "test-tool"))
+
+-- Create two fake versions
+local v1_dir = path.join(multi_home, ".local", "share", "test-tool", "1.0.0-abc123")
+local v2_dir = path.join(multi_home, ".local", "share", "test-tool", "2.0.0-def456")
+unix.makedirs(path.join(v1_dir, "bin"))
+unix.makedirs(path.join(v2_dir, "bin"))
+
+-- Create fake binaries
+local v1_bin = path.join(v1_dir, "bin", "test-tool")
+local v2_bin = path.join(v2_dir, "bin", "test-tool")
+local fd = unix.open(v1_bin, unix.O_WRONLY | unix.O_CREAT, tonumber("755", 8))
+unix.close(fd)
+fd = unix.open(v2_bin, unix.O_WRONLY | unix.O_CREAT, tonumber("755", 8))
+unix.close(fd)
+
+-- Scan should find both versions
+local all_versions = version.scan_versions("test-tool", path.join(multi_home, ".local", "share")) as {VersionInfo}
+assert(#all_versions == 2, "should find two versions, got " .. #all_versions)
+
+-- Should be sorted with latest first
+assert(all_versions[1].version == "2.0.0", "latest version first: " .. all_versions[1].version)
+assert(all_versions[2].version == "1.0.0", "older version second: " .. all_versions[2].version)
+
+-- find_latest should return newest
+local latest = version.find_latest("test-tool", path.join(multi_home, ".local", "share")) as VersionInfo
+assert(latest.version == "2.0.0", "find_latest returns newest: " .. latest.version)
+assert(latest.path == v2_bin, "latest path correct")

--- a/lib/skill/test_hook.tl
+++ b/lib/skill/test_hook.tl
@@ -1,0 +1,428 @@
+#!/usr/bin/env run-test.lua
+
+local hook = require("skill.hook")
+local cosmo = require("cosmo")
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+
+--------------------------------------------------------------------------------
+-- types
+--------------------------------------------------------------------------------
+
+local record MockStdin
+  read: function(self: MockStdin, mode: string): string
+end
+
+local record MockStdout
+  write: function(self: MockStdout, data: string): boolean
+  data: function(self: MockStdout): string
+end
+
+local record HookInput
+  hook_event_name: string
+  source: string
+  cwd: string
+  tool_name: string
+  tool_input: ToolInput
+  data: string
+end
+
+local record ToolInput
+  command: string
+end
+
+local record HookOutput
+  continue: boolean
+  systemMessage: string
+  custom: string
+  received: string
+  first: boolean
+  second: boolean
+  reason: string
+  hookSpecificOutput: HookSpecificOutput
+end
+
+local record HookSpecificOutput
+  postToolUse: PostToolUse
+end
+
+local record PostToolUse
+  additionalContext: string
+end
+
+--------------------------------------------------------------------------------
+-- mock helpers
+--------------------------------------------------------------------------------
+
+local function mock_stdin(json: string): MockStdin
+  return {
+    read = function(_: MockStdin, mode: string): string
+      if mode == "*a" then
+        return json
+      end
+      return nil
+    end,
+  }
+end
+
+local function mock_stdout(): MockStdout
+  local buffer: {string} = {}
+  return {
+    write = function(_: MockStdout, data: string): boolean
+      buffer[#buffer + 1] = data
+      return true
+    end,
+    data = function(_: MockStdout): string
+      return table.concat(buffer)
+    end,
+  }
+end
+
+--------------------------------------------------------------------------------
+-- read_input tests
+--------------------------------------------------------------------------------
+
+local function test_read_input_valid()
+  local input: HookInput = {hook_event_name = "SessionStart", cwd = "/tmp"}
+  local stdin = mock_stdin(cosmo.EncodeJson(input))
+  local result, err = hook.read_input(stdin as FILE)
+  assert(result, "expected result, got: " .. tostring(err))
+  local r = result as HookInput
+  assert(r.hook_event_name == "SessionStart", "expected event name")
+  assert(r.cwd == "/tmp", "expected cwd")
+end
+test_read_input_valid()
+
+local function test_read_input_empty()
+  local stdin = mock_stdin("")
+  local result, err = hook.read_input(stdin as FILE)
+  assert(not result, "expected no result")
+  assert(err == "no input", "expected no input error")
+end
+test_read_input_empty()
+
+local function test_read_input_invalid_json()
+  local stdin = mock_stdin("not json")
+  local result, err = hook.read_input(stdin as FILE)
+  assert(not result, "expected no result")
+  assert(err:match("invalid json"), "expected json error")
+end
+test_read_input_invalid_json()
+
+--------------------------------------------------------------------------------
+-- write_output tests
+--------------------------------------------------------------------------------
+
+local function test_write_output()
+  local stdout = mock_stdout()
+  local output: HookOutput = {continue = true, systemMessage = "hello"}
+  hook.write_output(output, stdout as FILE)
+  local data = stdout.data()
+  assert(data:match('"continue"'), "expected continue in output")
+end
+test_write_output()
+
+local function test_write_output_nil()
+  local stdout = mock_stdout()
+  hook.write_output(nil, stdout as FILE)
+  assert(stdout.data() == "", "expected empty output")
+end
+test_write_output_nil()
+
+--------------------------------------------------------------------------------
+-- register and dispatch tests
+--------------------------------------------------------------------------------
+
+local function test_dispatch_custom_handler()
+  -- register a handler that only handles TestEvent
+  hook.register(function(input: HookInput): HookOutput, string
+    if input.hook_event_name ~= "TestEvent" then
+      return nil
+    end
+    return {custom = "response", received = input.data}
+  end)
+
+  local input: HookInput = {hook_event_name = "TestEvent", data = "test"}
+  local result = hook.dispatch(input) as HookOutput
+  assert(result, "expected result")
+  assert(result.custom == "response", "expected custom response")
+  assert(result.received == "test", "expected received data")
+end
+test_dispatch_custom_handler()
+
+local function test_dispatch_multiple_handlers()
+  -- register handlers that produce output for any event
+  hook.register(function(input: HookInput): HookOutput, string
+    if input.hook_event_name ~= "MultiEvent" then
+      return nil
+    end
+    return {first = true}
+  end)
+  hook.register(function(input: HookInput): HookOutput, string
+    if input.hook_event_name ~= "MultiEvent" then
+      return nil
+    end
+    return {second = true}
+  end)
+
+  local input: HookInput = {hook_event_name = "MultiEvent"}
+  local result = hook.dispatch(input) as HookOutput
+  assert(result, "expected result")
+  assert(result.first == true, "expected first handler output")
+  assert(result.second == true, "expected second handler output")
+end
+test_dispatch_multiple_handlers()
+
+--------------------------------------------------------------------------------
+-- session_start bootstrap tests
+--------------------------------------------------------------------------------
+
+local function test_session_start_bootstrap()
+  local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
+  local env_file = path.join(tmpdir, "test_env")
+
+  -- set up env var
+  local orig_env_file = os.getenv("CLAUDE_ENV_FILE")
+  unix.setenv("CLAUDE_ENV_FILE", env_file)
+
+  -- dispatch session start
+  local input: HookInput = {
+    hook_event_name = "SessionStart",
+    source = "startup",
+    cwd = "/home/user/project",
+  }
+  local result, err = hook.dispatch(input)
+  assert(not err, "expected no error, got: " .. tostring(err))
+
+  -- check file was written
+  local f = io.open(env_file, "r")
+  if f then
+    local content = f:read("*a")
+    f:close()
+    assert(content:match('PATH="/home/user/project/bin'), "expected PATH export")
+  end
+
+  -- cleanup
+  os.remove(env_file)
+  if orig_env_file then
+    unix.setenv("CLAUDE_ENV_FILE", orig_env_file)
+  else
+    unix.unsetenv("CLAUDE_ENV_FILE")
+  end
+end
+test_session_start_bootstrap()
+
+local function test_session_start_skip_on_resume()
+  local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
+  local env_file = path.join(tmpdir, "test_env_resume")
+
+  -- set up env var
+  local orig_env_file = os.getenv("CLAUDE_ENV_FILE")
+  unix.setenv("CLAUDE_ENV_FILE", env_file)
+
+  -- dispatch session start with resume source
+  local input: HookInput = {
+    hook_event_name = "SessionStart",
+    source = "resume",
+    cwd = "/home/user/project",
+  }
+  local result, err = hook.dispatch(input)
+  assert(not err, "expected no error")
+
+  -- check file was NOT written
+  local f = io.open(env_file, "r")
+  if f then
+    local content = f:read("*a")
+    f:close()
+    assert(content == "" or not content:match("PATH"), "expected no PATH export on resume")
+  end
+
+  -- cleanup
+  os.remove(env_file)
+  if orig_env_file then
+    unix.setenv("CLAUDE_ENV_FILE", orig_env_file)
+  else
+    unix.unsetenv("CLAUDE_ENV_FILE")
+  end
+end
+test_session_start_skip_on_resume()
+
+--------------------------------------------------------------------------------
+-- run integration test
+--------------------------------------------------------------------------------
+
+local function test_run_integration()
+  local input: HookInput = {hook_event_name = "SessionStart", source = "compact"}
+  local stdin = mock_stdin(cosmo.EncodeJson(input))
+  local stdout = mock_stdout()
+
+  local code = hook.run({stdin = stdin as FILE, stdout = stdout as FILE})
+  assert(code == 0, "expected success")
+end
+test_run_integration()
+
+--------------------------------------------------------------------------------
+-- post_commit_pr_reminder tests
+--------------------------------------------------------------------------------
+
+local function test_post_commit_pr_reminder_skip_non_bash()
+  local input: HookInput = {hook_event_name = "PostToolUse", tool_name = "Edit"}
+  local result = hook.dispatch(input) as HookOutput
+  -- should not produce pr reminder output for non-Bash tools
+  assert(not result or not result.hookSpecificOutput, "expected no output for Edit tool")
+end
+test_post_commit_pr_reminder_skip_non_bash()
+
+local function test_post_commit_pr_reminder_skip_non_commit()
+  local input: HookInput = {
+    hook_event_name = "PostToolUse",
+    tool_name = "Bash",
+    tool_input = {command = "ls -la"},
+  }
+  local result = hook.dispatch(input) as HookOutput
+  -- should not produce pr reminder for non-commit commands
+  assert(not result or not result.hookSpecificOutput, "expected no output for ls command")
+end
+test_post_commit_pr_reminder_skip_non_commit()
+
+--------------------------------------------------------------------------------
+-- post_push_check_reminder tests
+--------------------------------------------------------------------------------
+
+local function test_post_push_check_reminder_on_feature_branch()
+  local input: HookInput = {
+    hook_event_name = "PostToolUse",
+    tool_name = "Bash",
+    tool_input = {command = "git push -u origin feature-branch"},
+  }
+  local result = hook.dispatch(input) as HookOutput
+  -- we're on a feature branch, so should get reminder
+  if result and result.hookSpecificOutput then
+    local ctx = result.hookSpecificOutput.postToolUse
+    assert(ctx and ctx.additionalContext:match("make help"), "expected make help in reminder")
+  end
+end
+test_post_push_check_reminder_on_feature_branch()
+
+local function test_post_push_check_reminder_skip_non_push()
+  local input: HookInput = {
+    hook_event_name = "PostToolUse",
+    tool_name = "Bash",
+    tool_input = {command = "git status"},
+  }
+  local result = hook.dispatch(input) as HookOutput
+  -- should not produce check reminder for non-push commands
+  local has_check_reminder = result and result.hookSpecificOutput
+    and result.hookSpecificOutput.postToolUse
+    and result.hookSpecificOutput.postToolUse.additionalContext
+    and result.hookSpecificOutput.postToolUse.additionalContext:match("checks")
+  assert(not has_check_reminder, "expected no check reminder for git status")
+end
+test_post_push_check_reminder_skip_non_push()
+
+--------------------------------------------------------------------------------
+-- dispatch reason concatenation tests
+--------------------------------------------------------------------------------
+
+local function test_dispatch_concatenates_reasons()
+  -- register two handlers that return different reasons
+  hook.register(function(input: HookInput): HookOutput, string
+    if input.hook_event_name ~= "ConcatTest" then
+      return nil
+    end
+    return {reason = "first reason"}
+  end)
+  hook.register(function(input: HookInput): HookOutput, string
+    if input.hook_event_name ~= "ConcatTest" then
+      return nil
+    end
+    return {reason = "second reason"}
+  end)
+
+  local input: HookInput = {hook_event_name = "ConcatTest"}
+  local result = hook.dispatch(input) as HookOutput
+  assert(result, "expected result")
+  assert(result.reason, "expected reason")
+  assert(result.reason:match("first reason"), "expected first reason")
+  assert(result.reason:match("second reason"), "expected second reason")
+  assert(result.reason:match("\n"), "expected newline between reasons")
+end
+test_dispatch_concatenates_reasons()
+
+local function test_dispatch_concatenates_additional_context()
+  -- register two handlers that return different additionalContext
+  hook.register(function(input: HookInput): HookOutput, string
+    if input.hook_event_name ~= "ContextConcatTest" then
+      return nil
+    end
+    return {
+      hookSpecificOutput = {
+        postToolUse = {additionalContext = "first context message"},
+      },
+    }
+  end)
+  hook.register(function(input: HookInput): HookOutput, string
+    if input.hook_event_name ~= "ContextConcatTest" then
+      return nil
+    end
+    return {
+      hookSpecificOutput = {
+        postToolUse = {additionalContext = "second context message"},
+      },
+    }
+  end)
+
+  local input: HookInput = {hook_event_name = "ContextConcatTest"}
+  local result = hook.dispatch(input) as HookOutput
+  assert(result, "expected result")
+  assert(result.hookSpecificOutput, "expected hookSpecificOutput")
+  assert(result.hookSpecificOutput.postToolUse, "expected postToolUse")
+  local ctx = result.hookSpecificOutput.postToolUse.additionalContext
+  assert(ctx, "expected additionalContext")
+  assert(ctx:match("first context message"), "expected first context")
+  assert(ctx:match("second context message"), "expected second context")
+  assert(ctx:match("\n"), "expected newline between contexts")
+end
+test_dispatch_concatenates_additional_context()
+
+--------------------------------------------------------------------------------
+-- post_push_pr_check tests
+--------------------------------------------------------------------------------
+
+local function test_post_push_hooks_on_git_push()
+  -- on feature branch, both post_push handlers fire for git push
+  local input: HookInput = {
+    hook_event_name = "PostToolUse",
+    tool_name = "Bash",
+    tool_input = {command = "git push -u origin feature-branch"},
+  }
+  local result = hook.dispatch(input) as HookOutput
+  -- we're on a feature branch so should get output
+  if result and result.hookSpecificOutput then
+    local ctx = result.hookSpecificOutput.postToolUse
+    if ctx and ctx.additionalContext then
+      -- should contain both the PR hint and make help reminder
+      local has_pr = ctx.additionalContext:match("PR") or ctx.additionalContext:match("pr") or ctx.additionalContext:match("trailer")
+      local has_help = ctx.additionalContext:match("make help")
+      assert(has_pr or has_help, "expected PR hint or make help reminder")
+    end
+  end
+end
+test_post_push_hooks_on_git_push()
+
+local function test_post_push_skip_non_push()
+  local input: HookInput = {
+    hook_event_name = "PostToolUse",
+    tool_name = "Bash",
+    tool_input = {command = "git fetch origin"},
+  }
+  local result = hook.dispatch(input) as HookOutput
+  -- should not produce pr check output for non-push commands
+  local has_pr_output = result and result.hookSpecificOutput
+    and result.hookSpecificOutput.postToolUse
+    and result.hookSpecificOutput.postToolUse.additionalContext
+    and (result.hookSpecificOutput.postToolUse.additionalContext:match("PR")
+      or result.hookSpecificOutput.postToolUse.additionalContext:match("trailer"))
+  assert(not has_pr_output, "expected no PR output for git fetch")
+end
+test_post_push_skip_non_push()

--- a/lib/skill/test_pr.tl
+++ b/lib/skill/test_pr.tl
@@ -1,0 +1,460 @@
+#!/usr/bin/env run-test.lua
+
+local pr = require("skill.pr")
+local cosmo = require("cosmo")
+local path = require("cosmo.path")
+
+--------------------------------------------------------------------------------
+-- types
+--------------------------------------------------------------------------------
+
+local record SpawnHandle
+  read: function(self: SpawnHandle): boolean, string
+  wait: function(self: SpawnHandle): integer
+end
+
+local record SpawnOpts
+  spawn: function({string}): SpawnHandle
+end
+
+local record MockEnv
+  GITHUB_ACTIONS: string
+  GITHUB_TOKEN: string
+  GITHUB_REPOSITORY: string
+  GITHUB_PR_NUMBER: string
+end
+
+local record MainOpts
+  getenv: function(string): string
+  spawn: function({string}): SpawnHandle
+  fetch: FetchFn
+end
+
+local record FetchOpts
+  method: string
+  headers: {string:string}
+  body: string
+end
+
+local type FetchFn = function(url: string, opts?: FetchOpts): number, {string:string}, string
+
+local record ParsedPr
+  title: string
+  body: string
+end
+
+local record TrailerInfo
+  commit_count: number
+  first_sha: string
+  last_sha: string
+  winning_sha: string
+  winning_trailer: string
+end
+
+local record GitHubPr
+  number: number
+  title: string
+  body: string
+end
+
+--------------------------------------------------------------------------------
+-- mock helpers
+--------------------------------------------------------------------------------
+
+local function mock_spawn(output: string): function({string}): SpawnHandle
+  return function(_: {string}): SpawnHandle
+    return {
+      read = function(_: SpawnHandle): boolean, string return true, output end,
+      wait = function(_: SpawnHandle): integer return 0 end,
+    }
+  end
+end
+
+--------------------------------------------------------------------------------
+-- parsing tests (no external deps)
+--------------------------------------------------------------------------------
+
+local function test_parse_basic()
+  local result = pr.parse_pr_md("# My Title\n\nBody here.") as ParsedPr
+  assert(result.title == "My Title", "expected title")
+  assert(result.body == "Body here.", "expected body")
+end
+test_parse_basic()
+
+local function test_parse_multiline()
+  local content = [[# Feature
+
+Description.
+
+## Changes
+- Added foo
+]]
+  local result = pr.parse_pr_md(content) as ParsedPr
+  assert(result.title == "Feature", "expected title")
+  assert(result.body:match("## Changes"), "expected changes section")
+end
+test_parse_multiline()
+
+local function test_parse_title_only()
+  local result = pr.parse_pr_md("# Just a title") as ParsedPr
+  assert(result.title == "Just a title", "expected title")
+  assert(result.body == "", "expected empty body")
+end
+test_parse_title_only()
+
+local function test_parse_no_title()
+  local result, err = pr.parse_pr_md("No hash mark")
+  assert(not result, "expected no result")
+  assert(err:match("no title"), "expected error")
+end
+test_parse_no_title()
+
+--------------------------------------------------------------------------------
+-- timestamp tests
+--------------------------------------------------------------------------------
+
+local function test_timestamp_new_body()
+  local result = pr.append_timestamp_details("Body content.")
+  assert(result:match("<!%-%- pr%-update%-history %-%->"), "expected marker")
+  assert(result:match("<details>"), "expected details tag")
+  assert(result:match("Updated: %d%d%d%d%-%d%d%-%d%d"), "expected timestamp")
+end
+test_timestamp_new_body()
+
+local function test_timestamp_replace_existing()
+  local body = [[Body.
+
+<!-- pr-update-history -->
+<details><summary>Update history</summary>
+
+- Updated: 2026-01-01T00:00:00Z
+</details>]]
+
+  local result = pr.append_timestamp_details(body)
+  local _, count = result:gsub("Updated:", "")
+  assert(count == 1, "expected one timestamp")
+  assert(not result:match("2026%-01%-01"), "expected old timestamp replaced")
+end
+test_timestamp_replace_existing()
+
+--------------------------------------------------------------------------------
+-- github api tests (mocked)
+--------------------------------------------------------------------------------
+
+local function test_github_request_success()
+  local mock_fetch: FetchFn = function(_: string, opts: FetchOpts): number, {string:string}, string
+    assert(opts.headers["Authorization"]:match("Bearer"), "expected bearer")
+    return 200, {}, cosmo.EncodeJson({number = 42})
+  end
+  local status, data = pr.github_request("GET", "/test", "token", nil, {fetch = mock_fetch})
+  assert(status == 200, "expected 200")
+  local d = data as GitHubPr
+  assert(d.number == 42, "expected number")
+end
+test_github_request_success()
+
+local function test_github_request_failure()
+  local mock_fetch: FetchFn = function(_: string, _opts: FetchOpts): number, {string:string}, string return nil, nil, "connection refused" end
+  local status, err = pr.github_request("GET", "/test", "token", nil, {fetch = mock_fetch})
+  assert(not status, "expected no status")
+  assert((err as string):match("fetch failed"), "expected error")
+end
+test_github_request_failure()
+
+local function test_get_pr()
+  local mock_fetch: FetchFn = function(_: string, _opts: FetchOpts): number, {string:string}, string
+    return 200, {}, cosmo.EncodeJson({number = 42, title = "Test", body = "Body"})
+  end
+  local data = pr.get_pr("owner", "repo", 42, "token", {fetch = mock_fetch}) as GitHubPr
+  assert(data.number == 42, "expected pr number")
+end
+test_get_pr()
+
+local function test_update_pr()
+  local captured: {string:string}
+  local mock_fetch: FetchFn = function(_: string, opts: FetchOpts): number, {string:string}, string
+    captured = cosmo.DecodeJson(opts.body) as {string:string}
+    return 200, {}, cosmo.EncodeJson({number = 42})
+  end
+  local ok = pr.update_pr("owner", "repo", 42, "Title", "Body", "token", {fetch = mock_fetch})
+  assert(ok, "expected success")
+  assert(captured.title == "Title", "expected title")
+end
+test_update_pr()
+
+--------------------------------------------------------------------------------
+-- local mode: shows help when not in github actions
+--------------------------------------------------------------------------------
+
+local function test_local_mode_shows_help()
+  local mock_env: MockEnv = {}
+  local code = pr.main({getenv = function(k: string): string return (mock_env as {string:string})[k] end})
+  assert(code == 0, "expected success (help shown)")
+end
+test_local_mode_shows_help()
+
+--------------------------------------------------------------------------------
+-- remote mode: github actions with env vars
+--------------------------------------------------------------------------------
+
+local function test_remote_missing_token()
+  local mock_env: MockEnv = {GITHUB_ACTIONS = "true", GITHUB_REPOSITORY = "owner/repo"}
+  local code, msg = pr.main({getenv = function(k: string): string return (mock_env as {string:string})[k] end})
+  assert(code == 1, "expected failure")
+  assert(msg:match("GITHUB_TOKEN"), "expected token error")
+end
+test_remote_missing_token()
+
+local function test_remote_missing_repository()
+  local mock_env: MockEnv = {GITHUB_ACTIONS = "true", GITHUB_TOKEN = "token"}
+  local code, msg = pr.main({getenv = function(k: string): string return (mock_env as {string:string})[k] end})
+  assert(code == 1, "expected failure")
+  assert(msg:match("GITHUB_REPOSITORY"), "expected repo error")
+end
+test_remote_missing_repository()
+
+local function test_remote_missing_pr_number()
+  local mock_env: MockEnv = {GITHUB_ACTIONS = "true", GITHUB_TOKEN = "token", GITHUB_REPOSITORY = "owner/repo"}
+  local code, msg = pr.main({getenv = function(k: string): string return (mock_env as {string:string})[k] end})
+  assert(code == 1, "expected failure")
+  assert(msg:match("GITHUB_PR_NUMBER"), "expected pr number error")
+end
+test_remote_missing_pr_number()
+
+--------------------------------------------------------------------------------
+-- trailer extraction (mocked git output)
+--------------------------------------------------------------------------------
+
+local function test_trailer_not_found()
+  local output = "abc123\ndef456\n"  -- commits with no trailers
+  local result = pr.get_pr_name_from_trailer({spawn = mock_spawn(output)} as SpawnOpts)
+  assert(result == nil, "expected no trailer")
+end
+test_trailer_not_found()
+
+local function test_trailer_found()
+  local output = "abc123 2026-01-04-feature.md\n"
+  local result = pr.get_pr_name_from_trailer({spawn = mock_spawn(output)} as SpawnOpts)
+  assert(result == "2026-01-04-feature.md", "expected trailer value, got: " .. tostring(result))
+end
+test_trailer_found()
+
+local function test_trailer_disabled()
+  -- first commit has name, second disables
+  local output = "abc123 feature.md\ndef456 false\n"
+  local result = pr.get_pr_name_from_trailer({spawn = mock_spawn(output)} as SpawnOpts)
+  assert(result == nil, "expected disabled, got: " .. tostring(result))
+end
+test_trailer_disabled()
+
+local function test_trailer_reenabled()
+  -- name -> disable -> new name
+  local output = "abc123 old.md\ndef456 false\nghi789 2026-01-04-new.md\n"
+  local result = pr.get_pr_name_from_trailer({spawn = mock_spawn(output)} as SpawnOpts)
+  assert(result == "2026-01-04-new.md", "expected re-enabled with new name, got: " .. tostring(result))
+end
+test_trailer_reenabled()
+
+local function test_trailer_info_returned()
+  local output = "abc123\ndef456 feature.md\nghi789\n"
+  local result, info = pr.get_pr_name_from_trailer({spawn = mock_spawn(output)} as SpawnOpts)
+  local trailer_info = info as TrailerInfo
+  assert(result == "feature.md", "expected trailer")
+  assert(trailer_info.commit_count == 3, "expected 3 commits")
+  assert(trailer_info.first_sha == "abc123", "expected first sha")
+  assert(trailer_info.last_sha == "ghi789", "expected last sha")
+  assert(trailer_info.winning_sha == "def456", "expected winning sha")
+  assert(trailer_info.winning_trailer == "x-cosmic-pr-name: feature.md", "expected winning trailer")
+end
+test_trailer_info_returned()
+
+--------------------------------------------------------------------------------
+-- do_update integration
+--------------------------------------------------------------------------------
+
+local function test_do_update_with_changes()
+  local mock_fetch: FetchFn = function(_: string, opts: FetchOpts): number, {string:string}, string
+    if opts.method == "GET" then
+      return 200, {}, cosmo.EncodeJson({number = 42, title = "Old", body = "Old body"})
+    else
+      return 200, {}, cosmo.EncodeJson({number = 42})
+    end
+  end
+
+  local original_exists = path.exists
+  local original_slurp = cosmo.Slurp
+  path.exists = function(p: string): boolean
+    if p:match("test%.md") then return true end
+    return original_exists(p)
+  end
+  cosmo.Slurp = function(p: string): string
+    if p:match("test%.md") then return "# New\n\nNew body" end
+    return original_slurp(p)
+  end
+
+  local code = pr.do_update("owner", "repo", 42, "test.md", nil, "token", {fetch = mock_fetch})
+
+  path.exists = original_exists
+  cosmo.Slurp = original_slurp
+
+  assert(code == 0, "expected success")
+end
+test_do_update_with_changes()
+
+--------------------------------------------------------------------------------
+-- trailer without .md extension should still find file
+--------------------------------------------------------------------------------
+
+local function test_do_update_finds_file_without_extension()
+  local patch_called = false
+  local mock_fetch: FetchFn = function(_: string, opts: FetchOpts): number, {string:string}, string
+    if opts.method == "GET" then
+      return 200, {}, cosmo.EncodeJson({number = 42, title = "Old", body = "Old body"})
+    else
+      patch_called = true
+      return 200, {}, cosmo.EncodeJson({number = 42})
+    end
+  end
+
+  local original_exists = path.exists
+  local original_slurp = cosmo.Slurp
+  -- only the .md version exists
+  path.exists = function(p: string): boolean
+    if p:match("feature%-name%.md$") then return true end
+    return false
+  end
+  cosmo.Slurp = function(p: string): string
+    if p:match("feature%-name%.md$") then return "# New\n\nNew body" end
+    return nil
+  end
+
+  -- trailer value omits the .md extension
+  local code = pr.do_update("owner", "repo", 42, "feature-name", nil, "token", {fetch = mock_fetch})
+
+  path.exists = original_exists
+  cosmo.Slurp = original_slurp
+
+  assert(code == 0, "expected success when extension omitted")
+  assert(patch_called, "expected PR to be updated (PATCH called)")
+end
+test_do_update_finds_file_without_extension()
+
+--------------------------------------------------------------------------------
+-- get_pr_files_from_branch tests
+--------------------------------------------------------------------------------
+
+local function test_pr_files_from_branch_none()
+  local result = pr.get_pr_files_from_branch({spawn = mock_spawn("")} as SpawnOpts)
+  assert(#result == 0, "expected no files")
+end
+test_pr_files_from_branch_none()
+
+local function test_pr_files_from_branch_one()
+  local result = pr.get_pr_files_from_branch({spawn = mock_spawn(".github/pr/feature.md\n")} as SpawnOpts)
+  assert(#result == 1, "expected one file")
+  assert(result[1] == ".github/pr/feature.md", "expected file path")
+end
+test_pr_files_from_branch_one()
+
+local function test_pr_files_from_branch_multiple()
+  local result = pr.get_pr_files_from_branch({spawn = mock_spawn(".github/pr/a.md\n.github/pr/b.md\n")} as SpawnOpts)
+  assert(#result == 2, "expected two files")
+end
+test_pr_files_from_branch_multiple()
+
+--------------------------------------------------------------------------------
+-- main() fallback to branch file detection
+--------------------------------------------------------------------------------
+
+local function test_main_fallback_to_branch_file()
+  local patch_called = false
+  local mock_fetch: FetchFn = function(_: string, opts: FetchOpts): number, {string:string}, string
+    if opts.method == "GET" then
+      return 200, {}, cosmo.EncodeJson({number = 42, title = "Old", body = "Old body"})
+    else
+      patch_called = true
+      return 200, {}, cosmo.EncodeJson({number = 42})
+    end
+  end
+
+  local original_exists = path.exists
+  local original_slurp = cosmo.Slurp
+  path.exists = function(p: string): boolean
+    if p:match("auto%-feature%.md$") then return true end
+    return false
+  end
+  cosmo.Slurp = function(p: string): string
+    if p:match("auto%-feature%.md$") then return "# Auto Feature\n\nBody" end
+    return nil
+  end
+
+  local mock_env: MockEnv = {
+    GITHUB_ACTIONS = "true",
+    GITHUB_TOKEN = "token",
+    GITHUB_REPOSITORY = "owner/repo",
+    GITHUB_PR_NUMBER = "42",
+  }
+
+  -- mock spawn to return no trailer but one branch file
+  local spawn_calls: {{string}} = {}
+  local mock_spawn_fn = function(cmd: {string}): SpawnHandle
+    table.insert(spawn_calls, cmd)
+    -- first call is trailer check, second is branch file check
+    if cmd[#cmd] == ".github/pr/*.md" then
+      return {
+        read = function(_: SpawnHandle): boolean, string return true, ".github/pr/auto-feature.md\n" end,
+        wait = function(_: SpawnHandle): integer return 0 end,
+      }
+    else
+      return {
+        read = function(_: SpawnHandle): boolean, string return true, "abc123\ndef456\n" end,  -- no trailers
+        wait = function(_: SpawnHandle): integer return 0 end,
+      }
+    end
+  end
+
+  local code = pr.main({
+    getenv = function(k: string): string return (mock_env as {string:string})[k] end,
+    spawn = mock_spawn_fn,
+    fetch = mock_fetch,
+  } as MainOpts)
+
+  path.exists = original_exists
+  cosmo.Slurp = original_slurp
+
+  assert(code == 0, "expected success")
+  assert(patch_called, "expected PR to be updated via fallback")
+end
+test_main_fallback_to_branch_file()
+
+local function test_main_no_fallback_when_multiple_files()
+  local mock_env: MockEnv = {
+    GITHUB_ACTIONS = "true",
+    GITHUB_TOKEN = "token",
+    GITHUB_REPOSITORY = "owner/repo",
+    GITHUB_PR_NUMBER = "42",
+  }
+
+  local mock_spawn_fn = function(cmd: {string}): SpawnHandle
+    if cmd[#cmd] == ".github/pr/*.md" then
+      return {
+        read = function(_: SpawnHandle): boolean, string return true, ".github/pr/a.md\n.github/pr/b.md\n" end,
+        wait = function(_: SpawnHandle): integer return 0 end,
+      }
+    else
+      return {
+        read = function(_: SpawnHandle): boolean, string return true, "abc123\n" end,  -- no trailers
+        wait = function(_: SpawnHandle): integer return 0 end,
+      }
+    end
+  end
+
+  local code, msg = pr.main({
+    getenv = function(k: string): string return (mock_env as {string:string})[k] end,
+    spawn = mock_spawn_fn,
+  } as MainOpts)
+
+  assert(code == 0, "expected success (skipped)")
+  assert(msg:match("no x%-cosmic%-pr%-name"), "expected no trailer message")
+end
+test_main_no_fallback_when_multiple_files()

--- a/lib/skill/test_pr_comments.tl
+++ b/lib/skill/test_pr_comments.tl
@@ -1,0 +1,148 @@
+-- teal ignore: test file
+
+local pr_comments = require("skill.pr_comments")
+
+local record User
+  login: string
+end
+
+local record ReviewComment
+  id: number
+  user: User
+  path: string
+  line: number
+  created_at: string
+  body: string
+  in_reply_to_id: number
+end
+
+local record IssueComment
+  user: User
+  created_at: string
+  body: string
+end
+
+local record Review
+  user: User
+  state: string
+  submitted_at: string
+  body: string
+end
+
+local record ParsedOpts
+  owner: string
+  repo: string
+  pr_number: number
+  json: boolean
+end
+
+local function test_format_review_comment()
+  local comment: ReviewComment = {
+    id = 12345,
+    user = {login = "testuser"},
+    path = "lib/foo.lua",
+    line = 42,
+    created_at = "2025-01-10T12:00:00Z",
+    body = "This looks good!",
+  }
+
+  local output = pr_comments.format_review_comment(comment)
+  assert(output:find("testuser"), "should include username")
+  assert(output:find("12345"), "should include comment id")
+  assert(output:find("lib/foo.lua"), "should include file path")
+  assert(output:find("42"), "should include line number")
+  assert(output:find("This looks good"), "should include body")
+end
+test_format_review_comment()
+
+local function test_format_issue_comment()
+  local comment: IssueComment = {
+    user = {login = "reviewer"},
+    created_at = "2025-01-10T12:00:00Z",
+    body = "LGTM!",
+  }
+
+  local output = pr_comments.format_issue_comment(comment)
+  assert(output:find("reviewer"), "should include username")
+  assert(output:find("LGTM"), "should include body")
+end
+test_format_issue_comment()
+
+local function test_format_review()
+  local review: Review = {
+    user = {login = "approver"},
+    state = "APPROVED",
+    submitted_at = "2025-01-10T12:00:00Z",
+    body = "Ship it!",
+  }
+
+  local output = pr_comments.format_review(review)
+  assert(output:find("approver"), "should include username")
+  assert(output:find("APPROVED"), "should include state")
+  assert(output:find("Ship it"), "should include body")
+end
+test_format_review()
+
+local function test_format_review_without_body()
+  local review: Review = {
+    user = {login = "commenter"},
+    state = "COMMENTED",
+    submitted_at = "2025-01-10T12:00:00Z",
+    body = "",
+  }
+
+  local output = pr_comments.format_review(review)
+  assert(output:find("commenter"), "should include username")
+  assert(output:find("COMMENTED"), "should include state")
+end
+test_format_review_without_body()
+
+local function test_reply_to_id()
+  local comment: ReviewComment = {
+    id = 99999,
+    user = {login = "replier"},
+    path = "test.lua",
+    line = 10,
+    created_at = "2025-01-10T12:00:00Z",
+    body = "I agree",
+    in_reply_to_id = 12345,
+  }
+
+  local output = pr_comments.format_review_comment(comment)
+  assert(output:find("12345"), "should include reply id")
+end
+test_reply_to_id()
+
+local function test_parse_pr_url()
+  local owner, repo, pr_num = pr_comments.parse_pr_url("https://github.com/whilp/world/pull/283")
+  assert(owner == "whilp", "owner should be whilp")
+  assert(repo == "world", "repo should be world")
+  assert(pr_num == 283, "pr_num should be 283")
+
+  owner, repo, pr_num = pr_comments.parse_pr_url("https://github.com/foo/bar/pull/42")
+  assert(owner == "foo", "owner should be foo")
+  assert(repo == "bar", "repo should be bar")
+  assert(pr_num == 42, "pr_num should be 42")
+
+  local invalid = pr_comments.parse_pr_url("https://gitlab.com/foo/bar/merge_requests/1")
+  assert(invalid == nil, "gitlab url should return nil")
+end
+test_parse_pr_url()
+
+local function test_parse_args()
+  local opts = pr_comments.parse_args({"--owner", "whilp", "--repo", "world", "--pr", "283"}) as ParsedOpts
+  assert(opts.owner == "whilp", "owner should be whilp")
+  assert(opts.repo == "world", "repo should be world")
+  assert(opts.pr_number == 283, "pr_number should be 283")
+  assert(opts.json == false, "json should be false")
+
+  opts = pr_comments.parse_args({"-o", "whilp", "-r", "world", "-p", "283", "--json"}) as ParsedOpts
+  assert(opts.owner == "whilp", "owner should be whilp")
+  assert(opts.json == true, "json should be true")
+
+  opts = pr_comments.parse_args({"--url", "https://github.com/foo/bar/pull/42"}) as ParsedOpts
+  assert(opts.owner == "foo", "owner should be foo")
+  assert(opts.repo == "bar", "repo should be bar")
+  assert(opts.pr_number == 42, "pr_number should be 42")
+end
+test_parse_args()

--- a/lib/test/test_test.tl
+++ b/lib/test/test_test.tl
@@ -1,0 +1,3 @@
+#!/usr/bin/env run-test.lua
+
+assert(1 == 1)

--- a/lib/test_version.tl
+++ b/lib/test_version.tl
@@ -1,0 +1,119 @@
+#!/usr/bin/env run-test.lua
+
+local version = require("version")
+
+-- Test parse_version_dir with valid inputs
+local function test_parse_valid()
+  -- Standard full sha256
+  local v, s = version.parse_version_dir("1.2.3-abc123def456")
+  assert(v == "1.2.3", "version should be 1.2.3, got: " .. tostring(v))
+  assert(s == "abc123def456", "sha should be abc123def456, got: " .. tostring(s))
+
+  -- Full 64-char sha256
+  local v2, s2 = version.parse_version_dir("2.0.0-e7af0c72a607c0528fda1989f7c8e3be85e67d321889002af0e2938ad9c8fb68")
+  assert(v2 == "2.0.0", "version should be 2.0.0")
+  assert(s2 == "e7af0c72a607c0528fda1989f7c8e3be85e67d321889002af0e2938ad9c8fb68", "sha should be full 64 chars")
+
+  -- Minimum 6-char sha
+  local v3, s3 = version.parse_version_dir("1.0.0-abc123")
+  assert(v3 == "1.0.0", "version should be 1.0.0")
+  assert(s3 == "abc123", "sha should be abc123")
+
+  -- Complex version with dev/pre-release
+  local v4, s4 = version.parse_version_dir("0.12.0-dev-49450c182c-91a8b837")
+  assert(v4 == "0.12.0-dev-49450c182c", "version should preserve dev part")
+  assert(s4 == "91a8b837", "sha should be extracted correctly")
+
+  -- Version with multiple dashes
+  local v5, s5 = version.parse_version_dir("2024-12-18-b9cb666")
+  assert(v5 == "2024-12-18", "version should be 2024-12-18")
+  assert(s5 == "b9cb666", "sha should be b9cb666")
+end
+test_parse_valid()
+
+-- Test parse_version_dir with invalid inputs
+local function test_parse_invalid()
+  -- Too short sha (less than 6 chars)
+  local v1, s1 = version.parse_version_dir("1.0.0-abc12")
+  assert(v1 == nil, "should reject sha with 5 chars")
+  assert(s1 == nil, "sha should be nil")
+
+  -- No dash
+  local v2, s2 = version.parse_version_dir("1.0.0")
+  assert(v2 == nil, "should reject version without dash")
+  assert(s2 == nil, "sha should be nil")
+
+  -- Empty version
+  local v3, s3 = version.parse_version_dir("-abc123")
+  assert(v3 == nil, "should reject empty version")
+  assert(s3 == nil, "sha should be nil")
+
+  -- Non-hex characters in sha
+  local v4, s4 = version.parse_version_dir("1.0.0-ghijkl")
+  assert(v4 == nil, "should reject non-hex sha")
+  assert(s4 == nil, "sha should be nil")
+
+  -- Empty string
+  local v5, s5 = version.parse_version_dir("")
+  assert(v5 == nil, "should reject empty string")
+  assert(s5 == nil, "sha should be nil")
+
+  -- Just a dash
+  local v6, s6 = version.parse_version_dir("-")
+  assert(v6 == nil, "should reject just dash")
+  assert(s6 == nil, "sha should be nil")
+
+  -- Sha-like version with non-hex sha
+  local v7, s7 = version.parse_version_dir("abc123-1.0.0")
+  assert(v7 == nil, "should reject version part with non-hex in sha position")
+  assert(s7 == nil, "sha should be nil")
+end
+test_parse_invalid()
+
+-- Test is_version_dir
+local function test_is_version_dir()
+  -- Valid patterns
+  assert(version.is_version_dir("1.2.3-abc123"), "should accept standard version-sha")
+  assert(version.is_version_dir("2.79.0-e7af0c7"), "should accept real gh version")
+  assert(version.is_version_dir("0.12.0-dev-49450c182c-91a8b83"), "should accept nvim version")
+  assert(version.is_version_dir("2024-12-18-b9cb666"), "should accept date-based version")
+
+  -- Invalid patterns
+  assert(not version.is_version_dir("1.0.0"), "should reject version without sha")
+  assert(not version.is_version_dir("bin"), "should reject non-versioned dir")
+  assert(not version.is_version_dir("share"), "should reject non-versioned dir")
+  assert(not version.is_version_dir("LICENSE"), "should reject non-versioned dir")
+  assert(not version.is_version_dir("1.0.0-abc"), "should reject short sha")
+  assert(not version.is_version_dir("-abc123"), "should reject empty version")
+  assert(not version.is_version_dir(""), "should reject empty string")
+  assert(not version.is_version_dir("."), "should reject dot")
+  assert(not version.is_version_dir(".."), "should reject dotdot")
+end
+test_is_version_dir()
+
+-- Test with real-world examples
+local function test_real_world()
+  -- From actual home binary
+  local real_versions: {string} = {
+    "2.79.0-e7af0c72a607c0528fda1989f7c8e3be85e67d321889002af0e2938ad9c8fb68",  -- gh
+    "0.12.0-dev-49450c182c-91a8b837a7e3665b5bd2a5b9419a5619262cdb8450f2707aa5febccfd81d9907",  -- nvim
+    "0.18.2-b7ea845004762358a00ef9127dd9fd723e333c7e4b9cb1da220c3909372310ee",  -- delta
+    "1.4.2-fae3ba93eedf20b08bca4b23aeac1ba94c446f1c10d029c193e2fc4b4e0bc1bc",  -- duckdb
+    "2024-12-18-b9cb666a4f360cba7b80c0f016c0e0d4af3f1a6b6e23bee85a0ff2b5da96b49",  -- marksman
+  }
+
+  for _, name in ipairs(real_versions) do
+    local v, s = version.parse_version_dir(name)
+    assert(v ~= nil, "should parse real version: " .. name)
+    assert(s ~= nil, "should extract sha from: " .. name)
+    assert(#s >= 6, "sha should be at least 6 chars: " .. s)
+    assert(version.is_version_dir(name), "is_version_dir should accept: " .. name)
+  end
+
+  -- Non-versioned directories that should be rejected
+  local non_versions: {string} = {"bin", "share", "lib", "LICENSE", "README.md", ".", ".."}
+  for _, name in ipairs(non_versions) do
+    assert(not version.is_version_dir(name), "should reject non-version: " .. name)
+  end
+end
+test_real_world()

--- a/lib/work/cook.mk
+++ b/lib/work/cook.mk
@@ -1,5 +1,8 @@
+modules += work
 lib_lua_modules += work
 lib_dirs += o/any/work/lib
+work_srcs := $(wildcard lib/work/*.lua) $(wildcard lib/work/*.tl)
+work_tests := $(filter-out lib/work/test_lib.lua,$(wildcard lib/work/test_*.lua))
 
 work_all_lua := $(wildcard lib/work/*.lua)
 work_tl_srcs := $(wildcard lib/work/*.tl)

--- a/lib/work/test_backup.tl
+++ b/lib/work/test_backup.tl
@@ -1,0 +1,250 @@
+local lu = require("luaunit")
+
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  global function test_backup_skipped()
+    lu.skip("requires luaposix")
+  end
+  return
+end
+
+local record WorkItemMeta
+  source: string
+  kind: string
+end
+
+local record WorkItem
+  id: string
+  title: string
+  created: string
+  blocks: {string}
+  completed: string
+  started: string
+  description: string
+  due: string
+  priority: number
+  log: {string:string}
+  _meta: WorkItemMeta
+end
+
+local record WorkStore
+  items: {string:WorkItem}
+end
+
+local record DataModule
+  _lock_handle: number
+  _lock_path: string
+  validate: function(item: WorkItem): boolean, string
+  save: function(item: WorkItem, dir: string): boolean, string
+  list_backups: function(dir: string): {string}
+  restore_backup: function(backup_path: string): boolean, string
+  release_lock: function(): boolean, string
+  get: function(store: WorkStore, id: string): WorkItem
+end
+
+local record StoreModule
+  reset: function(store: WorkStore): WorkStore
+end
+
+local record WorkModule
+  store: WorkStore
+end
+
+local data = require("work.data") as DataModule
+local store = require("work.store") as StoreModule
+local Work = require("work.test_lib") as WorkModule
+local test_store = Work.store
+
+local test_dir: string
+
+global TestBackup: {string:any} = {}
+
+function TestBackup:setUp()
+  store.reset(test_store)
+  test_dir = os.getenv("TEST_TMPDIR") as string
+end
+
+function TestBackup:tearDown()
+  data.release_lock()
+  data._lock_handle = nil
+  data._lock_path = nil
+end
+
+function TestBackup:test_backup_created_on_update()
+  local item: WorkItem = {
+    id = "01BACKUP00000000000000001",
+    title = "original title",
+    created = "2025-12-01",
+  }
+
+  -- Save original
+  local ok, err = data.save(item, test_dir)
+  lu.assertTrue(ok, "first save should succeed: " .. tostring(err))
+
+  -- Update item
+  item.title = "updated title"
+  ok, err = data.save(item, test_dir)
+  lu.assertTrue(ok, "second save should succeed: " .. tostring(err))
+
+  -- Verify backup was removed after successful save
+  local backup_path = test_dir .. "/01BACKUP00000000000000001.lua.bak"
+  local f = io.open(backup_path, "r")
+  lu.assertNil(f, "backup should be removed after successful save")
+
+  -- Verify updated content
+  local file_path = test_dir .. "/01BACKUP00000000000000001.lua"
+  f = io.open(file_path, "r")
+  local content = f:read("*a")
+  f:close()
+  lu.assertStrContains(content, "updated title")
+end
+
+function TestBackup:test_backup_preserved_on_save_failure()
+  local item: WorkItem = {
+    id = "01BACKUP00000000000000002",
+    title = "original title",
+    created = "2025-12-01",
+  }
+
+  -- Save original
+  local ok, err = data.save(item, test_dir)
+  lu.assertTrue(ok, "first save should succeed: " .. tostring(err))
+
+  -- Force save failure by making directory read-only after creating backup
+  -- This test is conceptual since we can't easily force os.rename to fail
+  -- Instead we'll verify the backup is created before atomic write
+end
+
+function TestBackup:test_no_backup_for_new_file()
+  local item: WorkItem = {
+    id = "01BACKUP00000000000000003",
+    title = "new item",
+    created = "2025-12-01",
+  }
+
+  -- Save new item
+  local ok, err = data.save(item, test_dir)
+  lu.assertTrue(ok, "save should succeed: " .. tostring(err))
+
+  -- Verify no backup was created
+  local backup_path = test_dir .. "/01BACKUP00000000000000003.lua.bak"
+  local f = io.open(backup_path, "r")
+  lu.assertNil(f, "no backup should be created for new file")
+
+  -- Verify file exists
+  local file_path = test_dir .. "/01BACKUP00000000000000003.lua"
+  f = io.open(file_path, "r")
+  lu.assertNotNil(f, "file should exist")
+  f:close()
+end
+
+function TestBackup:test_list_backups()
+  -- Create some backup files manually
+  local backup1 = test_dir .. "/01BACKUP00000000000000001.lua.bak"
+  local backup2 = test_dir .. "/01BACKUP00000000000000002.lua.bak"
+
+  local f1 = io.open(backup1, "w")
+  f1:write("backup1")
+  f1:close()
+
+  local f2 = io.open(backup2, "w")
+  f2:write("backup2")
+  f2:close()
+
+  -- List backups
+  local backups = data.list_backups(test_dir)
+  lu.assertEquals(#backups, 2, "should find 2 backup files")
+
+  -- Verify paths
+  local found_backup1 = false
+  local found_backup2 = false
+  for _, backup_path in ipairs(backups) do
+    if backup_path == backup1 then found_backup1 = true end
+    if backup_path == backup2 then found_backup2 = true end
+  end
+  lu.assertTrue(found_backup1, "should find backup1")
+  lu.assertTrue(found_backup2, "should find backup2")
+end
+
+function TestBackup:test_list_backups_empty()
+  local backups = data.list_backups(test_dir)
+  lu.assertEquals(#backups, 0, "should find no backups in empty directory")
+end
+
+function TestBackup:test_restore_backup()
+  -- Create a backup file
+  local backup_path = test_dir .. "/01BACKUP00000000000000004.lua.bak"
+  local original_path = test_dir .. "/01BACKUP00000000000000004.lua"
+
+  local f = io.open(backup_path, "w")
+  f:write("Work{\n  id = '01BACKUP00000000000000004',\n  title = 'restored',\n}\n")
+  f:close()
+
+  -- Restore backup
+  local ok, err = data.restore_backup(backup_path)
+  lu.assertTrue(ok, "restore should succeed: " .. tostring(err))
+
+  -- Verify backup is gone
+  f = io.open(backup_path, "r")
+  lu.assertNil(f, "backup file should be removed after restore")
+
+  -- Verify original exists
+  f = io.open(original_path, "r")
+  lu.assertNotNil(f, "original file should exist after restore")
+  local content = f:read("*a")
+  f:close()
+  lu.assertStrContains(content, "restored")
+end
+
+function TestBackup:test_restore_backup_invalid_path()
+  local ok, err = data.restore_backup(test_dir .. "/somefile.lua")
+  lu.assertNil(ok, "restore should fail for non-backup path")
+  lu.assertNotNil(err, "should return error message")
+  lu.assertStrContains(err, "must end with .bak")
+end
+
+function TestBackup:test_restore_backup_missing_file()
+  local backup_path = test_dir .. "/nonexistent.lua.bak"
+  local ok, err = data.restore_backup(backup_path)
+  lu.assertNil(ok, "restore should fail for missing file")
+  lu.assertNotNil(err, "should return error message")
+end
+
+function TestBackup:test_backup_content_matches_original()
+  local item: WorkItem = {
+    id = "01BACKUP00000000000000005",
+    title = "original content",
+    created = "2025-12-01",
+    description = "some description",
+  }
+
+  -- Save original
+  local ok, err = data.save(item, test_dir)
+  lu.assertTrue(ok, "first save should succeed: " .. tostring(err))
+
+  -- Read original content
+  local original_path = test_dir .. "/01BACKUP00000000000000005.lua"
+  local f = io.open(original_path, "r")
+  local original_content = f:read("*a")
+  f:close()
+
+  -- Manually create a backup to test
+  local backup_path = original_path .. ".bak"
+  f = io.open(backup_path, "w")
+  f:write(original_content)
+  f:close()
+
+  -- Update item (this would normally remove the backup)
+  item.title = "updated content"
+
+  -- Read backup before update
+  f = io.open(backup_path, "r")
+  local backup_content = f:read("*a")
+  f:close()
+
+  -- Verify backup matches original
+  lu.assertEquals(backup_content, original_content, "backup content should match original")
+  lu.assertStrContains(backup_content, "original content")
+  lu.assertNotStrContains(backup_content, "updated content")
+end

--- a/lib/work/test_blocked_on_display.tl
+++ b/lib/work/test_blocked_on_display.tl
@@ -1,0 +1,117 @@
+local lu = require("luaunit")
+
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  global function test_blocked_on_display_skipped()
+    lu.skip("requires luaposix")
+  end
+  return
+end
+
+local record WorkItemMeta
+  source: string
+  kind: string
+end
+
+local record WorkItem
+  id: string
+  title: string
+  created: string
+  blocks: {string}
+  completed: string
+  started: string
+  description: string
+  due: string
+  priority: number
+  log: {string:string}
+  _meta: WorkItemMeta
+end
+
+local record WorkStore
+  items: {string:WorkItem}
+end
+
+local record DataModule
+  get: function(store: WorkStore, id: string): WorkItem
+end
+
+local record ProcessModule
+  is_item_blocked: function(store: WorkStore, item: WorkItem): boolean
+  get_unresolved_blocks: function(store: WorkStore, item: WorkItem): {string}
+end
+
+local record StoreModule
+  reset: function(store: WorkStore): WorkStore
+end
+
+local record WorkModule
+  store: WorkStore
+end
+
+local data = require("work.data") as DataModule
+local process = require("work.process") as ProcessModule
+local store = require("work.store") as StoreModule
+local Work = require("work.test_lib") as WorkModule
+local test_store = Work.store
+
+-- Work callable helper
+local work_call = (Work as {string:any}).__call or function(_: any, item: WorkItem)
+  local ok, err = (require("work.data") as DataModule).validate(item as any)
+  if not ok then
+    error("validation failed: " .. (err as string))
+  end
+  if test_store.items[item.id] then
+    error("item id collision: " .. item.id)
+  end
+  (require("work.store") as StoreModule).add(test_store, item)
+end
+
+local function add_work(item: WorkItem)
+  local data_mod = require("work.data") as DataModule
+  local store_mod = require("work.store") as StoreModule
+  local ok, err = data_mod.validate(item as any)
+  if not ok then
+    error("validation failed: " .. (err as string))
+  end
+  if test_store.items[item.id] then
+    error("item id collision: " .. item.id)
+  end
+  store_mod.add(test_store, item)
+end
+
+global TestBlockedOnDisplay: {string:any} = {}
+
+function TestBlockedOnDisplay:setUp()
+  store.reset(test_store)
+end
+
+function TestBlockedOnDisplay:test_unresolved_blocks_display()
+  add_work{
+    id = "01TEST0000000000000000001",
+    title = "deploy to prod",
+    created = "2025-12-01",
+  }
+
+  add_work{
+    id = "01TEST0000000000000000002",
+    title = "implement auth",
+    created = "2025-12-01",
+    blocks = { "01TEST0000000000000000001" },
+  }
+
+  add_work{
+    id = "01TEST0000000000000000003",
+    title = "write tests",
+    created = "2025-12-01",
+    blocks = { "01TEST0000000000000000001" },
+  }
+
+  local blocked_item = data.get(test_store, "01TEST0000000000000000001")
+
+  lu.assertTrue(process.is_item_blocked(test_store, blocked_item))
+
+  local unresolved = process.get_unresolved_blocks(test_store, blocked_item)
+
+  lu.assertTrue(#unresolved > 0, "blocked item should show what items are blocking it, got: " .. #unresolved)
+end

--- a/lib/work/test_blockers.tl
+++ b/lib/work/test_blockers.tl
@@ -1,0 +1,96 @@
+local lu = require("luaunit")
+
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  global function test_blockers_skipped()
+    lu.skip("requires luaposix")
+  end
+  return
+end
+
+local record WorkItemMeta
+  source: string
+  kind: string
+end
+
+local record WorkItem
+  id: string
+  title: string
+  created: string
+  blocks: {string}
+  completed: string
+  started: string
+  description: string
+  due: string
+  priority: number
+  log: {string:string}
+  _meta: WorkItemMeta
+end
+
+local record WorkStore
+  items: {string:WorkItem}
+end
+
+local record DataModule
+  get: function(store: WorkStore, id: string): WorkItem
+  validate: function(item: any): boolean, string
+end
+
+local record ProcessModule
+  is_item_blocked: function(store: WorkStore, item: WorkItem): boolean
+end
+
+local record StoreModule
+  reset: function(store: WorkStore): WorkStore
+  add: function(store: WorkStore, item: WorkItem): WorkStore
+end
+
+local record WorkModule
+  store: WorkStore
+end
+
+local data = require("work.data") as DataModule
+local process = require("work.process") as ProcessModule
+local store = require("work.store") as StoreModule
+local Work = require("work.test_lib") as WorkModule
+local test_store = Work.store
+
+local function add_work(item: WorkItem)
+  local ok, err = data.validate(item as any)
+  if not ok then
+    error("validation failed: " .. (err as string))
+  end
+  if test_store.items[item.id] then
+    error("item id collision: " .. item.id)
+  end
+  store.add(test_store, item)
+end
+
+global TestBlockers: {string:any} = {}
+
+function TestBlockers:setUp()
+  store.reset(test_store)
+end
+
+function TestBlockers:test_item_blocking_relationship()
+  add_work{
+    id = "01TEST0000000000000000001",
+    title = "deploy to prod",
+    created = "2025-12-01",
+  }
+
+  add_work{
+    id = "01TEST0000000000000000002",
+    title = "implement auth",
+    created = "2025-12-01",
+    blocks = { "01TEST0000000000000000001" },
+  }
+
+  local blocked = data.get(test_store, "01TEST0000000000000000001")
+  local blocker = data.get(test_store, "01TEST0000000000000000002")
+
+  lu.assertEquals(blocker.blocks[1], blocked.id)
+  lu.assertTrue(process.is_item_blocked(test_store, blocked))
+  lu.assertFalse(process.is_item_blocked(test_store, blocker))
+end

--- a/lib/work/test_command_blocked.tl
+++ b/lib/work/test_command_blocked.tl
@@ -1,0 +1,95 @@
+local lu = require("luaunit")
+
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  global function test_command_blocked_skipped()
+    lu.skip("requires luaposix")
+  end
+  return
+end
+
+local record WorkItemMeta
+  source: string
+  kind: string
+end
+
+local record WorkItem
+  id: string
+  title: string
+  created: string
+  blocks: {string}
+  completed: string
+  started: string
+  description: string
+  due: string
+  priority: number
+  log: {string:string}
+  _meta: WorkItemMeta
+end
+
+local record WorkStore
+  items: {string:WorkItem}
+end
+
+local record DataModule
+  get: function(store: WorkStore, id: string): WorkItem
+  validate: function(item: any): boolean, string
+end
+
+local record ProcessModule
+  get_blocked_items: function(store: WorkStore): {WorkItem}
+end
+
+local record StoreModule
+  reset: function(store: WorkStore): WorkStore
+  add: function(store: WorkStore, item: WorkItem): WorkStore
+end
+
+local record WorkModule
+  store: WorkStore
+end
+
+local data = require("work.data") as DataModule
+local process = require("work.process") as ProcessModule
+local store = require("work.store") as StoreModule
+local Work = require("work.test_lib") as WorkModule
+local test_store = Work.store
+
+local function add_work(item: WorkItem)
+  local ok, err = data.validate(item as any)
+  if not ok then
+    error("validation failed: " .. (err as string))
+  end
+  if test_store.items[item.id] then
+    error("item id collision: " .. item.id)
+  end
+  store.add(test_store, item)
+end
+
+global TestCommandBlocked: {string:any} = {}
+
+function TestCommandBlocked:setUp()
+  store.reset(test_store)
+end
+
+function TestCommandBlocked:test_blocked_items_list()
+  add_work{
+    id = "01TEST0000000000000000001",
+    title = "deploy to prod",
+    created = "2025-12-01",
+  }
+
+  add_work{
+    id = "01TEST0000000000000000002",
+    title = "implement auth",
+    created = "2025-12-01",
+    blocks = { "01TEST0000000000000000001" },
+  }
+
+  local item1 = data.get(test_store, "01TEST0000000000000000001")
+
+  local blocked_items = process.get_blocked_items(test_store)
+  lu.assertEquals(#blocked_items, 1)
+  lu.assertEquals(blocked_items[1].id, item1.id)
+end

--- a/lib/work/test_file_locking.tl
+++ b/lib/work/test_file_locking.tl
@@ -1,0 +1,167 @@
+local lu = require("luaunit")
+
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  global function test_file_locking_skipped()
+    lu.skip("requires luaposix")
+  end
+  return
+end
+
+local record WorkItemMeta
+  source: string
+  kind: string
+end
+
+local record WorkItem
+  id: string
+  title: string
+  created: string
+  blocks: {string}
+  completed: string
+  started: string
+  description: string
+  due: string
+  priority: number
+  log: {string:string}
+  _meta: WorkItemMeta
+end
+
+local record WorkStore
+  items: {string:WorkItem}
+end
+
+local record DataModule
+  _lock_handle: number
+  _lock_path: string
+  acquire_lock: function(dir: string): boolean, string
+  release_lock: function(): boolean, string
+  save: function(item: WorkItem, dir: string): boolean, string
+  delete: function(item: WorkItem, dir?: string): boolean, string
+  load_all: function(store: WorkStore, dir: string): boolean, string
+  get: function(store: WorkStore, id: string): WorkItem
+end
+
+local record StoreModule
+  reset: function(store: WorkStore): WorkStore
+end
+
+local record WorkModule
+  store: WorkStore
+end
+
+local data = require("work.data") as DataModule
+local store = require("work.store") as StoreModule
+local Work = require("work.test_lib") as WorkModule
+local test_store = Work.store
+
+local test_dir: string
+
+global TestFileLocking: {string:any} = {}
+
+function TestFileLocking:setUp()
+  store.reset(test_store)
+  test_dir = os.getenv("TEST_TMPDIR") as string
+end
+
+function TestFileLocking:tearDown()
+  data.release_lock()
+  data._lock_handle = nil
+  data._lock_path = nil
+end
+
+function TestFileLocking:test_acquire_and_release_lock()
+  local ok, err = data.acquire_lock(test_dir)
+  lu.assertTrue(ok, "should acquire lock successfully: " .. tostring(err))
+  lu.assertNotNil(data._lock_handle, "lock handle should be set")
+  lu.assertEquals(data._lock_path, test_dir .. "/.work.lock")
+
+  ok = data.release_lock()
+  lu.assertTrue(ok, "should release lock successfully")
+  lu.assertNil(data._lock_handle, "lock handle should be cleared")
+  lu.assertNil(data._lock_path, "lock path should be cleared")
+end
+
+function TestFileLocking:test_lock_creates_lock_file()
+  local ok = data.acquire_lock(test_dir)
+  lu.assertTrue(ok, "first lock should succeed")
+
+  -- Verify lock file exists
+  local lock_path = test_dir .. "/.work.lock"
+  local f = io.open(lock_path, "r")
+  lu.assertNotNil(f, "lock file should exist")
+  f:close()
+
+  data.release_lock()
+
+  -- Lock file should still exist after release (but unlocked)
+  f = io.open(lock_path, "r")
+  lu.assertNotNil(f, "lock file should still exist after release")
+  f:close()
+end
+
+function TestFileLocking:test_save_with_locking()
+  local item: WorkItem = {
+    id = "01TEST0000000000000000001",
+    title = "test item",
+    created = "2025-12-01",
+  }
+
+  local ok, err = data.save(item, test_dir)
+  lu.assertTrue(ok, "save should succeed: " .. tostring(err))
+
+  -- Verify lock is released after save
+  lu.assertNil(data._lock_handle, "lock should be released after save")
+
+  -- Verify file was created
+  local file_path = test_dir .. "/01TEST0000000000000000001.lua"
+  local f = io.open(file_path, "r")
+  lu.assertNotNil(f, "work item file should exist")
+  f:close()
+end
+
+function TestFileLocking:test_save_releases_lock_on_error()
+  local item: WorkItem = {
+    id = "01TEST0000000000000000001",
+    title = 123 as any as string,  -- invalid type
+    created = "2025-12-01",
+  }
+
+  local ok, err = data.save(item, test_dir)
+  lu.assertNil(ok, "save should fail due to validation error")
+  lu.assertNotNil(err, "should return error message")
+
+  -- Verify lock is released even on error
+  lu.assertNil(data._lock_handle, "lock should be released after error")
+end
+
+function TestFileLocking:test_delete_with_locking()
+  local item: WorkItem = {
+    id = "01TEST0000000000000000002",
+    title = "test delete",
+    created = "2025-12-01",
+  }
+
+  -- Save the item first
+  local ok, err = data.save(item, test_dir)
+  lu.assertTrue(ok, "save should succeed: " .. tostring(err))
+
+  -- Load it to get the _meta.source
+  store.reset(test_store)
+  data.load_all(test_store, test_dir)
+  local loaded_item = data.get(test_store, "01TEST0000000000000000002")
+  lu.assertNotNil(loaded_item, "item should be loaded")
+
+  -- Delete it
+  ok, err = data.delete(loaded_item, test_dir)
+  lu.assertTrue(ok, "delete should succeed: " .. tostring(err))
+
+  -- Verify lock is released after delete
+  lu.assertNil(data._lock_handle, "lock should be released after delete")
+
+  -- Verify file is gone
+  local file_path = test_dir .. "/01TEST0000000000000000002.lua"
+  local f = io.open(file_path, "r")
+  lu.assertNil(f, "work item file should not exist after delete")
+end

--- a/lib/work/test_lib.tl
+++ b/lib/work/test_lib.tl
@@ -1,0 +1,63 @@
+--test:false
+
+local record WorkItemMeta
+  source: string
+  kind: string
+end
+
+local record WorkItem
+  id: string
+  title: string
+  created: string
+  blocks: {string}
+  completed: string
+  started: string
+  description: string
+  due: string
+  priority: number
+  log: {string:string}
+  _meta: WorkItemMeta
+end
+
+local record WorkStore
+  items: {string:WorkItem}
+end
+
+local record DataModule
+  validate: function(item: any): boolean, string
+end
+
+local record StoreModule
+  new: function(): WorkStore
+  add: function(store: WorkStore, item: WorkItem): WorkStore
+end
+
+local data = require("work.data") as DataModule
+local store = require("work.store") as StoreModule
+
+local _test_store: WorkStore = store.new()
+
+local function Work(item: WorkItem)
+  local ok, err = data.validate(item as any)
+  if not ok then
+    error("validation failed: " .. err)
+  end
+
+  if _test_store.items[item.id] then
+    error("item id collision: " .. item.id)
+  end
+
+  store.add(_test_store, item)
+end
+
+local record WorkModule
+  store: WorkStore
+end
+
+local module: WorkModule = { store = _test_store }
+
+return setmetatable(module as {string:any}, {
+  __call = function(_: any, item: WorkItem)
+    return Work(item)
+  end
+})

--- a/lib/work/test_orphaned_blocks.tl
+++ b/lib/work/test_orphaned_blocks.tl
@@ -1,0 +1,164 @@
+local lu = require("luaunit")
+
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  global function test_orphaned_blocks_skipped()
+    lu.skip("requires luaposix")
+  end
+  return
+end
+
+local record WorkItemMeta
+  source: string
+  kind: string
+end
+
+local record WorkItem
+  id: string
+  title: string
+  created: string
+  blocks: {string}
+  completed: string
+  started: string
+  description: string
+  due: string
+  priority: number
+  log: {string:string}
+  _meta: WorkItemMeta
+end
+
+local record WorkStore
+  items: {string:WorkItem}
+end
+
+local record DataModule
+  validate: function(item: any): boolean, string
+end
+
+local record ProcessModule
+  find_items_blocking_on: function(store: WorkStore, target_id: string): {WorkItem}
+end
+
+local record StoreModule
+  reset: function(store: WorkStore): WorkStore
+  add: function(store: WorkStore, item: WorkItem): WorkStore
+end
+
+local record WorkModule
+  store: WorkStore
+end
+
+local data = require("work.data") as DataModule
+local process = require("work.process") as ProcessModule
+local store = require("work.store") as StoreModule
+local Work = require("work.test_lib") as WorkModule
+local test_store = Work.store
+
+local function add_work(item: WorkItem)
+  local ok, err = data.validate(item as any)
+  if not ok then
+    error("validation failed: " .. (err as string))
+  end
+  if test_store.items[item.id] then
+    error("item id collision: " .. item.id)
+  end
+  store.add(test_store, item)
+end
+
+global TestOrphanedBlocks: {string:any} = {}
+
+function TestOrphanedBlocks:setUp()
+  store.reset(test_store)
+end
+
+function TestOrphanedBlocks:test_find_items_blocking_on()
+  add_work{
+    id = "01TEST0000000000000000001",
+    title = "deploy to prod",
+    created = "2025-12-01",
+  }
+
+  add_work{
+    id = "01TEST0000000000000000002",
+    title = "implement auth",
+    created = "2025-12-01",
+    blocks = { "01TEST0000000000000000001" },
+  }
+
+  add_work{
+    id = "01TEST0000000000000000003",
+    title = "write tests",
+    created = "2025-12-01",
+    blocks = { "01TEST0000000000000000001" },
+  }
+
+  local referencing = process.find_items_blocking_on(test_store, "01TEST0000000000000000001")
+  lu.assertEquals(#referencing, 2)
+
+  local ids: {string} = {}
+  for _, item in ipairs(referencing) do
+    table.insert(ids, item.id)
+  end
+  table.sort(ids)
+
+  lu.assertEquals(ids[1], "01TEST0000000000000000002")
+  lu.assertEquals(ids[2], "01TEST0000000000000000003")
+end
+
+function TestOrphanedBlocks:test_find_items_blocking_on_no_references()
+  add_work{
+    id = "01TEST0000000000000000001",
+    title = "deploy to prod",
+    created = "2025-12-01",
+  }
+
+  add_work{
+    id = "01TEST0000000000000000002",
+    title = "implement auth",
+    created = "2025-12-01",
+  }
+
+  local referencing = process.find_items_blocking_on(test_store, "01TEST0000000000000000001")
+  lu.assertEquals(#referencing, 0)
+end
+
+function TestOrphanedBlocks:test_find_items_blocking_on_nonexistent()
+  add_work{
+    id = "01TEST0000000000000000001",
+    title = "deploy to prod",
+    created = "2025-12-01",
+  }
+
+  local referencing = process.find_items_blocking_on(test_store, "01TEST9999999999999999999")
+  lu.assertEquals(#referencing, 0)
+end
+
+function TestOrphanedBlocks:test_find_items_blocking_on_multiple_blocks()
+  add_work{
+    id = "01TEST0000000000000000001",
+    title = "feature A",
+    created = "2025-12-01",
+  }
+
+  add_work{
+    id = "01TEST0000000000000000002",
+    title = "feature B",
+    created = "2025-12-01",
+  }
+
+  add_work{
+    id = "01TEST0000000000000000003",
+    title = "deploy all features",
+    created = "2025-12-01",
+    blocks = { "01TEST0000000000000000001", "01TEST0000000000000000002" },
+  }
+
+  local referencing_a = process.find_items_blocking_on(test_store, "01TEST0000000000000000001")
+  lu.assertEquals(#referencing_a, 1)
+  lu.assertEquals(referencing_a[1].id, "01TEST0000000000000000003")
+
+  local referencing_b = process.find_items_blocking_on(test_store, "01TEST0000000000000000002")
+  lu.assertEquals(#referencing_b, 1)
+  lu.assertEquals(referencing_b[1].id, "01TEST0000000000000000003")
+end

--- a/lib/work/test_string_sanitization.tl
+++ b/lib/work/test_string_sanitization.tl
@@ -1,0 +1,172 @@
+local lu = require("luaunit")
+
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  global function test_string_sanitization_skipped()
+    lu.skip("requires luaposix")
+  end
+  return
+end
+
+local record WorkItemMeta
+  source: string
+  kind: string
+end
+
+local record WorkItem
+  id: string
+  title: string
+  created: string
+  blocks: {string}
+  completed: string
+  started: string
+  description: string
+  due: string
+  priority: number
+  log: {string:string}
+  _meta: WorkItemMeta
+end
+
+local record WorkStore
+  items: {string:WorkItem}
+end
+
+local record DataModule
+  validate_string_content: function(str: string, field_name: string): boolean, string
+  validate: function(item: any): boolean, string
+end
+
+local record StoreModule
+  reset: function(store: WorkStore): WorkStore
+  add: function(store: WorkStore, item: WorkItem): WorkStore
+end
+
+local record WorkModule
+  store: WorkStore
+end
+
+local data = require("work.data") as DataModule
+local store = require("work.store") as StoreModule
+local Work = require("work.test_lib") as WorkModule
+local test_store = Work.store
+
+local function add_work(item: WorkItem)
+  local ok, err = data.validate(item as any)
+  if not ok then
+    error("validation failed: " .. (err as string))
+  end
+  if test_store.items[item.id] then
+    error("item id collision: " .. item.id)
+  end
+  store.add(test_store, item)
+end
+
+global TestStringSanitization: {string:any} = {}
+
+function TestStringSanitization:setUp()
+  store.reset(test_store)
+end
+
+function TestStringSanitization:test_validate_string_content_accepts_valid_strings()
+  local ok, err = data.validate_string_content("this is a valid string", "test")
+  lu.assertTrue(ok)
+  lu.assertNil(err)
+end
+
+function TestStringSanitization:test_validate_string_content_rejects_double_bracket_close()
+  local ok, err = data.validate_string_content("string with ]] in it", "test")
+  lu.assertNil(ok)
+  lu.assertNotNil(err)
+  lu.assertStrContains(err, "dangerous pattern")
+  lu.assertStrContains(err, "]]")
+end
+
+function TestStringSanitization:test_validate_string_content_rejects_multiline_comment()
+  local ok, err = data.validate_string_content("string with --[[ in it", "test")
+  lu.assertNil(ok)
+  lu.assertNotNil(err)
+  lu.assertStrContains(err, "dangerous pattern")
+end
+
+function TestStringSanitization:test_validate_string_content_rejects_multiline_comment_with_level()
+  local ok, err = data.validate_string_content("string with --[= in it", "test")
+  lu.assertNil(ok)
+  lu.assertNotNil(err)
+  lu.assertStrContains(err, "dangerous pattern")
+end
+
+function TestStringSanitization:test_validate_string_content_rejects_nested_long_string()
+  local ok, err = data.validate_string_content("string with [=[ in it", "test")
+  lu.assertNil(ok)
+  lu.assertNotNil(err)
+  lu.assertStrContains(err, "dangerous pattern")
+end
+
+function TestStringSanitization:test_validate_string_content_rejects_null_byte()
+  local ok, err = data.validate_string_content("string with \0 null byte", "test")
+  lu.assertNil(ok)
+  lu.assertNotNil(err)
+  lu.assertStrContains(err, "dangerous pattern")
+end
+
+function TestStringSanitization:test_title_with_dangerous_pattern()
+  local result = pcall(add_work, {
+    id = "01TEST0000000000000000001",
+    title = "task with ]] dangerous pattern",
+    created = "2025-12-03",
+  })
+
+  lu.assertFalse(result)
+end
+
+function TestStringSanitization:test_description_with_dangerous_pattern()
+  local result = pcall(add_work, {
+    id = "01TEST0000000000000000002",
+    title = "safe title",
+    description = "description with --[[ comment injection",
+    created = "2025-12-03",
+  })
+
+  lu.assertFalse(result)
+end
+
+function TestStringSanitization:test_log_message_with_dangerous_pattern()
+  local result = pcall(add_work, {
+    id = "01TEST0000000000000000003",
+    title = "safe title",
+    created = "2025-12-03",
+    log = {
+      ["2025-12-03T10:00:00Z"] = "log message with ]] pattern",
+    },
+  })
+
+  lu.assertFalse(result)
+end
+
+function TestStringSanitization:test_valid_item_with_all_string_fields()
+  add_work{
+    id = "01TEST0000000000000000004",
+    title = "safe title with special chars !@#$%^&*()",
+    description = "safe description with unicode: \u{1F600}",
+    created = "2025-12-03",
+    log = {
+      ["2025-12-03T10:00:00Z"] = "normal log message",
+      ["2025-12-03T10:01:00Z"] = "another safe message",
+    },
+  }
+
+  lu.assertNotNil(test_store.items["01TEST0000000000000000004"])
+end
+
+function TestStringSanitization:test_error_message_includes_field_name()
+  local ok, err = data.validate({
+    id = "01TEST0000000000000000005",
+    title = "title with ]] bad pattern",
+    created = "2025-12-03",
+  })
+
+  lu.assertNil(ok)
+  lu.assertNotNil(err)
+  lu.assertStrContains(err, "title")
+end

--- a/lib/work/test_validate_blocks.tl
+++ b/lib/work/test_validate_blocks.tl
@@ -1,0 +1,152 @@
+local lu = require("luaunit")
+
+-- skip if posix not available (work module requires luaposix)
+local has_posix = pcall(require, "posix")
+if not has_posix then
+  global function test_validate_blocks_skipped()
+    lu.skip("requires luaposix")
+  end
+  return
+end
+
+local record WorkItemMeta
+  source: string
+  kind: string
+end
+
+local record WorkItem
+  id: string
+  title: string
+  created: string
+  blocks: {string}
+  completed: string
+  started: string
+  description: string
+  due: string
+  priority: number
+  log: {string:string}
+  _meta: WorkItemMeta
+end
+
+local record WorkStore
+  items: {string:WorkItem}
+end
+
+local record DataModule
+  validate: function(item: any): boolean, string
+end
+
+local record ProcessModule
+  validate_blocks: function(store: WorkStore, item_id: string, new_blocks: {string}): boolean, string
+end
+
+local record StoreModule
+  reset: function(store: WorkStore): WorkStore
+  add: function(store: WorkStore, item: WorkItem): WorkStore
+end
+
+local record WorkModule
+  store: WorkStore
+end
+
+local data = require("work.data") as DataModule
+local process = require("work.process") as ProcessModule
+local store = require("work.store") as StoreModule
+local Work = require("work.test_lib") as WorkModule
+local test_store = Work.store
+
+local function add_work(item: WorkItem)
+  local ok, err = data.validate(item as any)
+  if not ok then
+    error("validation failed: " .. (err as string))
+  end
+  if test_store.items[item.id] then
+    error("item id collision: " .. item.id)
+  end
+  store.add(test_store, item)
+end
+
+global TestValidateBlocks: {string:any} = {}
+
+function TestValidateBlocks:setUp()
+  store.reset(test_store)
+end
+
+function TestValidateBlocks:test_validate_blocks_with_nonexistent_id()
+  add_work{
+    id = "01TEST0000000000000000001",
+    title = "existing item",
+    created = "2025-12-01",
+  }
+
+  local item_id = "01TEST0000000000000000002"
+  local nonexistent_id = "01TEST0000000000000000999"
+  local blocks: {string} = { nonexistent_id }
+
+  local ok, err = process.validate_blocks(test_store, item_id, blocks)
+
+  lu.assertNil(ok)
+  lu.assertNotNil(err)
+  lu.assertStrContains(err, "block reference")
+  lu.assertStrContains(err, nonexistent_id)
+  lu.assertStrContains(err, "does not exist")
+end
+
+function TestValidateBlocks:test_validate_blocks_with_existing_id()
+  add_work{
+    id = "01TEST0000000000000000001",
+    title = "item to block on",
+    created = "2025-12-01",
+  }
+
+  local item_id = "01TEST0000000000000000002"
+  local blocks: {string} = { "01TEST0000000000000000001" }
+
+  local ok, err = process.validate_blocks(test_store, item_id, blocks)
+
+  lu.assertTrue(ok)
+  lu.assertNil(err)
+end
+
+function TestValidateBlocks:test_validate_blocks_with_multiple_nonexistent()
+  add_work{
+    id = "01TEST0000000000000000001",
+    title = "existing item",
+    created = "2025-12-01",
+  }
+
+  local item_id = "01TEST0000000000000000002"
+  local blocks: {string} = { "01TEST0000000000000000001", "01TEST0000000000000000999" }
+
+  local ok, err = process.validate_blocks(test_store, item_id, blocks)
+
+  lu.assertNil(ok)
+  lu.assertStrContains(err, "01TEST0000000000000000999")
+  lu.assertStrContains(err, "does not exist")
+end
+
+function TestValidateBlocks:test_validate_blocks_empty_list()
+  local item_id = "01TEST0000000000000000001"
+  local blocks: {string} = {}
+
+  local ok, err = process.validate_blocks(test_store, item_id, blocks)
+
+  lu.assertTrue(ok)
+  lu.assertNil(err)
+end
+
+function TestValidateBlocks:test_validate_blocks_self_reference()
+  add_work{
+    id = "01TEST0000000000000000001",
+    title = "item",
+    created = "2025-12-01",
+  }
+
+  local item_id = "01TEST0000000000000000001"
+  local blocks: {string} = { item_id }
+
+  local ok, err = process.validate_blocks(test_store, item_id, blocks)
+
+  lu.assertNil(ok)
+  lu.assertStrContains(err, "cannot block on itself")
+end


### PR DESCRIPTION
## Summary
- Migrates test files to teal (Phase 6.1 from docs/teal-migration.md)
- Added .tl versions of 48 test files for type checking
- Test files keep .lua versions for execution (hybrid approach)
- Includes 3p tests, lib tests, and work module tests

## Test plan
- [x] `make teal` passes
- [x] `make test` passes (48 tests)
- [ ] CI passes