### PR TITLE
ci: reduce noise and simplify module output paths

### DIFF
--- a/.github/pr/ci-cleanup.md
+++ b/.github/pr/ci-cleanup.md
@@ -1,0 +1,18 @@
+# ci: reduce noise and simplify module output paths
+
+Remove spammy output from CI and simplify the build system.
+
+## Changes
+
+- Remove luacheck from CI stages (it doesn't support .tl files)
+- Suppress "Wrote:" messages from tl-gen compilation
+- Add @ prefix to make recipes to hide mkdir/cp commands
+- Simplify module output paths from `o/any/<mod>/lib/<mod>/` to `o/lib/<mod>/`
+- Add `_tl_files` mechanism to auto-derive .lua outputs from .tl sources
+- Update all lib module cook.mk files to use simpler declarations
+
+## Validation
+
+- [x] `make -j ci` passes
+- [x] Incremental builds work correctly
+- [x] Test dependencies resolve properly

--- a/3p/lfs/cook.mk
+++ b/3p/lfs/cook.mk
@@ -3,5 +3,5 @@ lua_libs += lfs
 libs += o/%/lfs/lib/lfs.lua
 
 o/%/lfs/lib/lfs.lua: 3p/lua/lfs_stub.lua
-	mkdir -p $(dir $@)
-	cp $< $@
+	@mkdir -p $(dir $@)
+	@cp $< $@

--- a/3p/lua/cook.mk
+++ b/3p/lua/cook.mk
@@ -8,20 +8,20 @@ $(luatest_o)/3p/lua/test_release.lua.ok: $(lua_dist)
 $(luatest_o)/3p/lua/test_release.lua.ok: TEST_ENV = TEST_BIN_DIR=$(o_platform)/lua
 
 o/%/lua/bin/lua.ape: o/%/cosmos/bin/lua $(lib_libs) $(libs) $(luaunit)
-	rm -rf o/$*/lua/staging
-	mkdir -p o/$*/lua/staging/.lua $(@D)
-	$(foreach d,$(3p_lib_dirs),cp -r $(subst %,$*,$(d))/* o/$*/lua/staging/.lua/;)
-	$(foreach d,$(lib_dirs),cp -r $(d)/* o/$*/lua/staging/.lua/;)
-	# Remove test files and build artifacts from staging
-	find o/$*/lua/staging/.lua -name 'test*.lua' -delete
-	find o/$*/lua/staging/.lua -name 'cook.mk' -delete
-	find o/$*/lua/staging/.lua -name '*.ok' -delete
-	cp o/$*/cosmos/bin/lua $@
-	chmod +x $@
-	cd o/$*/lua/staging && zip -qr $(CURDIR)/$@ .lua
+	@rm -rf o/$*/lua/staging
+	@mkdir -p o/$*/lua/staging/.lua $(@D)
+	@$(foreach d,$(3p_lib_dirs),cp -r $(subst %,$*,$(d))/* o/$*/lua/staging/.lua/;)
+	@$(foreach d,$(lib_dirs),cp -r $(d)/* o/$*/lua/staging/.lua/;)
+	@# Remove test files and build artifacts from staging
+	@find o/$*/lua/staging/.lua -name 'test*.lua' -delete
+	@find o/$*/lua/staging/.lua -name 'cook.mk' -delete
+	@find o/$*/lua/staging/.lua -name '*.ok' -delete
+	@cp o/$*/cosmos/bin/lua $@
+	@chmod +x $@
+	@cd o/$*/lua/staging && zip -qr $(CURDIR)/$@ .lua
 
 o/%/lua/bin/lua.dist: o/%/lua/bin/lua.ape
-	cp $< $@
+	@cp $< $@
 
 lua-all: $(foreach p,$(platforms),o/$(p)/lua/bin/lua.dist) ## Build lua.dist for all platforms
 

--- a/3p/tl/tl-gen.tl
+++ b/3p/tl/tl-gen.tl
@@ -70,7 +70,6 @@ local function main(...: string): number
   local generated_file = input_basename:gsub("%.tl$", ".lua")
   if generated_file == output_file then
     -- already in the right place
-    io.write(stdout as string)
     return 0
   end
 
@@ -97,7 +96,6 @@ local function main(...: string): number
     os.remove(generated_file)
   end
 
-  io.write(stdout as string)
   return 0
 end
 

--- a/Makefile
+++ b/Makefile
@@ -246,9 +246,9 @@ clean:
 ## Bootstrap build environment
 bootstrap: $(bootstrap_files)
 
-all_checks := $(all_astgreps) $(all_luachecks) $(all_teals)
+all_checks := $(all_astgreps) $(all_teals)
 
-## Run all linters (astgrep, luacheck, teal)
+## Run all linters (astgrep, teal)
 check: $(o)/check-summary.txt
 
 $(o)/check-summary.txt: $(all_checks) | $(build_reporter)
@@ -300,10 +300,10 @@ release: $(o)/lib/home/gen-platforms.lua $(o)/lib/home/main.lua
 		--title "$$tag" \
 		release/home release/home-* release/cosmic-lua release/SHA256SUMS
 
-ci_stages := luacheck astgrep teal test build
+ci_stages := astgrep teal test build
 
 .PHONY: ci
-## Run full CI pipeline (luacheck, astgrep, teal, test, build)
+## Run full CI pipeline (astgrep, teal, test, build)
 ci:
 	@rm -f $(o)/failed
 	@$(foreach s,$(ci_stages),\

--- a/lib/aerosnap/cook.mk
+++ b/lib/aerosnap/cook.mk
@@ -9,8 +9,8 @@ lib_libs += o/any/aerosnap/lib/aerosnap/init.lua
 # uses secondary expansion so $(tl_files) is evaluated after 3p/tl/cook.mk
 .SECONDEXPANSION:
 o/any/aerosnap/lib/aerosnap/init.lua: lib/aerosnap/init.tl $(types_files) $$(tl_files) | $$(tl_staged)
-	mkdir -p $(@D)
-	$(tl_gen) -o $@ $<
+	@mkdir -p $(@D)
+	@$(tl_gen) -o $@ $<
 
 # test depends on module being compiled
 $(o)/lib/aerosnap/test.tl.test.ok: o/any/aerosnap/lib/aerosnap/init.lua

--- a/lib/aerosnap/cook.mk
+++ b/lib/aerosnap/cook.mk
@@ -1,9 +1,4 @@
 modules += aerosnap
-aerosnap_srcs := $(wildcard lib/aerosnap/*.tl)
+aerosnap_tl_files := lib/aerosnap/init.tl
 aerosnap_tests := lib/aerosnap/test.tl
-aerosnap_files := o/any/lib/aerosnap/init.lua
 lib_lua_modules += aerosnap
-lib_libs += o/any/lib/aerosnap/init.lua
-
-# test depends on module being compiled
-$(o)/lib/aerosnap/test.tl.test.ok: o/any/lib/aerosnap/init.lua

--- a/lib/aerosnap/cook.mk
+++ b/lib/aerosnap/cook.mk
@@ -1,16 +1,9 @@
 modules += aerosnap
 aerosnap_srcs := $(wildcard lib/aerosnap/*.tl)
 aerosnap_tests := lib/aerosnap/test.tl
-aerosnap_files := o/any/aerosnap/lib/aerosnap/init.lua
+aerosnap_files := o/any/lib/aerosnap/init.lua
 lib_lua_modules += aerosnap
-lib_dirs += o/any/aerosnap/lib
-lib_libs += o/any/aerosnap/lib/aerosnap/init.lua
-
-# uses secondary expansion so $(tl_files) is evaluated after 3p/tl/cook.mk
-.SECONDEXPANSION:
-o/any/aerosnap/lib/aerosnap/init.lua: lib/aerosnap/init.tl $(types_files) $$(tl_files) | $$(tl_staged)
-	@mkdir -p $(@D)
-	@$(tl_gen) -o $@ $<
+lib_libs += o/any/lib/aerosnap/init.lua
 
 # test depends on module being compiled
-$(o)/lib/aerosnap/test.tl.test.ok: o/any/aerosnap/lib/aerosnap/init.lua
+$(o)/lib/aerosnap/test.tl.test.ok: o/any/lib/aerosnap/init.lua

--- a/lib/build/make-help.snap
+++ b/lib/build/make-help.snap
@@ -11,12 +11,12 @@ Targets:
   teal                Run teal type checker on all files
   clean               Remove all build artifacts
   bootstrap           Bootstrap build environment
-  check               Run all linters (astgrep, luacheck, teal)
+  check               Run all linters (astgrep, teal)
   update              Check for dependency updates
   bump                Apply dependency updates (use with only=<module>)
   build               Build home and cosmic binaries
   release             Create release artifacts (CI only)
-  ci                  Run full CI pipeline (luacheck, astgrep, teal, test, build)
+  ci                  Run full CI pipeline (astgrep, teal, test, build)
 
 Options:
   filter-only         Filter targets by pattern (make test only='skill')

--- a/lib/claude/cook.mk
+++ b/lib/claude/cook.mk
@@ -2,14 +2,7 @@ modules += claude
 claude_srcs := $(wildcard lib/claude/*.tl)
 claude_tests := lib/claude/test.tl
 lib_lua_modules += claude
-lib_dirs += o/any/claude/lib
-lib_libs += o/any/claude/lib/claude/main.lua
-
-# uses secondary expansion so $(tl_files) is evaluated after 3p/tl/cook.mk
-.SECONDEXPANSION:
-o/any/claude/lib/claude/main.lua: lib/claude/main.tl $(types_files) $$(tl_files) | $$(tl_staged)
-	@mkdir -p $(@D)
-	@$(tl_gen) -o $@ $<
+lib_libs += o/any/lib/claude/main.lua
 
 # test depends on module being compiled
-$(o)/lib/claude/test.tl.test.ok: o/any/claude/lib/claude/main.lua
+$(o)/lib/claude/test.tl.test.ok: o/any/lib/claude/main.lua

--- a/lib/claude/cook.mk
+++ b/lib/claude/cook.mk
@@ -8,8 +8,8 @@ lib_libs += o/any/claude/lib/claude/main.lua
 # uses secondary expansion so $(tl_files) is evaluated after 3p/tl/cook.mk
 .SECONDEXPANSION:
 o/any/claude/lib/claude/main.lua: lib/claude/main.tl $(types_files) $$(tl_files) | $$(tl_staged)
-	mkdir -p $(@D)
-	$(tl_gen) -o $@ $<
+	@mkdir -p $(@D)
+	@$(tl_gen) -o $@ $<
 
 # test depends on module being compiled
 $(o)/lib/claude/test.tl.test.ok: o/any/claude/lib/claude/main.lua

--- a/lib/claude/cook.mk
+++ b/lib/claude/cook.mk
@@ -1,8 +1,4 @@
 modules += claude
-claude_srcs := $(wildcard lib/claude/*.tl)
+claude_tl_files := lib/claude/main.tl
 claude_tests := lib/claude/test.tl
 lib_lua_modules += claude
-lib_libs += o/any/lib/claude/main.lua
-
-# test depends on module being compiled
-$(o)/lib/claude/test.tl.test.ok: o/any/lib/claude/main.lua

--- a/lib/cook.mk
+++ b/lib/cook.mk
@@ -13,16 +13,16 @@ lib_dirs += o/any/lib
 lib_libs += o/any/lib/version.lua o/any/lib/platform.lua o/any/lib/utils.lua o/any/lib/ulid.lua o/any/lib/file.lua
 
 o/any/lib/%.lua: lib/%.lua
-	mkdir -p $(@D)
-	cp $< $@
+	@mkdir -p $(@D)
+	@cp $< $@
 
 # compile .tl files to .lua (for o/any/lib, used by standalone modules)
 # tl_staged must be regular prereq (not order-only) for parallel builds
 # uses secondary expansion so $(tl_files) is evaluated after 3p/tl/cook.mk
 .SECONDEXPANSION:
 o/any/lib/%.lua: lib/%.tl $(types_files) $$(tl_files) | $$(tl_staged)
-	mkdir -p $(@D)
-	$(tl_gen) -o $@ $<
+	@mkdir -p $(@D)
+	@$(tl_gen) -o $@ $<
 
 # compile .tl files to .lua (for o/teal/lib via tl gen -o)
 # uses secondary expansion so $(tl_staged) is evaluated after all includes

--- a/lib/cook.mk
+++ b/lib/cook.mk
@@ -2,30 +2,22 @@ modules += lib
 lib_lua_modules :=
 lib_dirs :=
 lib_libs :=
-lib_srcs := lib/file.tl lib/platform.tl lib/ulid.tl lib/utils.tl lib/version.lua
 lib_tests := lib/test_version.tl
 
 # type declaration files for teal compilation
 types_files := $(wildcard lib/types/*.d.tl lib/types/*/*.d.tl lib/types/*/*/*.d.tl)
 
-# standalone lib files
-lib_dirs += o/any/lib
-lib_libs += o/any/lib/version.lua o/any/lib/platform.lua o/any/lib/utils.lua o/any/lib/ulid.lua o/any/lib/file.lua
+# standalone lib files (use _tl_files mechanism)
+lib_dirs += o/lib
+lib_tl_files := lib/file.tl lib/platform.tl lib/ulid.tl lib/utils.tl
+lib_libs += o/lib/version.lua
 
-o/any/lib/%.lua: lib/%.lua
+# copy .lua files to o/lib/
+o/lib/%.lua: lib/%.lua
 	@mkdir -p $(@D)
 	@cp $< $@
 
-# compile .tl files to .lua (for o/any/lib, used by standalone modules)
-# tl_staged must be regular prereq (not order-only) for parallel builds
-# uses secondary expansion so $(tl_files) is evaluated after 3p/tl/cook.mk
-.SECONDEXPANSION:
-o/any/lib/%.lua: lib/%.tl $(types_files) $$(tl_files) | $$(tl_staged)
-	@mkdir -p $(@D)
-	@$(tl_gen) -o $@ $<
-
 # compile .tl files to .lua (for o/teal/lib via tl gen -o)
-# uses secondary expansion so $(tl_staged) is evaluated after all includes
 .SECONDEXPANSION:
 o/teal/lib/%.lua: lib/%.tl $(types_files) $$(tl_staged)
 	@mkdir -p $(@D)
@@ -44,3 +36,6 @@ include lib/skill/cook.mk
 include lib/test/cook.mk
 include lib/whereami/cook.mk
 include lib/work/cook.mk
+
+# After includes: derive lib_libs from lib module _tl_files
+lib_libs += $(patsubst %.tl,$(o)/%.lua,$(foreach m,$(lib_lua_modules),$($(m)_tl_files)))

--- a/lib/cosmic/tl-gen.lua
+++ b/lib/cosmic/tl-gen.lua
@@ -79,9 +79,6 @@ local function main(...)
   out:write(lua_code)
   out:close()
 
-  -- Report success
-  local basename = output_file:match("([^/]+)$") or output_file
-  io.stdout:write("Wrote: " .. basename .. "\n")
   return 0
 end
 

--- a/lib/daemonize/cook.mk
+++ b/lib/daemonize/cook.mk
@@ -9,5 +9,5 @@ lib_lua_modules += daemonize
 lib_dirs += o/any/daemonize/lib
 
 o/any/daemonize/lib/daemonize/init.lua: $(o)/teal/lib/daemonize/init.lua
-	mkdir -p $(@D)
-	cp $< $@
+	@mkdir -p $(@D)
+	@cp $< $@

--- a/lib/daemonize/cook.mk
+++ b/lib/daemonize/cook.mk
@@ -3,11 +3,6 @@ daemonize_tl_srcs := $(wildcard lib/daemonize/*.tl)
 daemonize_lua_srcs := $(wildcard lib/daemonize/*.lua)
 daemonize_srcs := $(daemonize_tl_srcs) $(daemonize_lua_srcs)
 daemonize_tests := $(filter lib/daemonize/test%.tl,$(daemonize_tl_srcs))
-daemonize_files := o/any/daemonize/lib/daemonize/init.lua
+daemonize_files := $(patsubst lib/%.tl,o/any/lib/%.lua,$(filter-out %test.tl,$(daemonize_tl_srcs)))
 
 lib_lua_modules += daemonize
-lib_dirs += o/any/daemonize/lib
-
-o/any/daemonize/lib/daemonize/init.lua: $(o)/teal/lib/daemonize/init.lua
-	@mkdir -p $(@D)
-	@cp $< $@

--- a/lib/daemonize/cook.mk
+++ b/lib/daemonize/cook.mk
@@ -1,8 +1,4 @@
 modules += daemonize
-daemonize_tl_srcs := $(wildcard lib/daemonize/*.tl)
-daemonize_lua_srcs := $(wildcard lib/daemonize/*.lua)
-daemonize_srcs := $(daemonize_tl_srcs) $(daemonize_lua_srcs)
-daemonize_tests := $(filter lib/daemonize/test%.tl,$(daemonize_tl_srcs))
-daemonize_files := $(patsubst lib/%.tl,o/any/lib/%.lua,$(filter-out %test.tl,$(daemonize_tl_srcs)))
-
+daemonize_tl_files := lib/daemonize/init.tl
+daemonize_tests := lib/daemonize/test.tl
 lib_lua_modules += daemonize

--- a/lib/environ/cook.mk
+++ b/lib/environ/cook.mk
@@ -2,14 +2,7 @@ modules += environ
 environ_srcs := $(wildcard lib/environ/*.tl)
 environ_tests := lib/environ/test.tl
 lib_lua_modules += environ
-lib_dirs += o/any/environ/lib
-lib_libs += o/any/environ/lib/environ/init.lua
-
-# uses secondary expansion so $(tl_files) is evaluated after 3p/tl/cook.mk
-.SECONDEXPANSION:
-o/any/environ/lib/environ/init.lua: lib/environ/init.tl $(types_files) $$(tl_files) | $$(tl_staged)
-	@mkdir -p $(@D)
-	@$(tl_gen) -o $@ $<
+lib_libs += o/any/lib/environ/init.lua
 
 # test depends on module being compiled
-$(o)/lib/environ/test.tl.test.ok: o/any/environ/lib/environ/init.lua
+$(o)/lib/environ/test.tl.test.ok: o/any/lib/environ/init.lua

--- a/lib/environ/cook.mk
+++ b/lib/environ/cook.mk
@@ -1,8 +1,4 @@
 modules += environ
-environ_srcs := $(wildcard lib/environ/*.tl)
+environ_tl_files := lib/environ/init.tl
 environ_tests := lib/environ/test.tl
 lib_lua_modules += environ
-lib_libs += o/any/lib/environ/init.lua
-
-# test depends on module being compiled
-$(o)/lib/environ/test.tl.test.ok: o/any/lib/environ/init.lua

--- a/lib/environ/cook.mk
+++ b/lib/environ/cook.mk
@@ -8,8 +8,8 @@ lib_libs += o/any/environ/lib/environ/init.lua
 # uses secondary expansion so $(tl_files) is evaluated after 3p/tl/cook.mk
 .SECONDEXPANSION:
 o/any/environ/lib/environ/init.lua: lib/environ/init.tl $(types_files) $$(tl_files) | $$(tl_staged)
-	mkdir -p $(@D)
-	$(tl_gen) -o $@ $<
+	@mkdir -p $(@D)
+	@$(tl_gen) -o $@ $<
 
 # test depends on module being compiled
 $(o)/lib/environ/test.tl.test.ok: o/any/environ/lib/environ/init.lua

--- a/lib/nvim/cook.mk
+++ b/lib/nvim/cook.mk
@@ -10,5 +10,5 @@ lib_lua_modules += nvim
 lib_dirs += o/any/nvim/lib
 
 o/any/nvim/lib/nvim/main.lua: $(o)/lib/nvim/main.lua
-	mkdir -p $(@D)
-	cp $< $@
+	@mkdir -p $(@D)
+	@cp $< $@

--- a/lib/nvim/cook.mk
+++ b/lib/nvim/cook.mk
@@ -1,9 +1,5 @@
 modules += nvim-lib
-nvim-lib_tl_srcs := $(wildcard lib/nvim/*.tl)
-nvim-lib_lua_srcs := $(wildcard lib/nvim/*.lua)
-nvim-lib_srcs := $(nvim-lib_tl_srcs) $(nvim-lib_lua_srcs)
-nvim-lib_tests := $(filter lib/nvim/test%.tl,$(nvim-lib_tl_srcs))
-nvim-lib_files := $(patsubst lib/%.tl,o/any/lib/%.lua,$(filter-out %test.tl,$(nvim-lib_tl_srcs)))
+nvim-lib_tl_files := lib/nvim/main.tl
+nvim-lib_tests := lib/nvim/test.tl
 nvim-lib_deps := cosmic daemonize whereami
-
 lib_lua_modules += nvim

--- a/lib/nvim/cook.mk
+++ b/lib/nvim/cook.mk
@@ -3,12 +3,7 @@ nvim-lib_tl_srcs := $(wildcard lib/nvim/*.tl)
 nvim-lib_lua_srcs := $(wildcard lib/nvim/*.lua)
 nvim-lib_srcs := $(nvim-lib_tl_srcs) $(nvim-lib_lua_srcs)
 nvim-lib_tests := $(filter lib/nvim/test%.tl,$(nvim-lib_tl_srcs))
-nvim-lib_files := o/any/nvim/lib/nvim/main.lua
+nvim-lib_files := $(patsubst lib/%.tl,o/any/lib/%.lua,$(filter-out %test.tl,$(nvim-lib_tl_srcs)))
 nvim-lib_deps := cosmic daemonize whereami
 
 lib_lua_modules += nvim
-lib_dirs += o/any/nvim/lib
-
-o/any/nvim/lib/nvim/main.lua: $(o)/lib/nvim/main.lua
-	@mkdir -p $(@D)
-	@cp $< $@

--- a/lib/whereami/cook.mk
+++ b/lib/whereami/cook.mk
@@ -1,6 +1,4 @@
 modules += whereami
-whereami_srcs := lib/whereami/init.tl lib/whereami/test.tl
+whereami_tl_files := lib/whereami/init.tl
 whereami_tests := lib/whereami/test.tl
-whereami_files := o/any/lib/whereami/init.lua
-
 lib_lua_modules += whereami

--- a/lib/whereami/cook.mk
+++ b/lib/whereami/cook.mk
@@ -9,5 +9,5 @@ lib_dirs += o/any/whereami/lib
 # Use secondary expansion for tl_files (defined in 3p/tl/cook.mk after this file)
 .SECONDEXPANSION:
 o/any/whereami/lib/whereami/init.lua: lib/whereami/init.tl $(types_files) $$(tl_files) | $$(tl_staged)
-	mkdir -p $(@D)
-	$(tl_gen) -o $@ $<
+	@mkdir -p $(@D)
+	@$(tl_gen) -o $@ $<

--- a/lib/whereami/cook.mk
+++ b/lib/whereami/cook.mk
@@ -1,13 +1,6 @@
 modules += whereami
 whereami_srcs := lib/whereami/init.tl lib/whereami/test.tl
 whereami_tests := lib/whereami/test.tl
-whereami_files := o/any/whereami/lib/whereami/init.lua
+whereami_files := o/any/lib/whereami/init.lua
 
 lib_lua_modules += whereami
-lib_dirs += o/any/whereami/lib
-
-# Use secondary expansion for tl_files (defined in 3p/tl/cook.mk after this file)
-.SECONDEXPANSION:
-o/any/whereami/lib/whereami/init.lua: lib/whereami/init.tl $(types_files) $$(tl_files) | $$(tl_staged)
-	@mkdir -p $(@D)
-	@$(tl_gen) -o $@ $<

--- a/lib/work/cook.mk
+++ b/lib/work/cook.mk
@@ -1,22 +1,10 @@
 modules += work
 lib_lua_modules += work
-lib_dirs += o/any/work/lib
 work_srcs := $(wildcard lib/work/*.lua) $(wildcard lib/work/*.tl)
 work_tests := $(filter-out lib/work/test_lib.tl,$(wildcard lib/work/test_*.tl))
 
-work_all_lua := $(wildcard lib/work/*.lua)
-work_tl_srcs := $(wildcard lib/work/*.tl)
-work_lua_src := $(filter-out lib/work/test%.lua,$(work_all_lua))
-work_lua_lib := $(patsubst lib/%,o/any/work/lib/%,$(work_lua_src))
-work_tl_lib := $(patsubst lib/%.tl,o/any/work/lib/%.lua,$(work_tl_srcs))
-work_lib := $(work_lua_lib) $(work_tl_lib)
-lib_libs += $(work_lib)
-
-o/any/work/lib/work/%.lua: lib/work/%.lua
-	@mkdir -p $(@D)
-	@cp $< $@
-
-# tl files: compile via o/teal/lib, then copy to o/any/work/lib
-o/any/work/lib/work/%.lua: $(o)/teal/lib/work/%.lua
-	@mkdir -p $(@D)
-	@cp $< $@
+work_lua_src := $(filter-out lib/work/test%.lua,$(wildcard lib/work/*.lua))
+work_tl_src := $(filter-out lib/work/test%.tl,$(wildcard lib/work/*.tl))
+work_lua_lib := $(patsubst lib/%,o/any/lib/%,$(work_lua_src))
+work_tl_lib := $(patsubst lib/%.tl,o/any/lib/%.lua,$(work_tl_src))
+lib_libs += $(work_lua_lib) $(work_tl_lib)

--- a/lib/work/cook.mk
+++ b/lib/work/cook.mk
@@ -13,10 +13,10 @@ work_lib := $(work_lua_lib) $(work_tl_lib)
 lib_libs += $(work_lib)
 
 o/any/work/lib/work/%.lua: lib/work/%.lua
-	mkdir -p $(@D)
-	cp $< $@
+	@mkdir -p $(@D)
+	@cp $< $@
 
 # tl files: compile via o/teal/lib, then copy to o/any/work/lib
 o/any/work/lib/work/%.lua: $(o)/teal/lib/work/%.lua
-	mkdir -p $(@D)
-	cp $< $@
+	@mkdir -p $(@D)
+	@cp $< $@

--- a/lib/work/cook.mk
+++ b/lib/work/cook.mk
@@ -1,10 +1,4 @@
 modules += work
-lib_lua_modules += work
-work_srcs := $(wildcard lib/work/*.lua) $(wildcard lib/work/*.tl)
+work_tl_files := $(filter-out lib/work/test%.tl,$(wildcard lib/work/*.tl))
 work_tests := $(filter-out lib/work/test_lib.tl,$(wildcard lib/work/test_*.tl))
-
-work_lua_src := $(filter-out lib/work/test%.lua,$(wildcard lib/work/*.lua))
-work_tl_src := $(filter-out lib/work/test%.tl,$(wildcard lib/work/*.tl))
-work_lua_lib := $(patsubst lib/%,o/any/lib/%,$(work_lua_src))
-work_tl_lib := $(patsubst lib/%.tl,o/any/lib/%.lua,$(work_tl_src))
-lib_libs += $(work_lua_lib) $(work_tl_lib)
+lib_lua_modules += work


### PR DESCRIPTION
Remove spammy output from CI and simplify the build system.

## Changes

- Remove luacheck from CI stages (it doesn't support .tl files)
- Suppress "Wrote:" messages from tl-gen compilation
- Add @ prefix to make recipes to hide mkdir/cp commands
- Simplify module output paths from `o/any/<mod>/lib/<mod>/` to `o/lib/<mod>/`
- Add `_tl_files` mechanism to auto-derive .lua outputs from .tl sources
- Update all lib module cook.mk files to use simpler declarations

## Validation

- [x] `make -j ci` passes
- [x] Incremental builds work correctly
- [x] Test dependencies resolve properly

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-12T02:15:05Z
</details>