### PR TITLE
build: use source tl-gen.lua instead of bundled version

### DIFF
--- a/.github/pr/build-tl-gen-source.md
+++ b/.github/pr/build-tl-gen-source.md
@@ -1,0 +1,34 @@
+# build: use source tl-gen.lua instead of bundled version
+
+Use `lib/cosmic/tl-gen.lua` directly instead of the bundled `/zip/tl-gen.lua`
+to suppress "Wrote:" messages during bootstrap.
+
+## Problem
+
+After `make clean`, the CI output showed 6 spammy "Wrote:" lines:
+```
+Wrote: build-fetch.lua
+Wrote: test-snap.lua
+Wrote: make-help.lua
+Wrote: reporter.lua
+Wrote: build-stage.lua
+Wrote: check-update.lua
+```
+
+The source file `lib/cosmic/tl-gen.lua` already had this output removed in
+commit bc480e1, but the pre-built `bin/cosmic-lua` binary (from release
+2026-01-12-5a4658b) still contains the old bundled version with the print.
+
+## Solution
+
+Instead of running the bundled `/zip/tl-gen.lua`, run the source file directly.
+Cosmic can execute it since it has `tl.lua` bundled.
+
+## Changes
+
+- lib/build/cook.mk - use source tl-gen.lua, add it as dependency
+
+## Validation
+
+- [x] `make clean && make -j ci` passes with no "Wrote:" output
+- [x] `make -j ci` second run is fully cached (8 lines)

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -18,9 +18,9 @@ build_snaps := $(wildcard lib/build/*.snap)
 
 # Build scripts use cosmic's bundled teal (no tl_staged dependency)
 # This breaks the circular dependency: build scripts -> fetch -> tl_staged -> build scripts
-$(build_files): $(o)/bin/%.lua: lib/build/%.tl | $(bootstrap_files)
+$(build_files): $(o)/bin/%.lua: lib/build/%.tl lib/cosmic/tl-gen.lua | $(bootstrap_files)
 	@mkdir -p $(@D)
-	@$(bootstrap_cosmic) /zip/tl-gen.lua -- $< -o $@
+	@$(bootstrap_cosmic) lib/cosmic/tl-gen.lua -- $< -o $@
 	@{ echo '#!/usr/bin/env lua'; cat $@; } > $@.tmp && mv $@.tmp $@
 	@chmod +x $@
 reporter := $(bootstrap_cosmic) -- $(build_reporter)


### PR DESCRIPTION
Use `lib/cosmic/tl-gen.lua` directly instead of the bundled `/zip/tl-gen.lua`
to suppress "Wrote:" messages during bootstrap.

## Problem

After `make clean`, the CI output showed 6 spammy "Wrote:" lines:
```
Wrote: build-fetch.lua
Wrote: test-snap.lua
Wrote: make-help.lua
Wrote: reporter.lua
Wrote: build-stage.lua
Wrote: check-update.lua
```

The source file `lib/cosmic/tl-gen.lua` already had this output removed in
commit bc480e1, but the pre-built `bin/cosmic-lua` binary (from release
2026-01-12-5a4658b) still contains the old bundled version with the print.

## Solution

Instead of running the bundled `/zip/tl-gen.lua`, run the source file directly.
Cosmic can execute it since it has `tl.lua` bundled.

## Changes

- lib/build/cook.mk - use source tl-gen.lua, add it as dependency

## Validation

- [x] `make clean && make -j ci` passes with no "Wrote:" output
- [x] `make -j ci` second run is fully cached (8 lines)

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-13T05:45:03Z
</details>