### PR TITLE
Bump Cosmos to 2026.01.14

### DIFF
--- a/.github/pr/bump-cosmos.md
+++ b/.github/pr/bump-cosmos.md
@@ -1,0 +1,7 @@
+# cosmos: bump to 2026.01.14-dff272e74
+
+Update cosmos dependency to the latest release from 2026.01.08-e226a5d6a.
+
+## Changes
+
+- `3p/cosmos/version.lua` - update version and SHA256 hash for latest release

--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format="zip",
-  platforms={["*"]={sha="89252076290537a66046df14665f227d3d63ee93830160b95ad6688df059eba1"}},
+  platforms={["*"]={sha="661d9b89b1742f258edccd76dadc78ee6fbd5f8cfc980f28a800542229639357"}},
   strip_components=0,
   url="https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version="2026.01.08-e226a5d6a"
+  version="2026.01.14-dff272e74"
 }


### PR DESCRIPTION
Update cosmos dependency from 2026.01.08-e226a5d6a to the latest release.