### PR TITLE
release: fix LUA_PATH for gen-platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .SECONDEXPANSION:
 .SECONDARY:
 SHELL := /bin/bash
+.SHELLFLAGS := -ec
 .DEFAULT_GOAL := help
 
 MAKEFLAGS += --no-print-directory
@@ -277,7 +278,7 @@ build: home cosmic
 
 .PHONY: release
 ## Create release artifacts (CI only)
-release: $(o)/lib/home/gen-platforms.lua
+release: $(o)/lib/home/gen-platforms.lua $(o)/lib/home/main.lua
 	@mkdir -p release
 	@cp artifacts/home-darwin-arm64/home release/home-darwin-arm64
 	@cp artifacts/home-linux-arm64/home release/home-linux-arm64
@@ -288,7 +289,7 @@ release: $(o)/lib/home/gen-platforms.lua
 	@chmod +x artifacts/cosmos-zip/zip
 	@tag="$$(date -u +%Y-%m-%d)-$${GITHUB_SHA::7}"; \
 	base_url="https://github.com/$${GITHUB_REPOSITORY}/releases/download/$$tag"; \
-	LUA_PATH="lib/home/?.lua;;" ./release/cosmic-lua $(o)/lib/home/gen-platforms.lua \
+	LUA_PATH="$(o)/lib/home/?.lua;;" ./release/cosmic-lua $(o)/lib/home/gen-platforms.lua \
 		release/platforms "$$base_url" "$$tag" \
 		release/home-darwin-arm64 release/home-linux-arm64 release/home-linux-x86_64; \
 	(cd release/platforms && ../../artifacts/cosmos-zip/zip -j ../home platforms.lua); \


### PR DESCRIPTION
## Summary
- Add `main.lua` dependency (compiled from main.tl)
- Fix LUA_PATH to use `o/lib/home/` for compiled lua files

gen-platforms.lua requires the `main` module which is compiled from main.tl to o/lib/home/main.lua.

## Test plan
- [x] Release workflow should now correctly generate platform metadata