### PR TITLE
make: fix test rule to fail if tl compilation fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,8 @@ $(o)/%.test.ok: % $(test_files) $(checker_files) | $(bootstrap_files)
 	@mkdir -p $(@D)
 	@if [ "$(suffix $<)" = ".tl" ]; then \
 		compiled="$(o)/$(basename $<).lua"; \
-		$(MAKE) --no-print-directory "$$compiled"; \
-		[ -x "$$compiled" ] || chmod a+x "$$compiled"; \
+		$(MAKE) --no-print-directory "$$compiled" && \
+		{ [ -x "$$compiled" ] || chmod a+x "$$compiled"; } && \
 		TEST_DIR=$(TEST_DIR) $(test_runner) "$$compiled" > $@; \
 	else \
 		[ -x $< ] || chmod a+x $<; \


### PR DESCRIPTION
## Summary
- Chain commands with `&&` so sub-make failure stops execution immediately
- Previously if `$(MAKE)` failed to compile a `.tl` test file, the script continued to `chmod` a non-existent file, producing a confusing error

## Test plan
- [x] Local build passes
- [ ] CI passes