### PR TITLE
tests: migrate phase 6.2 test utilities to teal

### DIFF
--- a/3p/luacheck/test.tl
+++ b/3p/luacheck/test.tl
@@ -1,0 +1,19 @@
+local lu = require("luaunit")
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+local record SpawnHandle
+  wait: function(self: SpawnHandle): number
+end
+
+global TEST_BIN_DIR: string
+
+local bin = path.join(os.getenv("TEST_BIN_DIR") as string, "bin", "luacheck")
+
+global TestLuacheck: {string: function()}
+TestLuacheck = {}
+
+function TestLuacheck.test_version()
+  local handle = spawn({ bin, "--version" }) as SpawnHandle
+  lu.assertEquals(handle:wait(), 0)
+end

--- a/3p/nvim-parsers/install.tl
+++ b/3p/nvim-parsers/install.tl
@@ -1,0 +1,163 @@
+#!/usr/bin/env lua
+-- Installs treesitter parsers
+-- Usage: install.lua <nvim_staged> <treesitter_staged> <output_dir> <parsers_config>
+
+local cosmo = require("cosmo")
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+local spawn = require("cosmic.spawn")
+
+local record SpawnHandle
+  stdin: file
+  stdout: file
+  stderr: file
+  wait: function(self: SpawnHandle): number
+  read: function(self: SpawnHandle): boolean | string
+end
+
+local record SpawnOpts
+  env: {string}
+end
+
+local record InstallModule
+  install: function(nvim_staged: string, treesitter_staged: string, output_dir: string, parsers_config: string, tree_sitter_staged: string, target: string): boolean, string
+end
+
+local function install(nvim_staged: string, treesitter_staged: string, output_dir: string, parsers_config: string, tree_sitter_staged: string, target: string): boolean, string
+  local nvim_bin = path.join(nvim_staged, "bin/nvim")
+
+  -- Collect verbose output, only print on error
+  local log: {string} = {}
+  local function log_write(msg: string)
+    table.insert(log, msg)
+  end
+
+  log_write(string.format("nvim-parsers: nvim_bin=%s\n", nvim_bin))
+  log_write(string.format("nvim-parsers: treesitter_staged=%s\n", treesitter_staged))
+  log_write(string.format("nvim-parsers: output_dir=%s\n", output_dir))
+  log_write(string.format("nvim-parsers: parsers_config=%s\n", parsers_config))
+  log_write(string.format("nvim-parsers: tree_sitter_staged=%s\n", tree_sitter_staged))
+
+  -- check nvim is executable
+  local handle = spawn({nvim_bin, "--version"}) as SpawnHandle
+  local ok = handle:read()
+  if not ok then
+    io.stderr:write("nvim-parsers: skipped (nvim not executable on this platform)\n")
+    return true
+  end
+  log_write("nvim-parsers: nvim is executable\n")
+
+  local cwd = unix.getcwd()
+  local parsers = dofile(parsers_config) as {string}
+  local cache_dir = path.join(cwd, output_dir, "cache")
+  unix.makedirs(cache_dir)
+
+  local abs_treesitter = path.join(cwd, treesitter_staged)
+  local abs_output = path.join(cwd, output_dir)
+  local script = string.format([[
+io.stderr:write("nvim-parsers-inner: starting\n")
+io.stderr:write("nvim-parsers-inner: PATH=" .. (vim.env.PATH or "nil"):sub(1, 200) .. "\n")
+vim.opt.runtimepath:prepend("%s")
+io.stderr:write("nvim-parsers-inner: rtp set\n")
+local ts = require("nvim-treesitter")
+io.stderr:write("nvim-parsers-inner: ts loaded\n")
+ts.setup({ install_dir = "%s" })
+io.stderr:write("nvim-parsers-inner: ts setup done\n")
+local task = ts.install({"%s"})
+io.stderr:write("nvim-parsers-inner: install called, waiting...\n")
+local ok, err = task:pwait(300000)
+io.stderr:write("nvim-parsers-inner: pwait returned ok=" .. tostring(ok) .. " err=" .. tostring(err) .. "\n")
+if ok then
+  vim.cmd("qall!")
+else
+  io.stderr:write("pwait failed: " .. tostring(err) .. "\n")
+  vim.cmd("cquit 1")
+end
+]], abs_treesitter, abs_output, table.concat(parsers, '","'))
+  log_write(string.format("nvim-parsers: abs_treesitter=%s\n", abs_treesitter))
+  log_write(string.format("nvim-parsers: abs_output=%s\n", abs_output))
+
+  local script_path = path.join(cache_dir, "install.lua")
+  cosmo.Barf(script_path, script)
+
+  -- unix.environ() returns array of "KEY=VALUE" strings
+  -- helper to set or update an env var in the array
+  local function set_env(env: {string}, key: string, value: string)
+    local prefix = key .. "="
+    for i, entry in ipairs(env) do
+      if entry:sub(1, #prefix) == prefix then
+        env[i] = prefix .. value
+        return
+      end
+    end
+    table.insert(env, prefix .. value)
+  end
+
+  local function get_env(env: {string}, key: string): string
+    local prefix = key .. "="
+    for _, entry in ipairs(env) do
+      if entry:sub(1, #prefix) == prefix then
+        return entry:sub(#prefix + 1)
+      end
+    end
+    return nil
+  end
+
+  local env = unix.environ() as {string}
+  set_env(env, "XDG_CACHE_HOME", cache_dir)
+  set_env(env, "VIMRUNTIME", path.join(cwd, nvim_staged, "share/nvim/runtime"))
+  set_env(env, "VIM", path.join(cwd, nvim_staged, "share/nvim"))
+  if not get_env(env, "CC") then
+    set_env(env, "CC", "cc")
+  end
+
+  -- add tree-sitter CLI to PATH
+  if tree_sitter_staged then
+    local ts_bin = path.join(cwd, tree_sitter_staged, "bin")
+    local current_path = get_env(env, "PATH") or ""
+    set_env(env, "PATH", ts_bin .. ":" .. current_path)
+    log_write(string.format("nvim-parsers: tree-sitter added to PATH: %s\n", ts_bin))
+  else
+    log_write("nvim-parsers: WARNING: tree_sitter_staged not provided\n")
+  end
+
+  log_write("nvim-parsers: running nvim to install parsers\n")
+  handle = spawn({nvim_bin, "--headless", "-u", "NONE", "-l", script_path}, {env = env} as SpawnOpts) as SpawnHandle
+  -- read stderr before wait() since wait() drains and closes it
+  local stderr = handle.stderr:read()
+  local exit_code = handle:wait()
+  log_write(string.format("nvim-parsers: nvim exit_code=%s\n", tostring(exit_code)))
+  if stderr and stderr ~= "" then
+    log_write("nvim-parsers: nvim stderr:\n  " .. (stderr as string):gsub("\n", "\n  ") .. "\n")
+  end
+  if exit_code ~= 0 then
+    -- dump log on error
+    io.stderr:write(table.concat(log))
+    io.stderr:write("nvim-parsers: installation failed\n")
+    io.stderr:write(string.format("  script: %s\n", script_path))
+    io.stderr:write(string.format("  exit: %d\n", exit_code or -1))
+    return nil, "parser installation failed"
+  end
+  -- check what was created
+  local parser_dir = path.join(cwd, output_dir, "parser")
+  local st = unix.stat(parser_dir)
+  if st then
+    log_write(string.format("nvim-parsers: parser_dir exists: %s\n", parser_dir))
+  else
+    log_write(string.format("nvim-parsers: parser_dir MISSING: %s\n", parser_dir))
+  end
+
+  -- Print success message
+  local parser_count = #parsers
+  if target then
+    io.stderr:write(string.format("✓ BUILD  %s (nvim-parsers: %d parsers built)\n", target, parser_count))
+  end
+  return true
+end
+
+if cosmo.is_main() then
+  local install_ok = install(arg[1], arg[2], arg[3], arg[4], arg[5], arg[6])
+  if not install_ok then os.exit(1) end
+end
+
+return { install = install } as InstallModule

--- a/3p/tl/cook.mk
+++ b/3p/tl/cook.mk
@@ -12,3 +12,14 @@ teal_runner := $(bootstrap_cosmic) -- $(tl_run)
 
 # tl gen: compile .tl files to .lua (using wrapper script)
 tl_gen = TL_BIN=$(tl_staged) $(bootstrap_cosmic) -- $(tl_gen_script)
+
+# explicit rules for tl_files to avoid circular dependency
+# tl-gen.lua is copied from bootstrap .lua (doesn't need teal compilation)
+$(tl_gen_script): 3p/tl/tl-gen.lua | $(bootstrap_files)
+	@mkdir -p $(@D)
+	@cp -p $< $@
+
+# run-teal.lua is compiled from .tl using tl_gen (which only needs tl_gen_script)
+$(tl_run): 3p/tl/run-teal.tl $(types_files) $(tl_gen_script) $(bootstrap_files) $$(tl_staged)
+	@mkdir -p $(@D)
+	@$(tl_gen) $< -o $@

--- a/3p/tl/test.tl
+++ b/3p/tl/test.tl
@@ -1,0 +1,22 @@
+local luaunit = require("luaunit")
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+local record SpawnHandle
+  wait: function(self: SpawnHandle): number
+end
+
+global TEST_BIN_DIR: string
+
+local lua_dist = path.join((os.getenv("TEST_BIN_DIR") as string):gsub("/tl$", "/lua"), "bin", "lua.dist")
+local tl_bin = path.join(os.getenv("TEST_BIN_DIR") as string, "bin", "tl")
+
+global TestTeal: {string: function()}
+TestTeal = {}
+
+function TestTeal.test_version()
+  local handle = spawn({ lua_dist, tl_bin, "--version" }) as SpawnHandle
+  luaunit.assertEquals(handle:wait(), 0)
+end
+
+os.exit(luaunit.LuaUnit.run())

--- a/3p/tl/tl-gen.tl
+++ b/3p/tl/tl-gen.tl
@@ -1,0 +1,107 @@
+#!/usr/bin/env lua
+-- wrapper for tl gen that handles output directory
+--
+-- tl gen has a bug where the -o option doesn't work reliably.
+-- this wrapper runs tl gen (which creates output next to input),
+-- then moves the generated file to the desired output location.
+
+local cosmo = require("cosmo")
+local getopt = require("cosmo.getopt")
+local path = require("cosmo.path")
+local spawn = require("cosmic.spawn")
+
+local record SpawnHandle
+  stdin: file
+  stdout: file
+  stderr: file
+  wait: function(self: SpawnHandle): number
+end
+
+local record GetoptParser
+  next: function(self: GetoptParser): string, string
+  remaining: function(self: GetoptParser): {string}
+end
+
+local function main(...: string): number
+  local args = {...}
+  local output_file: string = nil
+
+  local longopts = {{"output", "required"}}
+  local parser = getopt.new(args, "o:", longopts) as GetoptParser
+
+  while true do
+    local opt, optarg = parser:next()
+    if not opt then break end
+    if opt == "o" or opt == "output" then
+      output_file = optarg
+    elseif opt == "?" then
+      io.stderr:write("usage: tl-gen.lua -o OUTPUT INPUT\n")
+      return 1
+    end
+  end
+
+  local remaining = parser:remaining()
+  local input_file = remaining and remaining[1]
+
+  if not input_file or not output_file then
+    io.stderr:write("usage: tl-gen.lua -o OUTPUT INPUT\n")
+    return 1
+  end
+
+  local tl_bin = path.join(os.getenv("TL_BIN") as string, "tl")
+
+  -- run tl gen from the repo root (where tlconfig.lua is)
+  -- tl gen creates the output file in cwd with just the basename
+  local handle = spawn({ tl_bin, "gen", input_file }) as SpawnHandle
+  if handle.stdin then
+    handle.stdin:close()
+  end
+  local stdout = handle.stdout and handle.stdout:read() or ""
+  local stderr = handle.stderr and handle.stderr:read() or ""
+  local exit_code = handle:wait()
+
+  if exit_code ~= 0 then
+    io.stderr:write(stderr as string)
+    return exit_code
+  end
+
+  -- tl gen creates output in cwd with just the basename
+  local input_basename = path.basename(input_file)
+  local generated_file = input_basename:gsub("%.tl$", ".lua")
+  if generated_file == output_file then
+    -- already in the right place
+    io.write(stdout as string)
+    return 0
+  end
+
+  -- move the generated file to the output location
+  local ok, _ = os.rename(generated_file, output_file)
+  if not ok then
+    -- rename failed (maybe cross-device), try copy + remove
+    local src = io.open(generated_file, "rb")
+    if not src then
+      io.stderr:write("failed to open generated file: " .. generated_file .. "\n")
+      return 1
+    end
+    local content = src:read("*a")
+    src:close()
+
+    local dst = io.open(output_file, "wb")
+    if not dst then
+      io.stderr:write("failed to create output file: " .. output_file .. "\n")
+      return 1
+    end
+    dst:write(content)
+    dst:close()
+
+    os.remove(generated_file)
+  end
+
+  io.write(stdout as string)
+  return 0
+end
+
+if cosmo.is_main() then
+  local code = main(...)
+  os.exit(code)
+end

--- a/lib/skill/test_pr_comments.tl
+++ b/lib/skill/test_pr_comments.tl
@@ -1,5 +1,3 @@
--- teal ignore: test file
-
 local pr_comments = require("skill.pr_comments")
 
 local record User

--- a/lib/test/run-test.tl
+++ b/lib/test/run-test.tl
@@ -1,0 +1,123 @@
+#!/usr/bin/env lua
+-- ast-grep ignore: test runner creates TEST_TMPDIR
+
+local cosmo = require("cosmo")
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
+
+global TEST_TMPDIR: string
+global TEST_DIR: string
+
+local function run_test(test: string): boolean, string, string, string
+  TEST_TMPDIR = unix.mkdtemp("/tmp/test_XXXXXX")
+  unix.setenv("TEST_TMPDIR", TEST_TMPDIR)
+  TEST_DIR = os.getenv("TEST_DIR")
+
+  -- create temp files for capturing output
+  local stdout_file = path.join(TEST_TMPDIR, "stdout")
+  local stderr_file = path.join(TEST_TMPDIR, "stderr")
+
+  -- save original fds (dup returns lowest available fd, so these go to 3+)
+  local orig_stdout = unix.dup(1)
+  local orig_stderr = unix.dup(2)
+
+  -- open capture files
+  local stdout_fd = unix.open(stdout_file, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("644", 8))
+  local stderr_fd = unix.open(stderr_file, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("644", 8))
+
+  -- redirect stdout: close fd 1, then dup stdout_fd (becomes 1)
+  unix.close(1)
+  unix.dup(stdout_fd)
+  unix.close(stdout_fd)
+
+  -- redirect stderr: close fd 2, then dup stderr_fd (becomes 2)
+  unix.close(2)
+  unix.dup(stderr_fd)
+  unix.close(stderr_fd)
+
+  -- run the test
+  local ok, err = pcall(dofile, test)
+
+  -- flush lua's io buffers before restoring fds
+  io.stdout:flush()
+  io.stderr:flush()
+
+  -- restore stdout: close fd 1, dup orig_stdout (becomes 1)
+  unix.close(1)
+  unix.dup(orig_stdout)
+  unix.close(orig_stdout)
+
+  -- restore stderr: close fd 2, dup orig_stderr (becomes 2)
+  unix.close(2)
+  unix.dup(orig_stderr)
+  unix.close(orig_stderr)
+
+  -- read captured output
+  local stdout = cosmo.Slurp(stdout_file) or ""
+  local stderr = cosmo.Slurp(stderr_file) or ""
+
+  unix.rmrf(TEST_TMPDIR)
+
+  return ok, err as string, stdout, stderr
+end
+
+local function write_result(status: string, message: string, stdout: string, stderr: string): number
+  local lines: {string} = {}
+  if message and message ~= "" then
+    table.insert(lines, status .. ": " .. message)
+  else
+    table.insert(lines, status)
+  end
+  table.insert(lines, "")
+  table.insert(lines, "## stdout")
+  table.insert(lines, "")
+  table.insert(lines, stdout)
+  table.insert(lines, "## stderr")
+  table.insert(lines, "")
+  table.insert(lines, stderr)
+  local output = table.concat(lines, "\n")
+  -- write all output to stdout for capture by make
+  io.write(output)
+  return status == "fail" and 1 or 0
+end
+
+local function main(test: string): number, string
+  if not test then
+    return 1, "usage: run-test.lua <test>"
+  end
+
+  local ok, err, stdout, stderr = run_test(test)
+
+  local status: string
+  local message: string
+  if ok then
+    status = "pass"
+  else
+    local err_str = tostring(err)
+    -- check for SKIP or IGNORE in error message
+    local skip_reason = err_str:match("SKIP%s+(.+)")
+    local ignore_reason = err_str:match("IGNORE%s+(.+)")
+    if skip_reason then
+      status = "skip"
+      message = skip_reason
+    elseif ignore_reason then
+      status = "ignore"
+      message = ignore_reason
+    else
+      status = "fail"
+      -- strip path prefix to show just filename:line: message
+      message = err_str:gsub("^.-/([^/]+:%d+:)", "%1")
+    end
+  end
+
+  return write_result(status, message, stdout, stderr)
+end
+
+if cosmo.is_main() then
+  -- TODO: use varargs once bootstrap cosmic is updated
+  local code, err = main(arg[1])
+  if err then
+    io.stderr:write(err .. "\n")
+  end
+  os.exit(code)
+end


### PR DESCRIPTION
## Summary
- Migrates test utilities to teal (Phase 6.2 from docs/teal-migration.md)
- Added .tl versions of test utility files:
  - lib/test/run-test.tl
  - 3p/luacheck/test.tl
  - 3p/tl/test.tl
  - 3p/tl/tl-gen.tl
  - 3p/nvim-parsers/install.tl

## Test plan
- [x] `make teal` passes
- [x] `make test` passes
- [ ] CI passes