### PR TITLE
make: fix parallel build race with tl_gen dependencies

### DIFF
--- a/lib/aerosnap/cook.mk
+++ b/lib/aerosnap/cook.mk
@@ -6,7 +6,9 @@ lib_lua_modules += aerosnap
 lib_dirs += o/any/aerosnap/lib
 lib_libs += o/any/aerosnap/lib/aerosnap/init.lua
 
-o/any/aerosnap/lib/aerosnap/init.lua: lib/aerosnap/init.tl $(types_files) | $(tl_staged)
+# uses secondary expansion so $(tl_files) is evaluated after 3p/tl/cook.mk
+.SECONDEXPANSION:
+o/any/aerosnap/lib/aerosnap/init.lua: lib/aerosnap/init.tl $(types_files) $$(tl_files) | $$(tl_staged)
 	mkdir -p $(@D)
 	$(tl_gen) -o $@ $<
 

--- a/lib/claude/cook.mk
+++ b/lib/claude/cook.mk
@@ -5,7 +5,9 @@ lib_lua_modules += claude
 lib_dirs += o/any/claude/lib
 lib_libs += o/any/claude/lib/claude/main.lua
 
-o/any/claude/lib/claude/main.lua: lib/claude/main.tl $(types_files) | $(tl_staged)
+# uses secondary expansion so $(tl_files) is evaluated after 3p/tl/cook.mk
+.SECONDEXPANSION:
+o/any/claude/lib/claude/main.lua: lib/claude/main.tl $(types_files) $$(tl_files) | $$(tl_staged)
 	mkdir -p $(@D)
 	$(tl_gen) -o $@ $<
 

--- a/lib/cook.mk
+++ b/lib/cook.mk
@@ -18,7 +18,9 @@ o/any/lib/%.lua: lib/%.lua
 
 # compile .tl files to .lua (for o/any/lib, used by standalone modules)
 # tl_staged must be regular prereq (not order-only) for parallel builds
-o/any/lib/%.lua: lib/%.tl $(types_files) $(tl_staged)
+# uses secondary expansion so $(tl_files) is evaluated after 3p/tl/cook.mk
+.SECONDEXPANSION:
+o/any/lib/%.lua: lib/%.tl $(types_files) $$(tl_files) | $$(tl_staged)
 	mkdir -p $(@D)
 	$(tl_gen) -o $@ $<
 

--- a/lib/environ/cook.mk
+++ b/lib/environ/cook.mk
@@ -5,7 +5,9 @@ lib_lua_modules += environ
 lib_dirs += o/any/environ/lib
 lib_libs += o/any/environ/lib/environ/init.lua
 
-o/any/environ/lib/environ/init.lua: lib/environ/init.tl $(types_files) | $(tl_staged)
+# uses secondary expansion so $(tl_files) is evaluated after 3p/tl/cook.mk
+.SECONDEXPANSION:
+o/any/environ/lib/environ/init.lua: lib/environ/init.tl $(types_files) $$(tl_files) | $$(tl_staged)
 	mkdir -p $(@D)
 	$(tl_gen) -o $@ $<
 


### PR DESCRIPTION
## Summary
- Rules using `$(tl_gen)` need to depend on `$(tl_files)` which includes both the tl-gen.lua script and bootstrap_cosmic
- Without this, parallel builds could attempt to run tl_gen before the script exists, causing "No such file or directory" errors
- Use secondary expansion (`$$(tl_files)`) since `tl_files` is defined in `3p/tl/cook.mk` which is included after `lib/cook.mk`

## Test plan
- [x] Clean parallel build succeeds locally: `rm -rf o && bin/make -j o/any/aerosnap/lib/aerosnap/init.lua`
- [ ] PR CI build passes
- [ ] Release workflow succeeds