### PR TITLE
cosmic: update release pin to 2026-01-12-5a4658b

### DIFF
--- a/bin/cosmic
+++ b/bin/cosmic
@@ -4,7 +4,7 @@ set -e
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 COSMIC_LUA="${SCRIPT_DIR}/cosmic-lua"
-RELEASE_URL="https://github.com/whilp/world/releases/download/home-2026-01-11-f977087/cosmic-lua"
+RELEASE_URL="https://github.com/whilp/world/releases/download/2026-01-12-5a4658b/cosmic-lua"
 
 # Download cosmic-lua if it doesn't exist
 if [ ! -f "${COSMIC_LUA}" ]; then


### PR DESCRIPTION
Validated release artifacts:
- All SHA256 checksums verified
- home binary: list, unpack, --with-platform work correctly
- cosmic-lua binary: execution and help system work
- Files extract correctly with proper permissions