### PR TITLE
claude: add PR description template instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,7 +6,7 @@
 
 **CRITICAL: You MUST create and maintain a PR description file for every branch.**
 
-This file describes what's happening on the branch and MUST be kept up to date before every push.
+This file describes what's happening on the branch. Update it before every push.
 
 1. Create `.github/pr/<slug>.md` with a descriptive slug (e.g., `add-auth-logging.md`, `fix-parser-edge-case.md`)
 2. Use this format:
@@ -20,31 +20,13 @@ Brief description of what this change does and why.
 
 - `path/to/file.lua` - what it does
 - `path/to/other.lua` - what it does
-
-## Validation
-
-- [x] tests pass
-- [x] linter passes
 ```
-
-3. Add the trailer `x-cosmic-pr-name: <slug>.md` to your commit message:
-
-```
-component: brief description
-
-Longer explanation if needed.
-
-x-cosmic-pr-name: <slug>.md
-```
-
-The PR skill (`cosmic --skill pr`) reads this file and updates the GitHub PR title and description automatically when pushed.
 
 **Guidelines:**
 - Choose a descriptive, kebab-case slug
 - Title format: `component: verb explanation` (sentence case)
 - Keep descriptions concise but include key decisions and tradeoffs
 - **Update the file before every push** to reflect the current state of the branch
-- The `.md` extension in the trailer is optional
 
 ## Writing
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,9 +4,9 @@
 
 ## Pull request descriptions
 
-**CRITICAL: You MUST create a PR description file for every change.**
+**CRITICAL: You MUST create and maintain a PR description file for every branch.**
 
-Before committing any change:
+This file describes what's happening on the branch and MUST be kept up to date before every push.
 
 1. Create `.github/pr/<slug>.md` with a descriptive slug (e.g., `add-auth-logging.md`, `fix-parser-edge-case.md`)
 2. Use this format:
@@ -43,7 +43,7 @@ The PR skill (`cosmic --skill pr`) reads this file and updates the GitHub PR tit
 - Choose a descriptive, kebab-case slug
 - Title format: `component: verb explanation` (sentence case)
 - Keep descriptions concise but include key decisions and tradeoffs
-- Update the file as the PR evolves
+- **Update the file before every push** to reflect the current state of the branch
 - The `.md` extension in the trailer is optional
 
 ## Writing

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,50 @@
 
 - ALWAYS consider available skills. Almost every session will involve one or more skills, and the most relevant skills should be evident early in the session.
 
+## Pull request descriptions
+
+**CRITICAL: You MUST create a PR description file for every change.**
+
+Before committing any change:
+
+1. Create `.github/pr/<slug>.md` with a descriptive slug (e.g., `add-auth-logging.md`, `fix-parser-edge-case.md`)
+2. Use this format:
+
+```markdown
+# component: verb explanation
+
+Brief description of what this change does and why.
+
+## Changes
+
+- `path/to/file.lua` - what it does
+- `path/to/other.lua` - what it does
+
+## Validation
+
+- [x] tests pass
+- [x] linter passes
+```
+
+3. Add the trailer `x-cosmic-pr-name: <slug>.md` to your commit message:
+
+```
+component: brief description
+
+Longer explanation if needed.
+
+x-cosmic-pr-name: <slug>.md
+```
+
+The PR skill (`cosmic --skill pr`) reads this file and updates the GitHub PR title and description automatically when pushed.
+
+**Guidelines:**
+- Choose a descriptive, kebab-case slug
+- Title format: `component: verb explanation` (sentence case)
+- Keep descriptions concise but include key decisions and tradeoffs
+- Update the file as the PR evolves
+- The `.md` extension in the trailer is optional
+
 ## Writing
 
 - Always use sentence case

--- a/.github/pr/add-pr-description-template.md
+++ b/.github/pr/add-pr-description-template.md
@@ -7,14 +7,4 @@ Adds a critical instruction to `.claude/CLAUDE.md` requiring PR description file
 - `.claude/CLAUDE.md` - added "Pull request descriptions" section requiring:
   - Creation of `.github/pr/<slug>.md` for every branch
   - Keeping the file up to date before every push
-  - Format template with title, changes, and validation sections
-  - Commit trailer usage (`x-cosmic-pr-name`)
-
-## Why
-
-Ensures all branches have proper documentation describing what's happening, which the `cosmic --skill pr` workflow uses to automatically update GitHub PR titles and descriptions.
-
-## Validation
-
-- [x] instructions match existing PR file format
-- [x] compatible with `cosmic --skill pr`
+  - Format template with title and changes sections

--- a/.github/pr/add-pr-description-template.md
+++ b/.github/pr/add-pr-description-template.md
@@ -1,0 +1,16 @@
+# claude: add PR description template instructions
+
+Adds a critical instruction to `.claude/CLAUDE.md` requiring PR description files for every change.
+
+## Changes
+
+- `.claude/CLAUDE.md` - added "Pull request descriptions" section with format requirements, commit trailer usage, and guidelines
+
+## Why
+
+Ensures all changes have proper documentation in `.github/pr/<slug>.md` files, which the `cosmic --skill pr` workflow uses to automatically update GitHub PR titles and descriptions.
+
+## Validation
+
+- [x] instructions match existing PR file format
+- [x] compatible with `cosmic --skill pr`

--- a/.github/pr/add-pr-description-template.md
+++ b/.github/pr/add-pr-description-template.md
@@ -1,14 +1,18 @@
 # claude: add PR description template instructions
 
-Adds a critical instruction to `.claude/CLAUDE.md` requiring PR description files for every change.
+Adds a critical instruction to `.claude/CLAUDE.md` requiring PR description files for every branch.
 
 ## Changes
 
-- `.claude/CLAUDE.md` - added "Pull request descriptions" section with format requirements, commit trailer usage, and guidelines
+- `.claude/CLAUDE.md` - added "Pull request descriptions" section requiring:
+  - Creation of `.github/pr/<slug>.md` for every branch
+  - Keeping the file up to date before every push
+  - Format template with title, changes, and validation sections
+  - Commit trailer usage (`x-cosmic-pr-name`)
 
 ## Why
 
-Ensures all changes have proper documentation in `.github/pr/<slug>.md` files, which the `cosmic --skill pr` workflow uses to automatically update GitHub PR titles and descriptions.
+Ensures all branches have proper documentation describing what's happening, which the `cosmic --skill pr` workflow uses to automatically update GitHub PR titles and descriptions.
 
 ## Validation
 


### PR DESCRIPTION
Adds a critical instruction to `.claude/CLAUDE.md` requiring PR description files for every branch.

## Changes

- `.claude/CLAUDE.md` - added "Pull request descriptions" section requiring:
  - Creation of `.github/pr/<slug>.md` for every branch
  - Keeping the file up to date before every push
  - Format template with title and changes sections

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-14T01:32:56Z
</details>