### PR TITLE
build: add .zip artifacts for home modules

### DIFF
--- a/.github/pr/add-zip-build-artifacts.md
+++ b/.github/pr/add-zip-build-artifacts.md
@@ -1,0 +1,18 @@
+# build: add .zip artifacts for home modules
+
+Modify the build system to create individual .zip artifacts for each 3p module, preserving file types (symlinks) and modes while simplifying extraction.
+
+## Changes
+
+- `lib/build/build-zip.tl` - new script to create versioned .zip artifacts for each staged module
+- `lib/build/cook.mk` - add build-zip to build files
+- `Makefile` - add .zipped targets and rules to create module zips after staging
+- `lib/home/cook.mk` - bundle pre-created .zip artifacts instead of copying directory trees
+- `lib/home/main.tl` - extract module zips from `/zip/zips/` during home unpack
+
+## Benefits
+
+- Preserves symlinks and file modes (zip handles this natively)
+- Automatic versioned paths like `.local/share/gh/2.83.2-ca6e764/bin/gh`
+- Simpler extraction logic (iterate and extract each zip)
+- Reduces home build complexity by pre-creating artifacts

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,16 @@ $(o)/%/.staged: .UNVEIL = rx:$(o)/bootstrap r:3p rwc:$(o) rx:/usr/bin
 $(o)/%/.staged: $(o)/%/.fetched $(build_files)
 	@$(build_stage) $$(readlink $(o)/$*/.versioned) $(platform) $< $@
 
+# versions get zipped: o/module/.zip
+.PHONY: zipped
+all_zipped := $(patsubst %/.staged,%/.zip,$(all_staged))
+## Create .zip artifacts for all 3p modules
+zipped: $(all_zipped)
+$(o)/%/.zip: .PLEDGE = stdio rpath wpath cpath proc exec
+$(o)/%/.zip: .UNVEIL = rx:$(o)/bootstrap r:3p rwc:$(o) rwc:/tmp rx:/usr/bin
+$(o)/%/.zip: $(o)/%/.staged $(build_files)
+	@$(build_zip) $$(readlink $(o)/$*/.versioned) $(platform) $< $@
+
 all_tests := $(call filter-only,$(foreach x,$(modules),$($(x)_tests)))
 all_tested := $(patsubst %,o/%.test.ok,$(all_tests))
 all_snaps := $(call filter-only,$(foreach x,$(modules),$($(x)_snaps)))

--- a/lib/build/build-zip.tl
+++ b/lib/build/build-zip.tl
@@ -1,0 +1,117 @@
+#!/usr/bin/env lua
+-- build-zip.tl: create versioned .zip artifacts for 3p modules
+
+local cosmo = require("cosmo")
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+local spawn = require("cosmic.spawn")
+
+local record PlatformSpec
+  sha: string
+  format: string
+end
+
+local record VersionSpec
+  version: string
+  platforms: {string:PlatformSpec}
+end
+
+local function main(version_file: string, platform: string, staged_symlink: string, output_zip: string): boolean, string
+  if not version_file or not platform or not staged_symlink or not output_zip then
+    return nil, "usage: build-zip.lua <version_file> <platform> <staged_symlink> <output.zip>"
+  end
+
+  local load_ok, spec = pcall(dofile, version_file) as (boolean, VersionSpec)
+  if not load_ok then
+    return nil, "failed to load " .. version_file .. ": " .. tostring(spec)
+  end
+
+  local plat = spec.platforms[platform] or spec.platforms["*"]
+  if not plat then
+    return nil, "unknown platform: " .. platform
+  end
+
+  -- derive module name from staged_symlink path: o/<module>/.staged
+  local staged_dir = path.dirname(staged_symlink)
+  local module_name = path.basename(staged_dir)
+
+  -- make staged_symlink absolute for unix.readlink
+  local staged_symlink_abs: string
+  if staged_symlink:sub(1, 1) == "/" then
+    staged_symlink_abs = staged_symlink
+  else
+    local cwd = unix.getcwd()
+    staged_symlink_abs = path.join(cwd, staged_symlink)
+  end
+
+  -- read the staged directory path
+  local staged_path = unix.readlink(staged_symlink_abs, 1024)
+  if not staged_path then
+    return nil, "failed to read symlink " .. staged_symlink
+  end
+
+  -- resolve to absolute path
+  local staged_abs: string
+  if staged_path:sub(1, 1) == "/" then
+    staged_abs = staged_path
+  else
+    staged_abs = path.join(path.dirname(staged_symlink), staged_path)
+  end
+
+  -- get versioned name from staged path
+  local versioned_name = path.basename(staged_abs)
+
+  -- create a temporary directory for building the zip structure
+  local temp_dir = unix.mkdtemp("/tmp/build-zip_XXXXXX")
+  if not temp_dir then
+    return nil, "failed to create temp directory"
+  end
+
+  -- create the target structure: <module>/<versioned_name>/
+  local zip_root = path.join(temp_dir, module_name, versioned_name)
+  local ok_mk = unix.makedirs(zip_root)
+  if not ok_mk then
+    unix.rmrf(temp_dir)
+    return nil, "failed to create directory structure"
+  end
+
+  -- copy contents from staged directory to zip root
+  -- use cp -a to preserve symlinks and permissions
+  local handle = spawn({"cp", "-a", staged_abs .. "/.", zip_root})
+  local exit_code = handle:wait()
+  if exit_code ~= 0 then
+    unix.rmrf(temp_dir)
+    return nil, "failed to copy staged files"
+  end
+
+  -- create the zip file
+  -- use -r for recursive, -y for symlinks
+  unix.makedirs(path.dirname(output_zip))
+  unix.rmrf(output_zip)
+
+  -- cd to temp_dir and zip from there to get relative paths
+  local cwd = unix.getcwd()
+  unix.chdir(temp_dir)
+  local zip_handle = spawn({"zip", "-qry", path.join(cwd, output_zip), module_name})
+  local zip_exit = zip_handle:wait()
+  unix.chdir(cwd)
+  unix.rmrf(temp_dir)
+
+  if zip_exit ~= 0 then
+    return nil, "zip command failed with exit code " .. zip_exit
+  end
+
+  -- format: ZIPPED  module @ version-sha_prefix
+  local sha_prefix = plat.sha:sub(1, 7)
+  io.stderr:write(string.format("□ ZIPPED %s @ %s-%s\n", module_name, spec.version, sha_prefix))
+
+  return true
+end
+
+if cosmo.is_main() then
+  local ok, err = main(arg[1], arg[2], arg[3], arg[4])
+  if not ok then
+    io.stderr:write("error: " .. tostring(err) .. "\n")
+    os.exit(1)
+  end
+end

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -5,11 +5,12 @@ build_lua_srcs := $(wildcard lib/build/*.lua)
 build_srcs := $(build_lua_srcs)
 build_fetch := $(o)/bin/build-fetch.lua
 build_stage := $(o)/bin/build-stage.lua
+build_zip := $(o)/bin/build-zip.lua
 build_check_update := $(o)/bin/check-update.lua
 build_reporter := $(o)/bin/reporter.lua
 build_help := $(o)/bin/make-help.lua
 build_snap := $(o)/bin/test-snap.lua
-build_files := $(build_fetch) $(build_stage) $(build_check_update) $(build_reporter) $(build_help) $(build_snap)
+build_files := $(build_fetch) $(build_stage) $(build_zip) $(build_check_update) $(build_reporter) $(build_help) $(build_snap)
 # Test files - .tl source, compiled .lua run by test rule
 build_tests := $(wildcard lib/build/test_*.tl)
 build_snaps := $(wildcard lib/build/*.snap)

--- a/lib/home/main.tl
+++ b/lib/home/main.tl
@@ -351,6 +351,52 @@ local function cmd_unpack(dest: string, force: boolean, opts: UnpackOpts): integ
     ::continue::
   end
 
+  -- Extract module zips from /zip/zips/ to .local/share
+  if not dry_run then
+    local zips_dir = "/zip/zips"
+    local zips_stat = unix.stat(zips_dir)
+    if zips_stat and unix.S_ISDIR(zips_stat:mode()) then
+      local zips_list = unix.opendir(zips_dir)
+      if zips_list then
+        for zip_file in zips_list do
+          if zip_file ~= "." and zip_file ~= ".." and zip_file:match("%.zip$") then
+            local zip_path = path.join(zips_dir, zip_file)
+            local share_dest = path.join(dest, ".local", "share")
+            unix.makedirs(share_dest)
+
+            -- Read zip from /zip filesystem to temp file
+            local zip_data = read_file(zip_path)
+            if zip_data then
+              local temp_zip = unix.mkstemp("/tmp/module_XXXXXX.zip")
+              if temp_zip then
+                local temp_fd, temp_path = temp_zip as (number, string)
+                unix.write(temp_fd, zip_data)
+                unix.close(temp_fd)
+
+                -- Extract the temp zip file
+                local spawn = require("cosmic.spawn")
+                local unzip_bin = path.join(dest, ".local", "bin", "unzip")
+                -- Fall back to system unzip if not available yet
+                if not unix.stat(unzip_bin) then
+                  unzip_bin = "/usr/bin/unzip"
+                end
+                local handle = spawn({unzip_bin, "-o", "-q", "-d", share_dest, temp_path})
+                local exit_code = handle:wait()
+
+                -- Clean up temp file
+                unix.unlink(temp_path)
+
+                if exit_code ~= 0 and verbose then
+                  stderr:write("warning: failed to extract " .. zip_file .. "\n")
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
   -- Create symlinks from tool root to versioned subdirectories
   if not dry_run then
     local version_mod = require("version")


### PR DESCRIPTION
Create individual .zip artifacts for each 3p module to preserve symlinks
and file modes while simplifying extraction.

- Add lib/build/build-zip.tl to create versioned module zips
- Add .zipped targets in Makefile to build zips after staging
- Update home build to bundle pre-created .zip artifacts
- Update extraction to iterate over and extract module zips
- Automatic versioned paths like .local/share/gh/2.83.2-ca6e764/

This preserves file types (symlinks), modes, and simplifies the home
binary build process by pre-creating module artifacts.