### PR TITLE
ghostty: pass cmd+c through as ctrl+c

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -31,6 +31,7 @@ keybind = cmd+shift+w=quit
 keybind = cmd+w=text:\x17
 keybind = cmd+v=paste_from_clipboard
 keybind = cmd+c=copy_to_clipboard
+keybind = cmd+c=text:\x03
 keybind = shift+enter=text:\x1b\r
 
 keybind = cmd+h=unbind


### PR DESCRIPTION
## Summary
- Add keybind to pass cmd+c through as ctrl+c (0x03) for interrupt signal
- Works alongside existing copy_to_clipboard binding

## Test plan
- [ ] Press cmd+c in ghostty while running a process - should interrupt
- [ ] Press cmd+c with text selected - should still copy to clipboard