### PR TITLE
claude: disable hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,28 +1,4 @@
 {
-  "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "startup",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/bin/hook\""
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/bin/hook\""
-          }
-        ]
-      }
-    ]
-  },
   "env": {
     "DISABLE_AUTOUPDATER": "1"
   },

--- a/.github/pr/disable-claude-hooks.md
+++ b/.github/pr/disable-claude-hooks.md
@@ -1,0 +1,7 @@
+# claude: disable hooks
+
+Remove SessionStart and PostToolUse hooks from project settings.
+
+## Changes
+
+- `.claude/settings.json` - remove hooks configuration


### PR DESCRIPTION
## Summary

- Remove SessionStart and PostToolUse hooks from project settings

## Changes

- `.claude/settings.json` - remove hooks configuration

## Test plan

- [ ] Verify claude sessions start without hook errors