### PR TITLE
skill/pr: fix default branch detection when origin/HEAD not set

### DIFF
--- a/.github/pr/fix-pr-default-branch.md
+++ b/.github/pr/fix-pr-default-branch.md
@@ -1,0 +1,30 @@
+# skill/pr: fix default branch detection when origin/HEAD not set
+
+The pr skill's branch file auto-detection was failing when origin/HEAD
+wasn't configured, which is common in repos that don't run
+`git remote set-head origin --auto`.
+
+## Changes
+
+- lib/skill/pr.tl:108 - Added `get_default_branch()` function with smart fallback logic
+- lib/skill/pr.tl:157 - Updated `get_pr_files_from_branch()` to use `get_default_branch()`
+- lib/skill/test_pr.tl:466 - Added 4 comprehensive tests for all fallback scenarios
+
+## Implementation
+
+The new `get_default_branch()` function tries multiple strategies in order:
+
+1. Run `git remote show origin` to find the HEAD branch
+2. Check if `origin/main` exists using `git rev-parse --verify`
+3. Check if `origin/master` exists
+4. Fall back to `origin/HEAD` (original behavior)
+
+This ensures the pr skill works in repos with non-standard setups while
+maintaining backward compatibility.
+
+## Validation
+
+- [x] All existing tests pass
+- [x] Added tests for all fallback paths
+- [x] Verified `bin/cosmic --skill pr` works correctly
+- [x] Tested with simulated GitHub Actions environment

--- a/lib/skill/pr.tl
+++ b/lib/skill/pr.tl
@@ -105,12 +105,58 @@ local function normalize_pr_name(name: string): string
   return name
 end
 
+local function get_default_branch(opts?: SpawnOpts): string
+  opts = opts or {}
+  local do_spawn = opts.spawn or spawn_mod
+
+  -- Try to get the remote HEAD branch name
+  local cmd: {string} = {"git"}
+  if opts.repo then
+    table.insert(cmd, "-C")
+    table.insert(cmd, opts.repo)
+  end
+  table.insert(cmd, "remote")
+  table.insert(cmd, "show")
+  table.insert(cmd, "origin")
+
+  local handle = do_spawn(cmd)
+  local ok, out = handle:read()
+  if ok and out then
+    local branch = (out as string):match("HEAD branch: (%S+)")
+    if branch then
+      return "origin/" .. branch
+    end
+  end
+
+  -- Fallback: try common default branches
+  for _, branch in ipairs({"origin/main", "origin/master"}) do
+    cmd = {"git"}
+    if opts.repo then
+      table.insert(cmd, "-C")
+      table.insert(cmd, opts.repo)
+    end
+    table.insert(cmd, "rev-parse")
+    table.insert(cmd, "--verify")
+    table.insert(cmd, branch)
+
+    handle = do_spawn(cmd)
+    ok, _ = handle:read()
+    if ok then
+      return branch
+    end
+  end
+
+  -- Last resort: use origin/HEAD even if it might not exist
+  return "origin/HEAD"
+end
+
 local function get_pr_files_from_branch(opts?: SpawnOpts): {string}
   opts = opts or {}
   local do_spawn = opts.spawn or spawn_mod
 
+  local base_branch = get_default_branch(opts)
+
   -- Find files added on this branch matching .github/pr/*.md
-  -- Compare against origin/HEAD (default branch)
   local cmd: {string} = {"git"}
   if opts.repo then
     table.insert(cmd, "-C")
@@ -119,7 +165,7 @@ local function get_pr_files_from_branch(opts?: SpawnOpts): {string}
   table.insert(cmd, "diff")
   table.insert(cmd, "--name-only")
   table.insert(cmd, "--diff-filter=A")
-  table.insert(cmd, "origin/HEAD...HEAD")
+  table.insert(cmd, base_branch .. "...HEAD")
   table.insert(cmd, "--")
   table.insert(cmd, ".github/pr/*.md")
 
@@ -544,6 +590,7 @@ local record PrModule
   update_pr: function(owner: string, repo: string, pr_number: number, title: string, body: string, token: string, opts?: RequestOpts): boolean, string
   get_current_branch: function(): string
   get_commit_sha: function(): string
+  get_default_branch: function(opts?: SpawnOpts): string
   get_pr_name_from_trailer: function(opts?: SpawnOpts): string, TrailerInfo
   get_pr_files_from_branch: function(opts?: SpawnOpts): {string}
   is_github_actions: function(): boolean
@@ -559,6 +606,7 @@ return {
   update_pr = update_pr,
   get_current_branch = get_current_branch,
   get_commit_sha = get_commit_sha,
+  get_default_branch = get_default_branch,
   get_pr_name_from_trailer = get_pr_name_from_trailer,
   get_pr_files_from_branch = get_pr_files_from_branch,
   is_github_actions = is_github_actions,

--- a/lib/skill/test_pr.tl
+++ b/lib/skill/test_pr.tl
@@ -458,3 +458,106 @@ local function test_main_no_fallback_when_multiple_files()
   assert(msg:match("no x%-cosmic%-pr%-name"), "expected no trailer message")
 end
 test_main_no_fallback_when_multiple_files()
+
+--------------------------------------------------------------------------------
+-- get_default_branch tests
+--------------------------------------------------------------------------------
+
+local function test_default_branch_from_remote_show()
+  local call_count = 0
+  local mock_spawn_fn = function(cmd: {string}): SpawnHandle
+    call_count = call_count + 1
+    if call_count == 1 and cmd[1] == "git" and cmd[#cmd-1] == "show" then
+      return {
+        read = function(_: SpawnHandle): boolean, string
+          return true, "* remote origin\n  HEAD branch: main\n"
+        end,
+        wait = function(_: SpawnHandle): integer return 0 end,
+      }
+    end
+    return {
+      read = function(_: SpawnHandle): boolean, string return false, nil end,
+      wait = function(_: SpawnHandle): integer return 1 end,
+    }
+  end
+
+  local result = pr.get_default_branch({spawn = mock_spawn_fn} as SpawnOpts)
+  assert(result == "origin/main", "expected origin/main from remote show, got: " .. tostring(result))
+end
+test_default_branch_from_remote_show()
+
+local function test_default_branch_fallback_to_main()
+  local call_count = 0
+  local mock_spawn_fn = function(cmd: {string}): SpawnHandle
+    call_count = call_count + 1
+    if call_count == 1 then
+      -- remote show fails
+      return {
+        read = function(_: SpawnHandle): boolean, string return false, nil end,
+        wait = function(_: SpawnHandle): integer return 1 end,
+      }
+    elseif call_count == 2 and cmd[#cmd] == "origin/main" then
+      -- origin/main exists
+      return {
+        read = function(_: SpawnHandle): boolean, string return true, "abc123\n" end,
+        wait = function(_: SpawnHandle): integer return 0 end,
+      }
+    end
+    return {
+      read = function(_: SpawnHandle): boolean, string return false, nil end,
+      wait = function(_: SpawnHandle): integer return 1 end,
+    }
+  end
+
+  local result = pr.get_default_branch({spawn = mock_spawn_fn} as SpawnOpts)
+  assert(result == "origin/main", "expected origin/main fallback, got: " .. tostring(result))
+end
+test_default_branch_fallback_to_main()
+
+local function test_default_branch_fallback_to_master()
+  local call_count = 0
+  local mock_spawn_fn = function(cmd: {string}): SpawnHandle
+    call_count = call_count + 1
+    if call_count == 1 then
+      -- remote show fails
+      return {
+        read = function(_: SpawnHandle): boolean, string return false, nil end,
+        wait = function(_: SpawnHandle): integer return 1 end,
+      }
+    elseif call_count == 2 and cmd[#cmd] == "origin/main" then
+      -- origin/main doesn't exist
+      return {
+        read = function(_: SpawnHandle): boolean, string return false, nil end,
+        wait = function(_: SpawnHandle): integer return 1 end,
+      }
+    elseif call_count == 3 and cmd[#cmd] == "origin/master" then
+      -- origin/master exists
+      return {
+        read = function(_: SpawnHandle): boolean, string return true, "def456\n" end,
+        wait = function(_: SpawnHandle): integer return 0 end,
+      }
+    end
+    return {
+      read = function(_: SpawnHandle): boolean, string return false, nil end,
+      wait = function(_: SpawnHandle): integer return 1 end,
+    }
+  end
+
+  local result = pr.get_default_branch({spawn = mock_spawn_fn} as SpawnOpts)
+  assert(result == "origin/master", "expected origin/master fallback, got: " .. tostring(result))
+end
+test_default_branch_fallback_to_master()
+
+local function test_default_branch_ultimate_fallback()
+  local mock_spawn_fn = function(_: {string}): SpawnHandle
+    -- all commands fail
+    return {
+      read = function(_: SpawnHandle): boolean, string return false, nil end,
+      wait = function(_: SpawnHandle): integer return 1 end,
+    }
+  end
+
+  local result = pr.get_default_branch({spawn = mock_spawn_fn} as SpawnOpts)
+  assert(result == "origin/HEAD", "expected origin/HEAD ultimate fallback, got: " .. tostring(result))
+end
+test_default_branch_ultimate_fallback()


### PR DESCRIPTION
The pr skill's branch file auto-detection was failing when origin/HEAD
wasn't configured, which is common in repos that don't run
`git remote set-head origin --auto`.

## Changes

- lib/skill/pr.tl:108 - Added `get_default_branch()` function with smart fallback logic
- lib/skill/pr.tl:157 - Updated `get_pr_files_from_branch()` to use `get_default_branch()`
- lib/skill/test_pr.tl:466 - Added 4 comprehensive tests for all fallback scenarios

## Implementation

The new `get_default_branch()` function tries multiple strategies in order:

1. Run `git remote show origin` to find the HEAD branch
2. Check if `origin/main` exists using `git rev-parse --verify`
3. Check if `origin/master` exists
4. Fall back to `origin/HEAD` (original behavior)

This ensures the pr skill works in repos with non-standard setups while
maintaining backward compatibility.

## Validation

- [x] All existing tests pass
- [x] Added tests for all fallback paths
- [x] Verified `bin/cosmic --skill pr` works correctly
- [x] Tested with simulated GitHub Actions environment

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-12T03:15:53Z
</details>