### PR TITLE
hammerspoon: remove invalid chooser API calls

### DIFF
--- a/.config/hammerspoon/chooser-style.lua
+++ b/.config/hammerspoon/chooser-style.lua
@@ -14,8 +14,6 @@ M.apply = function(chooser)
   chooser:width(widthPercent)
   chooser:rows(15)
   chooser:searchSubText(true)
-  chooser:showImages(false)
-  chooser:showShortcuts(false)
 end
 
 return M


### PR DESCRIPTION
## Summary
- Remove `showImages()` and `showShortcuts()` calls from chooser-style.lua
- These methods don't exist on `hs.chooser`, causing `aeroSwitcher.show()` to fail

## Test plan
- [x] Reload Hammerspoon config
- [x] Verify cmd+space / alt+space trigger the switcher without errors