### PR TITLE
home: fix race condition in nvim tl compilation

### DIFF
--- a/lib/home/cook.mk
+++ b/lib/home/cook.mk
@@ -30,7 +30,9 @@ home_nvim_tl_srcs := $(shell find .config/nvim -name '*.tl' 2>/dev/null)
 home_nvim_tl_compiled := $(patsubst %.tl,$(o)/%.lua,$(home_nvim_tl_srcs))
 
 # Compile nvim .tl configs to .lua
-$(o)/.config/nvim/%.lua: .config/nvim/%.tl $(tl_files) $(bootstrap_files) | $(tl_staged)
+# Uses secondary expansion so $(tl_files) is evaluated after all includes
+.SECONDEXPANSION:
+$(o)/.config/nvim/%.lua: .config/nvim/%.tl $$(tl_files) $$(bootstrap_files) | $$(tl_staged)
 	@mkdir -p $(@D)
 	@$(tl_gen) $< -o $@
 


### PR DESCRIPTION
## Summary
Use secondary expansion for the nvim .tl to .lua pattern rule so that $(tl_files) is evaluated after all cook.mk files are included.

Without this, $(tl_files) was empty when the rule was parsed because 3p/tl/cook.mk is included after lib/cook.mk.

## Test plan
- [x] `make test` passes
- [x] Parallel builds with `make -j4` work correctly