### PR TITLE
skill/pr: use GITHUB_BASE_REF for shallow clone compatibility

### DIFF
--- a/.github/pr/cosmic-fallback-check.md
+++ b/.github/pr/cosmic-fallback-check.md
@@ -1,0 +1,24 @@
+# skill/pr: use GITHUB_BASE_REF for shallow clone compatibility
+
+The pr skill's file-based fallback detection (`git diff origin/main...HEAD`)
+fails in CI with shallow clones because `origin/main` isn't fetched when
+checking out the PR head with limited depth.
+
+## Changes
+
+- `lib/skill/pr.tl` - simplify `get_default_branch()` to use `GITHUB_BASE_REF`
+- `.github/workflows/pr.yml` - fetch base branch, run from source until next release
+- `lib/skill/test_pr.tl` - simplify tests to match new implementation
+
+## Implementation
+
+Since the pr skill only runs in GitHub Actions, we can simplify `get_default_branch()`
+to just use `GITHUB_BASE_REF` (automatically set to the PR target branch).
+
+The workflow now explicitly fetches the base branch with `--depth=1` before
+running the pr skill, ensuring the merge base is available for the git diff.
+
+## Follow-up
+
+After merging and cutting a new release, revert the workflow to use
+`--skill pr` instead of `-e 'require("lib.skill.pr").main()'`.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,8 +29,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 20
 
+      - name: fetch base branch
+        run: git fetch origin $GITHUB_BASE_REF --depth=1
+
       - id: update-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_NUMBER: ${{ github.event.number }}
-        run: ./bin/cosmic --skill pr
+        run: ./bin/cosmic -e 'require("lib.skill.pr").main()'

--- a/bin/cosmic
+++ b/bin/cosmic
@@ -4,7 +4,7 @@ set -e
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 COSMIC_LUA="${SCRIPT_DIR}/cosmic-lua"
-RELEASE_URL="https://github.com/whilp/world/releases/download/2026-01-12-5a4658b/cosmic-lua"
+RELEASE_URL="https://github.com/whilp/world/releases/download/2026-01-15-34a060f/cosmic-lua"
 
 # Download cosmic-lua if it doesn't exist
 if [ ! -f "${COSMIC_LUA}" ]; then

--- a/lib/skill/pr.tl
+++ b/lib/skill/pr.tl
@@ -38,6 +38,7 @@ local type FetchFn = function(url: string, opts?: FetchOpts): number, {string:st
 local record SpawnOpts
   spawn: function({string}): SpawnHandle
   repo: string
+  getenv: function(string): string
 end
 
 local record RequestOpts
@@ -107,47 +108,17 @@ end
 
 local function get_default_branch(opts?: SpawnOpts): string
   opts = opts or {}
-  local do_spawn = opts.spawn or spawn_mod
+  local getenv = opts.getenv or os.getenv
 
-  -- Try to get the remote HEAD branch name
-  local cmd: {string} = {"git"}
-  if opts.repo then
-    table.insert(cmd, "-C")
-    table.insert(cmd, opts.repo)
-  end
-  table.insert(cmd, "remote")
-  table.insert(cmd, "show")
-  table.insert(cmd, "origin")
-
-  local handle = do_spawn(cmd)
-  local ok, out = handle:read()
-  if ok and out then
-    local branch = (out as string):match("HEAD branch: (%S+)")
-    if branch then
-      return "origin/" .. branch
-    end
+  -- In GitHub Actions PR context, GITHUB_BASE_REF is always set
+  local base_ref = getenv("GITHUB_BASE_REF")
+  if base_ref and base_ref ~= "" then
+    log("GITHUB_BASE_REF=" .. base_ref)
+    return "origin/" .. base_ref
   end
 
-  -- Fallback: try common default branches
-  for _, branch in ipairs({"origin/main", "origin/master"}) do
-    cmd = {"git"}
-    if opts.repo then
-      table.insert(cmd, "-C")
-      table.insert(cmd, opts.repo)
-    end
-    table.insert(cmd, "rev-parse")
-    table.insert(cmd, "--verify")
-    table.insert(cmd, branch)
-
-    handle = do_spawn(cmd)
-    ok, _ = handle:read()
-    if ok then
-      return branch
-    end
-  end
-
-  -- Last resort: use origin/HEAD even if it might not exist
-  return "origin/HEAD"
+  log("GITHUB_BASE_REF not set, falling back to origin/main")
+  return "origin/main"
 end
 
 local function get_pr_files_from_branch(opts?: SpawnOpts): {string}
@@ -182,6 +153,7 @@ local function get_pr_files_from_branch(opts?: SpawnOpts): {string}
       table.insert(files, name)
     end
   end
+  log("found " .. #files .. " pr files: " .. table.concat(files, ", "))
   return files
 end
 

--- a/lib/skill/test_pr.tl
+++ b/lib/skill/test_pr.tl
@@ -463,101 +463,23 @@ test_main_no_fallback_when_multiple_files()
 -- get_default_branch tests
 --------------------------------------------------------------------------------
 
-local function test_default_branch_from_remote_show()
-  local call_count = 0
-  local mock_spawn_fn = function(cmd: {string}): SpawnHandle
-    call_count = call_count + 1
-    if call_count == 1 and cmd[1] == "git" and cmd[#cmd-1] == "show" then
-      return {
-        read = function(_: SpawnHandle): boolean, string
-          return true, "* remote origin\n  HEAD branch: main\n"
-        end,
-        wait = function(_: SpawnHandle): integer return 0 end,
-      }
-    end
-    return {
-      read = function(_: SpawnHandle): boolean, string return false, nil end,
-      wait = function(_: SpawnHandle): integer return 1 end,
-    }
+local function test_default_branch_from_github_base_ref()
+  local mock_getenv = function(name: string): string
+    if name == "GITHUB_BASE_REF" then return "develop" end
+    return nil
   end
 
-  local result = pr.get_default_branch({spawn = mock_spawn_fn} as SpawnOpts)
-  assert(result == "origin/main", "expected origin/main from remote show, got: " .. tostring(result))
+  local result = pr.get_default_branch({getenv = mock_getenv} as SpawnOpts)
+  assert(result == "origin/develop", "expected origin/develop from GITHUB_BASE_REF, got: " .. tostring(result))
 end
-test_default_branch_from_remote_show()
+test_default_branch_from_github_base_ref()
 
-local function test_default_branch_fallback_to_main()
-  local call_count = 0
-  local mock_spawn_fn = function(cmd: {string}): SpawnHandle
-    call_count = call_count + 1
-    if call_count == 1 then
-      -- remote show fails
-      return {
-        read = function(_: SpawnHandle): boolean, string return false, nil end,
-        wait = function(_: SpawnHandle): integer return 1 end,
-      }
-    elseif call_count == 2 and cmd[#cmd] == "origin/main" then
-      -- origin/main exists
-      return {
-        read = function(_: SpawnHandle): boolean, string return true, "abc123\n" end,
-        wait = function(_: SpawnHandle): integer return 0 end,
-      }
-    end
-    return {
-      read = function(_: SpawnHandle): boolean, string return false, nil end,
-      wait = function(_: SpawnHandle): integer return 1 end,
-    }
+local function test_default_branch_fallback_without_env()
+  local mock_getenv = function(_: string): string
+    return nil
   end
 
-  local result = pr.get_default_branch({spawn = mock_spawn_fn} as SpawnOpts)
+  local result = pr.get_default_branch({getenv = mock_getenv} as SpawnOpts)
   assert(result == "origin/main", "expected origin/main fallback, got: " .. tostring(result))
 end
-test_default_branch_fallback_to_main()
-
-local function test_default_branch_fallback_to_master()
-  local call_count = 0
-  local mock_spawn_fn = function(cmd: {string}): SpawnHandle
-    call_count = call_count + 1
-    if call_count == 1 then
-      -- remote show fails
-      return {
-        read = function(_: SpawnHandle): boolean, string return false, nil end,
-        wait = function(_: SpawnHandle): integer return 1 end,
-      }
-    elseif call_count == 2 and cmd[#cmd] == "origin/main" then
-      -- origin/main doesn't exist
-      return {
-        read = function(_: SpawnHandle): boolean, string return false, nil end,
-        wait = function(_: SpawnHandle): integer return 1 end,
-      }
-    elseif call_count == 3 and cmd[#cmd] == "origin/master" then
-      -- origin/master exists
-      return {
-        read = function(_: SpawnHandle): boolean, string return true, "def456\n" end,
-        wait = function(_: SpawnHandle): integer return 0 end,
-      }
-    end
-    return {
-      read = function(_: SpawnHandle): boolean, string return false, nil end,
-      wait = function(_: SpawnHandle): integer return 1 end,
-    }
-  end
-
-  local result = pr.get_default_branch({spawn = mock_spawn_fn} as SpawnOpts)
-  assert(result == "origin/master", "expected origin/master fallback, got: " .. tostring(result))
-end
-test_default_branch_fallback_to_master()
-
-local function test_default_branch_ultimate_fallback()
-  local mock_spawn_fn = function(_: {string}): SpawnHandle
-    -- all commands fail
-    return {
-      read = function(_: SpawnHandle): boolean, string return false, nil end,
-      wait = function(_: SpawnHandle): integer return 1 end,
-    }
-  end
-
-  local result = pr.get_default_branch({spawn = mock_spawn_fn} as SpawnOpts)
-  assert(result == "origin/HEAD", "expected origin/HEAD ultimate fallback, got: " .. tostring(result))
-end
-test_default_branch_ultimate_fallback()
+test_default_branch_fallback_without_env()


### PR DESCRIPTION
The pr skill's file-based fallback detection (`git diff origin/main...HEAD`)
fails in CI with shallow clones because `origin/main` isn't fetched when
checking out the PR head with limited depth.

## Changes

- `lib/skill/pr.tl` - simplify `get_default_branch()` to use `GITHUB_BASE_REF`
- `.github/workflows/pr.yml` - fetch base branch, run from source until next release
- `lib/skill/test_pr.tl` - simplify tests to match new implementation

## Implementation

Since the pr skill only runs in GitHub Actions, we can simplify `get_default_branch()`
to just use `GITHUB_BASE_REF` (automatically set to the PR target branch).

The workflow now explicitly fetches the base branch with `--depth=1` before
running the pr skill, ensuring the merge base is available for the git diff.

## Follow-up

After merging and cutting a new release, revert the workflow to use
`--skill pr` instead of `-e 'require("lib.skill.pr").main()'`.

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-16T06:49:44Z
</details>