### PR TITLE
cosmic: fix arg parsing to stop at script name

### DIFF
--- a/.github/pr/cosmic-fix-arg-parsing.md
+++ b/.github/pr/cosmic-fix-arg-parsing.md
@@ -1,0 +1,56 @@
+# cosmic: fix arg parsing to stop at script name
+
+Fixes argument parsing bug where script arguments were being consumed by cosmic's option parser instead of being passed to the script.
+
+## Problem
+
+When running a lua script via cosmic-lua, arguments like `--version` after the script name were consumed by cosmic-lua's option parser instead of being passed to the script:
+
+```bash
+# Expected: script sees arg[1] = "--version"
+# Actual: cosmic-lua consumes --version, script sees no args
+cosmic script.lua --version
+```
+
+This broke wrapper scripts like nvim that depend on receiving their own command-line flags.
+
+## Root cause
+
+`parse_args()` was passing all arguments to getopt, which would parse unknown options (like `--version` after the script name) and consume them, rather than stopping at the script name boundary.
+
+## Solution
+
+Implemented pre-scan approach that:
+- Scans arguments to find the first non-option argument (the script name)
+- Handles `--` separator as an explicit marker for end-of-options
+- Only passes arguments before the script name to getopt for parsing
+- Preserves all arguments after the script name as script arguments
+- Properly excludes `--` separators from script args
+
+This matches standard interpreter behavior (python, ruby, etc.) where option parsing stops at the script boundary.
+
+## Changes
+
+- lib/cosmic/main.tl - refactor parse_args() to pre-scan for script name
+  - Pre-scan arg array to locate script name before calling getopt
+  - Only pass cosmic options (before script name) to getopt
+  - Handle `--` separator to explicitly mark end of cosmic options
+  - Handle `?` return from getopt as genuine unknown option error
+  - Skip `--` separator when building script_args array
+
+- lib/cosmic/test_args.tl - add comprehensive tests for arg parsing fix
+  - Test --version flag passed to script (not consumed by cosmic -v)
+  - Test --help flag passed to script (not consumed by cosmic --help)
+  - Test -v flag passed to script after script name
+  - Test mixed cosmic options before script and script options after
+  - Test multiple option-like arguments after script name
+  - Test -- separator without following options
+  - Test real-world nvim-like pattern (script.lua --version)
+
+## Validation
+
+- [x] all existing tests pass
+- [x] new tests validate --version, --help, -v after script name
+- [x] cosmic's own options still work correctly (cosmic -v, cosmic -e, etc.)
+- [x] -- separator works as expected
+- [x] mixed cosmic and script options parse correctly

--- a/lib/cosmic/main.tl
+++ b/lib/cosmic/main.tl
@@ -40,56 +40,34 @@ local function parse_args(): Opts
     { "skill", "required", "s" },
   }
 
-  -- Pre-scan to find script name (first non-option arg)
-  -- This allows us to stop parsing options at the script boundary
-  local script_index: integer = nil
-  local i = 1
-  while i <= #arg do
+  -- Find first non-option argument (script name) to know where to stop parsing
+  local script_idx: integer = nil
+  for i = 1, #arg do
     local a = arg[i]
-    -- Check for -- separator (end of options marker)
     if a == "--" then
-      -- Everything after -- is positional args (script name + script args)
-      script_index = i + 1
+      -- Explicit end of options
+      script_idx = i + 1
       break
-    -- Check if this is an option
-    elseif a:sub(1, 1) == "-" then
-      -- It's an option, check if it takes an argument
-      if a == "-e" or a == "-l" or a == "-h" or a == "-s" or a == "--help" or a == "--skill" then
-        -- Option takes an argument, skip next arg
-        i = i + 2
-      elseif a:match("^%-[^-]") and #a > 2 then
-        -- Short option(s), might have bundled options like -ilv
-        -- For simplicity, just move to next
-        i = i + 1
-      else
-        i = i + 1
-      end
-    else
-      -- Found first non-option argument (script name)
-      script_index = i
+    elseif not a:match("^%-") then
+      -- First non-option is the script name
+      script_idx = i
       break
     end
   end
 
-  -- Only parse args up to (but not including) the script name or -- separator
-  local parse_args_list: {string} = {}
-  if script_index then
-    -- Parse args before script name, excluding -- if present
-    local limit = script_index - 1
-    if limit > 0 and arg[limit] == "--" then
-      limit = limit - 1
-    end
-    for j = 1, limit do
-      parse_args_list[#parse_args_list + 1] = arg[j]
+  -- Only parse cosmic options (before script name)
+  local cosmic_args: {string} = {}
+  if script_idx then
+    for i = 1, script_idx - 1 do
+      if arg[i] ~= "--" then  -- Exclude -- separator
+        cosmic_args[#cosmic_args + 1] = arg[i]
+      end
     end
   else
-    -- No script found, parse all args
-    for j = 1, #arg do
-      parse_args_list[#parse_args_list + 1] = arg[j]
-    end
+    cosmic_args = arg
   end
 
-  local parser = getopt.new(parse_args_list, "e:l:ivEWh::s:", longopts)
+  local parser = getopt.new(cosmic_args, "e:l:ivEWh::s:", longopts)
 
   -- Iterate through all options
   while true do
@@ -99,7 +77,7 @@ local function parse_args(): Opts
     end
 
     if opt == "?" then
-      -- Unknown option encountered during parsing
+      -- Unknown cosmic option
       io.stderr:write("cosmic-lua: unknown option '" .. optarg .. "'\n")
       os.exit(1)
     elseif opt == "e" then
@@ -129,32 +107,19 @@ local function parse_args(): Opts
     end
   end
 
-  -- Handle script and script args (if found during pre-scan)
-  if script_index then
-    opts.script = arg[script_index]
-    opts.script_args[0] = arg[script_index]
-    -- Add all args after script name as script args, skipping -- separator if present
+  -- Handle script and script args (from original arg, starting at script_idx)
+  if script_idx then
+    opts.script = arg[script_idx]
+    opts.script_args[0] = arg[script_idx]
     local arg_num = 1
-    for j = script_index + 1, #arg do
+    for i = script_idx + 1, #arg do
       -- Skip -- separator
-      if arg[j] == "--" then
-        -- Skip it
-      else
-        opts.script_args[arg_num] = arg[j]
+      if arg[i] ~= "--" then
+        opts.script_args[arg_num] = arg[i]
         arg_num = arg_num + 1
       end
     end
     opts.script_args[-1] = arg[-1]
-  else
-    -- No script found, check if getopt has remaining args
-    local rest = parser:remaining()
-    if rest and #rest > 0 then
-      opts.script = rest[1]
-      for j = 1, #rest do
-        opts.script_args[j - 1] = rest[j]
-      end
-      opts.script_args[-1] = arg[-1]
-    end
   end
 
   return opts

--- a/lib/cosmic/main.tl
+++ b/lib/cosmic/main.tl
@@ -40,7 +40,56 @@ local function parse_args(): Opts
     { "skill", "required", "s" },
   }
 
-  local parser = getopt.new(arg, "e:l:ivEWh::s:", longopts)
+  -- Pre-scan to find script name (first non-option arg)
+  -- This allows us to stop parsing options at the script boundary
+  local script_index: integer = nil
+  local i = 1
+  while i <= #arg do
+    local a = arg[i]
+    -- Check for -- separator (end of options marker)
+    if a == "--" then
+      -- Everything after -- is positional args (script name + script args)
+      script_index = i + 1
+      break
+    -- Check if this is an option
+    elseif a:sub(1, 1) == "-" then
+      -- It's an option, check if it takes an argument
+      if a == "-e" or a == "-l" or a == "-h" or a == "-s" or a == "--help" or a == "--skill" then
+        -- Option takes an argument, skip next arg
+        i = i + 2
+      elseif a:match("^%-[^-]") and #a > 2 then
+        -- Short option(s), might have bundled options like -ilv
+        -- For simplicity, just move to next
+        i = i + 1
+      else
+        i = i + 1
+      end
+    else
+      -- Found first non-option argument (script name)
+      script_index = i
+      break
+    end
+  end
+
+  -- Only parse args up to (but not including) the script name or -- separator
+  local parse_args_list: {string} = {}
+  if script_index then
+    -- Parse args before script name, excluding -- if present
+    local limit = script_index - 1
+    if limit > 0 and arg[limit] == "--" then
+      limit = limit - 1
+    end
+    for j = 1, limit do
+      parse_args_list[#parse_args_list + 1] = arg[j]
+    end
+  else
+    -- No script found, parse all args
+    for j = 1, #arg do
+      parse_args_list[#parse_args_list + 1] = arg[j]
+    end
+  end
+
+  local parser = getopt.new(parse_args_list, "e:l:ivEWh::s:", longopts)
 
   -- Iterate through all options
   while true do
@@ -49,7 +98,11 @@ local function parse_args(): Opts
       break
     end
 
-    if opt == "e" then
+    if opt == "?" then
+      -- Unknown option encountered during parsing
+      io.stderr:write("cosmic-lua: unknown option '" .. optarg .. "'\n")
+      os.exit(1)
+    elseif opt == "e" then
       opts.execute[#opts.execute + 1] = optarg
     elseif opt == "l" then
       opts.load[#opts.load + 1] = optarg
@@ -76,14 +129,32 @@ local function parse_args(): Opts
     end
   end
 
-  -- Handle remaining arguments (script and script args)
-  local rest = parser:remaining()
-  if rest and #rest > 0 then
-    opts.script = rest[1]
-    for j = 1, #rest do
-      opts.script_args[j - 1] = rest[j]
+  -- Handle script and script args (if found during pre-scan)
+  if script_index then
+    opts.script = arg[script_index]
+    opts.script_args[0] = arg[script_index]
+    -- Add all args after script name as script args, skipping -- separator if present
+    local arg_num = 1
+    for j = script_index + 1, #arg do
+      -- Skip -- separator
+      if arg[j] == "--" then
+        -- Skip it
+      else
+        opts.script_args[arg_num] = arg[j]
+        arg_num = arg_num + 1
+      end
     end
     opts.script_args[-1] = arg[-1]
+  else
+    -- No script found, check if getopt has remaining args
+    local rest = parser:remaining()
+    if rest and #rest > 0 then
+      opts.script = rest[1]
+      for j = 1, #rest do
+        opts.script_args[j - 1] = rest[j]
+      end
+      opts.script_args[-1] = arg[-1]
+    end
   end
 
   return opts

--- a/lib/cosmic/main.tl
+++ b/lib/cosmic/main.tl
@@ -35,20 +35,62 @@ local function parse_args(): Opts
     script_args = {},
   }
 
+  local shortopts = "e:l:ivEWh::s:"
   local longopts: {LongOpt} = {
     { "help", "optional", "h" },
     { "skill", "required", "s" },
   }
 
+  -- Parse shortopts to build set of options that require arguments
+  local short_needs_arg: {string:boolean} = {}
+  local j = 1
+  while j <= #shortopts do
+    local c = shortopts:sub(j, j)
+    if c ~= ":" then
+      -- Check if followed by : (required arg) but not :: (optional arg)
+      if j < #shortopts and shortopts:sub(j+1, j+1) == ":" and
+         (j+1 >= #shortopts or shortopts:sub(j+2, j+2) ~= ":") then
+        short_needs_arg[c] = true
+      end
+    end
+    j = j + 1
+  end
+
+  -- Parse longopts to build set of options that require arguments
+  local long_needs_arg: {string:boolean} = {}
+  for _, opt in ipairs(longopts) do
+    if opt[2] == "required" then
+      long_needs_arg[opt[1]] = true
+    end
+  end
+
   -- Find first non-option argument (script name) to know where to stop parsing
   local script_idx: integer = nil
-  for i = 1, #arg do
+  local i = 1
+  while i <= #arg do
     local a = arg[i]
     if a == "--" then
       -- Explicit end of options
       script_idx = i + 1
       break
-    elseif not a:match("^%-") then
+    elseif a:sub(1, 2) == "--" then
+      -- Long option
+      local opt_name = a:sub(3)
+      if not opt_name:find("=") and long_needs_arg[opt_name] then
+        -- Takes next arg
+        i = i + 2
+      else
+        i = i + 1
+      end
+    elseif a:sub(1, 1) == "-" and #a > 1 then
+      -- Short option
+      if #a == 2 and short_needs_arg[a:sub(2, 2)] then
+        -- Single short option that takes arg
+        i = i + 2
+      else
+        i = i + 1
+      end
+    else
       -- First non-option is the script name
       script_idx = i
       break
@@ -67,7 +109,7 @@ local function parse_args(): Opts
     cosmic_args = arg
   end
 
-  local parser = getopt.new(cosmic_args, "e:l:ivEWh::s:", longopts)
+  local parser = getopt.new(cosmic_args, shortopts, longopts)
 
   -- Iterate through all options
   while true do

--- a/lib/cosmic/test_args.tl
+++ b/lib/cosmic/test_args.tl
@@ -199,3 +199,142 @@ end
   assert((out as string):find("args_count=2"), "main should receive 2 args")
 end
 test_cosmo_is_main_compatibility()
+
+-- Test that --version after script name is passed to script (not consumed by cosmic)
+local function test_version_flag_after_script()
+  local script = path.join(tmpdir, "version_arg.lua")
+  cosmo.Barf(script, [[
+local args = {...}
+print("args_count=" .. #arg)
+for i, v in ipairs(args) do
+  print("arg[" .. i .. "]=" .. v)
+end
+]])
+
+  local ok, out = spawn({cosmic, script, "--version"}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("args_count=1"), "should have 1 arg")
+  assert((out as string):find("arg%[1%]=%-%-version"), "arg[1] should be --version")
+end
+test_version_flag_after_script()
+
+-- Test that --help after script name is passed to script (not consumed by cosmic)
+local function test_help_flag_after_script()
+  local script = path.join(tmpdir, "help_arg.lua")
+  cosmo.Barf(script, [[
+local args = {...}
+print("args_count=" .. #arg)
+for i, v in ipairs(args) do
+  print("arg[" .. i .. "]=" .. v)
+end
+]])
+
+  local ok, out = spawn({cosmic, script, "--help"}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("args_count=1"), "should have 1 arg")
+  assert((out as string):find("arg%[1%]=%-%-help"), "arg[1] should be --help")
+end
+test_help_flag_after_script()
+
+-- Test that -v after script name is passed to script (not consumed by cosmic)
+local function test_v_flag_after_script()
+  local script = path.join(tmpdir, "v_arg.lua")
+  cosmo.Barf(script, [[
+local args = {...}
+print("args_count=" .. #arg)
+for i, v in ipairs(args) do
+  print("arg[" .. i .. "]=" .. v)
+end
+]])
+
+  local ok, out = spawn({cosmic, script, "-v"}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("args_count=1"), "should have 1 arg")
+  assert((out as string):find("arg%[1%]=%-v"), "arg[1] should be -v")
+end
+test_v_flag_after_script()
+
+-- Test cosmic options before script and script options after
+local function test_mixed_cosmic_and_script_options()
+  local script = path.join(tmpdir, "mixed.lua")
+  cosmo.Barf(script, [[
+local args = {...}
+print("args_count=" .. #arg)
+for i, v in ipairs(args) do
+  print("arg[" .. i .. "]=" .. v)
+end
+]])
+
+  -- cosmic -e before script, then script gets --version
+  local ok, out = spawn({cosmic, "-e", "print('cosmic executed')", script, "--version", "arg2"}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("cosmic executed"), "cosmic -e should execute")
+  assert((out as string):find("args_count=2"), "script should have 2 args")
+  assert((out as string):find("arg%[1%]=%-%-version"), "arg[1] should be --version")
+  assert((out as string):find("arg%[2%]=arg2"), "arg[2] should be arg2")
+end
+test_mixed_cosmic_and_script_options()
+
+-- Test multiple option-like arguments after script name
+local function test_multiple_option_like_args()
+  local script = path.join(tmpdir, "multi_opts.lua")
+  cosmo.Barf(script, [[
+local args = {...}
+print("args_count=" .. #arg)
+for i, v in ipairs(args) do
+  print("arg[" .. i .. "]=" .. v)
+end
+]])
+
+  local ok, out = spawn({cosmic, script, "--version", "--help", "-v", "-i", "--unknown"}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("args_count=5"), "should have 5 args")
+  assert((out as string):find("arg%[1%]=%-%-version"), "arg[1] should be --version")
+  assert((out as string):find("arg%[2%]=%-%-help"), "arg[2] should be --help")
+  assert((out as string):find("arg%[3%]=%-v"), "arg[3] should be -v")
+  assert((out as string):find("arg%[4%]=%-i"), "arg[4] should be -i")
+  assert((out as string):find("arg%[5%]=%-%-unknown"), "arg[5] should be --unknown")
+end
+test_multiple_option_like_args()
+
+-- Test that -- separator works without script options after it
+local function test_separator_with_no_following_options()
+  local script = path.join(tmpdir, "separator_simple.lua")
+  cosmo.Barf(script, [[
+local args = {...}
+print("args_count=" .. #arg)
+for i, v in ipairs(args) do
+  print("arg[" .. i .. "]=" .. v)
+end
+]])
+
+  local ok, out = spawn({cosmic, script, "--", "arg1", "arg2"}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("args_count=2"), "should have 2 args")
+  assert((out as string):find("arg%[1%]=arg1"), "arg[1] should be arg1")
+  assert((out as string):find("arg%[2%]=arg2"), "arg[2] should be arg2")
+  -- Ensure -- separator is not included in script args
+  assert(not (out as string):find("arg%[%d+%]=%-%-$"), "-- should not be in script args")
+end
+test_separator_with_no_following_options()
+
+-- Test real-world nvim-like case: script.lua --version
+local function test_nvim_version_pattern()
+  local script = path.join(tmpdir, "nvim_like.lua")
+  cosmo.Barf(script, [[
+-- Simulate nvim-like wrapper that checks for --version
+for i = 1, #arg do
+  if arg[i] == "--version" then
+    print("NVIM v0.12.0-dev")
+    os.exit(0)
+  end
+end
+print("No --version flag found")
+]])
+
+  local ok, out = spawn({cosmic, script, "--version"}):read()
+  assert(ok, "cosmic should succeed")
+  assert((out as string):find("NVIM v0%.12%.0%-dev"), "script should handle --version")
+  assert(not (out as string):find("No %-%-version flag found"), "should not print fallback message")
+end
+test_nvim_version_pattern()


### PR DESCRIPTION
Script arguments were being consumed by cosmic's option parser. When
running `cosmic script.lua --version`, the `--version` flag was being
parsed as a cosmic option instead of being passed to the script.

Fix by pre-scanning arguments to find the script name (first non-option
argument or first argument after `--`), then only parsing arguments
before the script name. This matches standard interpreter behavior
(python, ruby, etc.) where option parsing stops at the script boundary.

Changes:
- Pre-scan arg array to locate script name before calling getopt
- Only pass cosmic options (before script name) to getopt
- Handle `--` separator to explicitly mark end of cosmic options
- Handle `?` return from getopt as genuine unknown option error
- Skip `--` separator when building script_args array

Fixes issue where script arguments like --version, --help, etc. were
being consumed instead of passed through to the script.