### PR TITLE
Fix Claude installation path and symlink setup

### DIFF
--- a/.github/pr/fix-claude-installation-path.md
+++ b/.github/pr/fix-claude-installation-path.md
@@ -1,0 +1,7 @@
+# home/setup/claude: install to bin subdirectory
+
+Fix Claude installation path to match zshenv glob pattern. The `.zshenv` file includes `~/.local/share/*/*-*/bin` in PATH, but Claude was being installed to `<version>-<sha>/claude` instead of `<version>-<sha>/bin/claude`.
+
+## Changes
+
+- `lib/home/setup/claude.tl` - Install Claude binary to `bin` subdirectory to match the pattern used by other versioned tools (nvim, gh, delta)

--- a/lib/home/setup/claude.tl
+++ b/lib/home/setup/claude.tl
@@ -54,12 +54,13 @@ local function run(env: env_module.Env): number
 
 		local short_sha = CLAUDE_SHA256:sub(1, 8)
 		local version_dir = path.join(env.DST, ".local", "share", "claude", string.format("%s-%s", CLAUDE_VERSION, short_sha))
-		local claude_bin = path.join(version_dir, "claude")
+		local bin_dir = path.join(version_dir, "bin")
+		local claude_bin = path.join(bin_dir, "claude")
 
 		if unix.stat(claude_bin) then
 			io.stderr:write("claude " .. CLAUDE_VERSION .. " already installed\n")
 		else
-			unix.makedirs(version_dir)
+			unix.makedirs(bin_dir)
 
 			local status, _, body = cosmo.Fetch(CLAUDE_URL, {maxresponse = 300 * 1024 * 1024})
 			if not status or status ~= 200 then


### PR DESCRIPTION
Fix Claude installation to use .local/share/claude/<version>-<sha>/bin/claude instead of .local/share/claude/<version>-<sha>/claude to match the zshenv glob pattern ~/.local/share/*/*-*/bin that automatically adds versioned binaries to PATH.