### PR TITLE
build: fix test dependency tracking for lib modules

### DIFF
--- a/.github/pr/fix-whereami-module.md
+++ b/.github/pr/fix-whereami-module.md
@@ -1,0 +1,20 @@
+# build: fix test dependency tracking for lib modules
+
+Fixes race condition in parallel builds where nvim tests would run before whereami module was compiled, causing "module 'whereami' not found" errors.
+
+The test dependency expansion only tracked `_dir` for dependencies, which only exists for versioned (3p) modules. When a lib module like `whereami` was a dependency, its compiled files weren't being tracked as prerequisites.
+
+- Makefile:186-202 - split dependency computation into two passes to ensure all `_tl_lua` variables are computed before setting up test dependencies
+
+## Changes
+
+Split test dependency expansion into:
+1. First pass: compute all `_tl_lua` variables for every module
+2. Second pass: set up test dependencies using those variables
+
+Now tests depend on both `_dir` (for 3p modules) and `_files`/`_tl_lua` (for lib modules).
+
+## Validation
+
+- [x] `make clean && make -j test only=nvim` passes consistently
+- [x] verified `o/lib/whereami/init.lua` now appears in nvim test prerequisites

--- a/Makefile
+++ b/Makefile
@@ -183,10 +183,12 @@ $(o)/%.snap.test.ok: %.snap $(o)/%.snap | $(bootstrap_cosmic)
 	@mkdir -p $(@D)
 	@$(bootstrap_cosmic) $(build_snap) $< $(word 2,$^) > $@
 
-# expand test deps: M's tests depend on own _files/_tl_files plus deps' _dir
-# derive compiled .lua from _tl_files
+# expand test deps: M's tests depend on own _files/_tl_files plus deps' _dir/_files/_tl_lua
+# derive compiled .lua from _tl_files (first pass: compute all _tl_lua)
 $(foreach m,$(filter-out bootstrap,$(modules)),\
-  $(eval $(m)_tl_lua := $(patsubst %.tl,$(o)/%.lua,$($(m)_tl_files)))\
+  $(eval $(m)_tl_lua := $(patsubst %.tl,$(o)/%.lua,$($(m)_tl_files))))
+# second pass: set up test dependencies
+$(foreach m,$(filter-out bootstrap,$(modules)),\
   $(eval $(patsubst %,$(o)/%.test.ok,$($(m)_tests)): $($(m)_files) $($(m)_tl_lua))\
   $(eval $(patsubst %,$(o)/%.test.ok,$($(m)_tests)): TEST_DEPS += $($(m)_files) $($(m)_tl_lua))\
   $(if $($(m)_dir),\
@@ -196,7 +198,8 @@ $(foreach m,$(filter-out bootstrap,$(modules)),\
   $(foreach d,$(filter-out $(m),$(default_deps) $($(m)_deps)),\
     $(if $($(d)_dir),\
       $(eval $(patsubst %,$(o)/%.test.ok,$($(m)_tests)): $($(d)_dir))\
-      $(eval $(patsubst %,$(o)/%.test.ok,$($(m)_tests)): TEST_DEPS += $($(d)_dir)))))
+      $(eval $(patsubst %,$(o)/%.test.ok,$($(m)_tests)): TEST_DEPS += $($(d)_dir)))\
+    $(eval $(patsubst %,$(o)/%.test.ok,$($(m)_tests)): $($(d)_files) $($(d)_tl_lua))))
 
 all_built_files := $(call filter-only,$(foreach x,$(modules),$($(x)_files)))
 all_built_files += $(all_tl_lua)


### PR DESCRIPTION
Fixes race condition in parallel builds where nvim tests would run before whereami module was compiled, causing "module 'whereami' not found" errors.

The test dependency expansion only tracked `_dir` for dependencies, which only exists for versioned (3p) modules. When a lib module like `whereami` was a dependency, its compiled files weren't being tracked as prerequisites.

- Makefile:186-202 - split dependency computation into two passes to ensure all `_tl_lua` variables are computed before setting up test dependencies

## Changes

Split test dependency expansion into:
1. First pass: compute all `_tl_lua` variables for every module
2. Second pass: set up test dependencies using those variables

Now tests depend on both `_dir` (for 3p modules) and `_files`/`_tl_lua` (for lib modules).

## Validation

- [x] `make clean && make -j test only=nvim` passes consistently
- [x] verified `o/lib/whereami/init.lua` now appears in nvim test prerequisites

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-12T03:32:04Z
</details>