### PR TITLE
claude: update to 2.1.11

### DIFF
--- a/.github/pr/update-claude.md
+++ b/.github/pr/update-claude.md
@@ -1,0 +1,7 @@
+# claude: update to 2.1.11
+
+Update Claude Code from 2.0.74 to 2.1.11.
+
+## Changes
+
+- `lib/claude/version.lua` - bump version and update sha256

--- a/lib/claude/version.lua
+++ b/lib/claude/version.lua
@@ -1,6 +1,6 @@
 return {
   base_url="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819",
-  platforms={["linux-x64"]={sha="43065ff86a1b952225e42042bf4dfe9f6b72ff8ed91686a23add5396b1a11e80"}},
+  platforms={["linux-x64"]={sha="9d79cc613d5feff19c82330601bcc53d41cd03c42431110d74bc3253fefee263"}},
   url="{base_url}/claude-code-releases/{version}/{platform}/claude",
-  version="2.0.74"
+  version="2.1.11"
 }


### PR DESCRIPTION
Update Claude Code from 2.0.74 to 2.1.11.

## Changes

- `lib/claude/version.lua` - bump version and update sha256