### PR TITLE
Fix remaining manual argument parsing cases

### DIFF
--- a/.github/pr/convert-to-cosmo-getopt.md
+++ b/.github/pr/convert-to-cosmo-getopt.md
@@ -1,0 +1,11 @@
+# argparse: convert manual parsing to cosmo.getopt
+
+Convert remaining manual argument parsing implementations to use cosmo.getopt for consistency and proper validation. This follows the pattern established in PR #367 which converted the home binary.
+
+## Changes
+
+- `lib/nvim/main.tl` - convert parse_socket_option to use getopt for --socket flag
+- `lib/cleanshot/init.tl` - convert parse_flags to use getopt for all cleanshot flags
+- `lib/cosmic/tl-gen.lua` - convert manual -o/--output parsing to use getopt
+
+All three modules now properly validate options and reject unknown flags with error messages, improving consistency across the codebase.

--- a/lib/cleanshot/init.tl
+++ b/lib/cleanshot/init.tl
@@ -1,5 +1,6 @@
 local unix = require("cosmo.unix")
 local cpath = require("cosmo.path")
+local getopt = require("cosmo.getopt")
 
 local VALID_COMMANDS: {string:boolean} = {
   ["all-in-one"] = true,
@@ -57,27 +58,34 @@ local function expand_path(p: string): string
 end
 
 local function parse_flags(args: {string}): Flags, string
+  local longopts = {
+    {"x", "required"},
+    {"y", "required"},
+    {"width", "required"},
+    {"height", "required"},
+    {"display", "required"},
+    {"action", "required"},
+    {"filepath", "required"},
+    {"tab", "required"},
+    {"path", "required"},
+    {"start", "none"},
+    {"autoscroll", "none"},
+    {"linebreaks", "none"},
+  }
+  local parser = getopt.new(args, "", longopts)
+
   local flags: Flags = {}
-  local i = 1
 
-  while i <= #args do
-    local a = args[i]
-    if a:match("^%-") then
-      local key = a:match("^%-(.+)$")
+  while true do
+    local opt, optarg = parser:next()
+    if not opt then break end
 
-      if BOOLEAN_FLAGS[key] then
-        flags[key] = "true"
-        i = i + 1
-      else
-        if i + 1 <= #args then
-          flags[key] = args[i + 1]
-          i = i + 2
-        else
-          return nil, "flag -" .. key .. " requires a value"
-        end
-      end
+    if opt == "?" then
+      return nil, "invalid option"
+    elseif BOOLEAN_FLAGS[opt] then
+      flags[opt] = "true"
     else
-      i = i + 1
+      flags[opt] = optarg
     end
   end
 

--- a/lib/cosmic/tl-gen.lua
+++ b/lib/cosmic/tl-gen.lua
@@ -3,22 +3,34 @@
 -- Usage: cosmic -- tl-gen.lua INPUT -o OUTPUT
 
 local tl = require("tl")
+local getopt = require("cosmo.getopt")
 
 local function main(...)
   local args = {...}
+
+  local longopts = {
+    {"output", "required", "o"},
+  }
+  local parser = getopt.new(args, "o:", longopts)
+
   local input_file = nil
   local output_file = nil
 
-  -- Parse args: INPUT -o OUTPUT
-  local i = 1
-  while i <= #args do
-    if args[i] == "-o" or args[i] == "--output" then
-      i = i + 1
-      output_file = args[i]
-    elseif not input_file then
-      input_file = args[i]
+  while true do
+    local opt, optarg = parser:next()
+    if not opt then break end
+
+    if opt == "?" then
+      io.stderr:write("error: invalid option\n")
+      return 1
+    elseif opt == "o" or opt == "output" then
+      output_file = optarg
     end
-    i = i + 1
+  end
+
+  local remaining = parser:remaining()
+  if remaining and #remaining > 0 then
+    input_file = remaining[1]
   end
 
   if not input_file or not output_file then

--- a/lib/nvim/main.tl
+++ b/lib/nvim/main.tl
@@ -1,5 +1,6 @@
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
+local getopt = require("cosmo.getopt")
 local version = require("version")
 local whereami = require("whereami")
 local daemonize = require("daemonize")
@@ -70,21 +71,26 @@ local function derive_paths(sock: string): Paths
 end
 
 local function parse_socket_option(args: {string}): string, {string}
-  local socket_path: string = nil
-  local new_args: {string} = {}
-  local i = 1
+  local longopts = {
+    {"socket", "required"},
+  }
+  local parser = getopt.new(args, "", longopts)
 
-  while i <= #args do
-    if args[i] == "--socket" and i < #args then
-      socket_path = args[i + 1]
-      i = i + 2
-    else
-      table.insert(new_args, args[i])
-      i = i + 1
+  local socket_path: string = nil
+
+  while true do
+    local opt, optarg = parser:next()
+    if not opt then break end
+
+    if opt == "?" then
+      io.stderr:write("error: invalid option\n")
+      os.exit(1)
+    elseif opt == "socket" then
+      socket_path = optarg
     end
   end
 
-  return socket_path, new_args
+  return socket_path, parser:remaining()
 end
 
 local function expand_tilde(file_path: string): string


### PR DESCRIPTION
Convert remaining manual argument parsing to use cosmo.getopt:
- lib/nvim/main.tl: parse_socket_option now uses getopt
- lib/cleanshot/init.tl: parse_flags now uses getopt
- lib/cosmic/tl-gen.lua: -o/--output parsing now uses getopt

This provides consistent argument validation and proper error handling for unknown options across all modules.