### PR TITLE
Remove unsupported platform flag from setup

### DIFF
--- a/.github/pr/remove-platform-flag.md
+++ b/.github/pr/remove-platform-flag.md
@@ -1,0 +1,15 @@
+# home: remove --with-platform flag support
+
+Remove support for the deprecated `--with-platform` flag in the home binary and update setup.sh to not use it.
+
+## Changes
+
+- `lib/home/main.tl` - refactor parse_args to use cosmo.getopt instead of manual parsing, which properly rejects unknown flags
+- `lib/home/test_main.tl` - add tests to verify unknown flags are rejected
+- `setup.sh` - remove --with-platform flag from home unpack command
+
+## Background
+
+The `--with-platform` flag was previously used to download platform-specific assets at runtime. This is no longer needed since we now build platform-specific binaries directly. The flag was still being passed in setup.sh but was silently ignored due to manual arg parsing that didn't validate unknown flags.
+
+By switching to cosmo.getopt, we now properly reject unknown flags and prevent this kind of issue in the future.

--- a/lib/home/main.tl
+++ b/lib/home/main.tl
@@ -2,6 +2,7 @@
 local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
+local getopt = require("cosmo.getopt")
 
 local function read_file(filepath: string): string, string
   local f, err = io.open(filepath, "rb")
@@ -205,24 +206,54 @@ local function parse_args(args: {string}): ParsedArgs
     dest = nil,
   }
 
-  local i = 2
-  while i <= #args do
-    if args[i] == "--force" or args[i] == "-f" then
+  if #args < 2 then
+    return result
+  end
+
+  local cmd_args: {string} = {}
+  for i = 2, #args do
+    table.insert(cmd_args, args[i])
+  end
+
+  local longopts = {
+    {"force", "none"},
+    {"verbose", "none"},
+    {"dry-run", "none"},
+    {"only", "none"},
+    {"null", "none"},
+  }
+  local parser = getopt.new(cmd_args, "fvn0", longopts)
+
+  while true do
+    local opt, _ = parser:next()
+    if not opt then break end
+
+    if opt == "f" or opt == "force" then
       result.force = true
-    elseif args[i] == "--verbose" or args[i] == "-v" then
+    elseif opt == "v" or opt == "verbose" then
       result.verbose = true
-    elseif args[i] == "--dry-run" or args[i] == "-n" then
+    elseif opt == "n" or opt == "dry-run" then
       result.dry_run = true
-    elseif args[i] == "--only" then
+    elseif opt == "only" then
       result.only = true
-    elseif args[i] == "--null" or args[i] == "-0" then
+    elseif opt == "0" or opt == "null" then
       result.null = true
-    elseif result.cmd == "mac" and not result.subcmd and not args[i]:match("^%-") then
-      result.subcmd = args[i]
-    elseif not result.dest then
-      result.dest = args[i]
+    elseif opt == "?" then
+      io.stderr:write("error: invalid option\n")
+      os.exit(1)
     end
-    i = i + 1
+  end
+
+  local remaining = parser:remaining()
+  if remaining and #remaining > 0 then
+    if result.cmd == "mac" and not remaining[1]:match("^%-") then
+      result.subcmd = remaining[1]
+      if #remaining > 1 then
+        result.dest = remaining[2]
+      end
+    else
+      result.dest = remaining[1]
+    end
   end
 
   return result

--- a/lib/home/test_main.tl
+++ b/lib/home/test_main.tl
@@ -189,3 +189,12 @@ ret = home.cmd_list({
   stdout = out.stdout_obj,
 })
 assert(ret == 0, "cmd_list valid manifest should return 0")
+
+-- Test unknown flags are rejected
+local handle = spawn({home_bin, "unpack", "--with-platform", TEST_TMPDIR})
+local exit_code = handle:wait()
+assert(exit_code ~= 0, "unknown flag --with-platform should fail, got exit code: " .. tostring(exit_code))
+
+handle = spawn({home_bin, "unpack", "--unknown-flag", TEST_TMPDIR})
+exit_code = handle:wait()
+assert(exit_code ~= 0, "unknown flag --unknown-flag should fail")

--- a/setup.sh
+++ b/setup.sh
@@ -53,7 +53,7 @@ install_home() {
 
 main() {
   home_bin=$(install_home) || return 1
-  "${home_bin}" unpack --force --with-platform --verbose "$HOME"
+  "${home_bin}" unpack --force --verbose "$HOME"
   "${home_bin}" setup --verbose "$HOME"
   rm -rf "$(dirname "${home_bin}")"
 }


### PR DESCRIPTION
The home binary was using manual arg parsing which silently ignored unknown flags like --with-platform. This caused setup.sh to pass the deprecated flag without error.

Changes:
- Switch parse_args to use cosmo.getopt for proper flag validation
- Add tests to verify unknown flags are rejected
- Remove --with-platform from setup.sh

Unknown flags now produce an error message and exit code 1.