### PR TITLE
aerospace: switch to tiles layout, rebind join-with

### DIFF
--- a/.aerospace.toml
+++ b/.aerospace.toml
@@ -18,10 +18,6 @@ enable-normalization-opposite-orientation-for-nested-containers = true
 # Accordion padding (shows edge of stacked windows)
 accordion-padding = 0
 
-# Default layout (accordion for stacked windows)
-default-root-container-layout = 'accordion'
-default-root-container-orientation = 'horizontal'
-
 # Exec environment
 [exec.env-vars]
 PATH = '${HOME}/.local/bin:${PATH}'
@@ -33,7 +29,7 @@ inner.horizontal = 0
 inner.vertical = 0
 outer.left = 0
 outer.bottom = 0
-outer.top = 1
+outer.top = 30
 outer.right = 0
 
 # Key mapping (use qwerty, dvorak, or colemak)
@@ -60,10 +56,10 @@ alt-shift-k = 'move up'
 alt-shift-l = 'move right'
 
 # Join windows (nest under common parent)
-alt-ctrl-h = 'join-with left'
-alt-ctrl-j = 'join-with down'
-alt-ctrl-k = 'join-with up'
-alt-ctrl-l = 'join-with right'
+cmd-shift-h = 'join-with left'
+cmd-shift-j = 'join-with down'
+cmd-shift-k = 'join-with up'
+cmd-shift-l = 'join-with right'
 
 # Focus monitors
 alt-comma = 'focus-monitor left'
@@ -117,11 +113,6 @@ k = 'resize smart -50'
 l = 'resize smart +50'
 enter = 'mode main'
 esc = 'mode main'
-
-# Auto-apply accordion layout to all windows
-[[on-window-detected]]
-if.during-aerospace-startup = false
-run = 'layout accordion'
 
 # Workspace 1: personal
 [[on-window-detected]]


### PR DESCRIPTION
## Summary
- Remove default accordion layout in favor of tiles
- Add top gap (30px) for menu bar visibility
- Rebind join-with from alt-ctrl to cmd-shift-h/j/k/l
- Remove on-window-detected accordion rule

## Test plan
- Reload aerospace config and verify tiles layout is default
- Test cmd-shift-h/j/k/l for join-with commands