### PR TITLE
skill/pr: simplify to file-based detection only

### DIFF
--- a/.github/pr/simplify-pr-file-detection.md
+++ b/.github/pr/simplify-pr-file-detection.md
@@ -1,0 +1,19 @@
+# skill/pr: simplify to file-based detection only
+
+Remove trailer-based PR file detection (`x-cosmic-pr-name`) in favor of
+simple file detection: if the branch adds exactly one `.github/pr/*.md`
+file, use it.
+
+## Changes
+
+- `lib/skill/pr.tl` - remove trailer logic, simplify to file detection
+- `lib/skill/test_pr.tl` - remove trailer tests, simplify test suite
+
+## Why
+
+The trailer approach was complex and error-prone. Merged commits containing
+trailers would pollute the detection logic, causing the wrong PR file to
+be selected (as seen in PR #381 where `cosmic-fallback-check.md` was
+picked instead of the correct file).
+
+The file-based approach is simpler: one PR file added = use it.

--- a/lib/skill/pr.tl
+++ b/lib/skill/pr.tl
@@ -1,13 +1,8 @@
 --[[
 Updates a GitHub PR title and description from .github/pr/<name>.md
 
-The PR file is identified by the x-cosmic-pr-name trailer in the commit message:
-
-  cosmic: add feature
-
-  Description of changes.
-
-  x-cosmic-pr-name: feature-name.md
+The PR file is auto-detected: if the branch adds exactly one .github/pr/*.md
+file, that file is used to update the PR title and description.
 
 The pr.md format:
   # <title>
@@ -53,14 +48,6 @@ local record MainOpts
   fetch: FetchFn
 end
 
-local record TrailerInfo
-  commit_count: number
-  first_sha: string
-  last_sha: string
-  winning_sha: string
-  winning_trailer: string
-end
-
 local record ParsedPr
   title: string
   body: string
@@ -76,36 +63,6 @@ local function log(msg: string)
   io.stderr:write("pr: " .. msg .. "\n")
 end
 
-local function get_current_branch(): string
-  local handle = spawn_mod({"git", "rev-parse", "--abbrev-ref", "HEAD"})
-  local ok, out = handle:read()
-  if not ok then
-    return nil
-  end
-  local branch = (out as string):match("^%s*(.-)%s*$")
-  if branch == "" then
-    return nil
-  end
-  return branch
-end
-
-local function get_commit_sha(): string
-  local handle = spawn_mod({"git", "rev-parse", "HEAD"})
-  local ok, out = handle:read()
-  if not ok or not out then
-    return "unknown"
-  end
-  return (out as string):match("^%s*(.-)%s*$") or "unknown"
-end
-
-local function normalize_pr_name(name: string): string
-  if not name then return nil end
-  if not name:match("%.md$") then
-    return name .. ".md"
-  end
-  return name
-end
-
 local function get_default_branch(opts?: SpawnOpts): string
   opts = opts or {}
   local getenv = opts.getenv or os.getenv
@@ -113,15 +70,13 @@ local function get_default_branch(opts?: SpawnOpts): string
   -- In GitHub Actions PR context, GITHUB_BASE_REF is always set
   local base_ref = getenv("GITHUB_BASE_REF")
   if base_ref and base_ref ~= "" then
-    log("GITHUB_BASE_REF=" .. base_ref)
     return "origin/" .. base_ref
   end
 
-  log("GITHUB_BASE_REF not set, falling back to origin/main")
   return "origin/main"
 end
 
-local function get_pr_files_from_branch(opts?: SpawnOpts): {string}
+local function get_pr_file_from_branch(opts?: SpawnOpts): string
   opts = opts or {}
   local do_spawn = opts.spawn or spawn_mod
 
@@ -143,7 +98,7 @@ local function get_pr_files_from_branch(opts?: SpawnOpts): {string}
   local handle = do_spawn(cmd)
   local ok, out = handle:read()
   if not ok or not out then
-    return {}
+    return nil
   end
 
   local files: {string} = {}
@@ -153,76 +108,19 @@ local function get_pr_files_from_branch(opts?: SpawnOpts): {string}
       table.insert(files, name)
     end
   end
-  log("found " .. #files .. " pr files: " .. table.concat(files, ", "))
-  return files
-end
 
-local function get_pr_name_from_trailer(opts?: SpawnOpts): string, TrailerInfo
-  opts = opts or {}
-  local do_spawn = opts.spawn or spawn_mod
-
-  -- Get all x-cosmic-pr-name and x-cosmic-pr-enable trailers from last 20 commits
-  -- Process in chronological order (oldest first) to find the final state
-  local cmd: {string} = {"git"}
-  if opts.repo then
-    table.insert(cmd, "-C")
-    table.insert(cmd, opts.repo)
-  end
-  table.insert(cmd, "log")
-  table.insert(cmd, "--format=%H %(trailers:key=x-cosmic-pr-name,valueonly)%(trailers:key=x-cosmic-pr-enable,valueonly)")
-  table.insert(cmd, "--reverse")
-  table.insert(cmd, "-20")
-  local handle = do_spawn(cmd)
-  local ok, out = handle:read()
-  if not ok or not out then
-    return nil, nil
+  if #files == 0 then
+    log("no .github/pr/*.md files added on this branch")
+    return nil
   end
 
-  -- Track the final state by processing commits in order
-  local pr_name: string = nil
-  local enabled = true
-  local first_sha: string
-  local last_sha: string
-  local winning_sha: string
-  local winning_trailer: string
-  local commit_count = 0
-
-  for line in (out as string):gmatch("[^\n]+") do
-    local sha, rest = line:match("^(%S+)%s*(.*)$")
-    if sha then
-      commit_count = commit_count + 1
-      if not first_sha then first_sha = sha end
-      last_sha = sha
-
-      local name = rest and rest:match("^%s*(.-)%s*$")
-      if name and name ~= "" then
-        if name == "false" then
-          enabled = false
-          pr_name = nil
-          winning_sha = sha
-          winning_trailer = "x-cosmic-pr-enable: false"
-        else
-          pr_name = name
-          enabled = true
-          winning_sha = sha
-          winning_trailer = "x-cosmic-pr-name: " .. name
-        end
-      end
-    end
+  if #files > 1 then
+    log("multiple .github/pr/*.md files found: " .. table.concat(files, ", "))
+    return nil
   end
 
-  local info: TrailerInfo = {
-    commit_count = commit_count,
-    first_sha = first_sha,
-    last_sha = last_sha,
-    winning_sha = winning_sha,
-    winning_trailer = winning_trailer,
-  }
-
-  if enabled and pr_name then
-    return pr_name, info
-  end
-  return nil, info
+  log("using " .. files[1])
+  return files[1]
 end
 
 
@@ -358,26 +256,13 @@ end
 
 
 local function print_help()
-  local pr_name = get_pr_name_from_trailer()
-  local pr_file: string
-  if pr_name then
-    pr_file = path.join(".github/pr", normalize_pr_name(pr_name))
-  else
-    pr_file = ".github/pr/<name>.md"
-  end
-
-  local help = string.format([[
+  local help = [[
 usage: pr.lua [-h]
 
-Updates PR title and description from %s
+Updates PR title and description from .github/pr/<name>.md
 
-The PR file is identified by the x-cosmic-pr-name trailer in your commit message:
-
-    cosmic: add feature
-
-    Description of changes.
-
-    x-cosmic-pr-name: feature-name.md
+The PR file is auto-detected: if the branch adds exactly one .github/pr/*.md
+file, that file is used.
 
 The file format:
 
@@ -385,34 +270,24 @@ The file format:
 
     Brief description of changes.
 
+    ## Changes
+
     - file1.lua - what it does
     - file2.lua - what it does
 
-    ## Validation
-
-    - [x] tests pass
-    - [x] linter passes
-
 Guidelines:
 
-  1. Choose a descriptive name for your PR file (e.g., feature-name.md)
-  2. Create %s
-  3. Add x-cosmic-pr-name: <name>.md trailer to your commit message
-  4. Follow repo conventions: `# component: verb explanation` title
-  5. Keep content concise but include key decisions, tradeoffs, examples
-  6. Update the file as the PR evolves
-  7. Push to trigger the workflow and update the PR
+  1. Create .github/pr/<descriptive-name>.md on your branch
+  2. Use `# component: verb explanation` as the title
+  3. Keep content concise but include key decisions and tradeoffs
+  4. Update the file as the PR evolves
+  5. Push to trigger the workflow and update the PR
 
 Environment variables (set automatically in GitHub Actions):
   GITHUB_TOKEN       - required for API authentication
   GITHUB_REPOSITORY  - owner/repo format
   GITHUB_PR_NUMBER   - PR number
-]], pr_file, pr_file)
-
-  if pr_name then
-    help = help .. string.format("\nDetected PR file: %s\n", pr_file)
-  end
-
+]]
   print(help)
 end
 
@@ -420,21 +295,7 @@ local function is_github_actions(): boolean
   return os.getenv("GITHUB_ACTIONS") == "true"
 end
 
-local function do_update(owner: string, repo_name: string, pr_number: number, pr_name: string, trailer_info: TrailerInfo, token: string, opts?: RequestOpts): number, string
-  -- log commit range and winning trailer
-  if trailer_info and trailer_info.first_sha then
-    local range = string.format("%s..%s (%d commits)",
-      trailer_info.first_sha:sub(1, 8),
-      trailer_info.last_sha:sub(1, 8),
-      trailer_info.commit_count)
-    log("checked " .. range)
-  end
-  if trailer_info and trailer_info.winning_sha then
-    log("using " .. trailer_info.winning_sha:sub(1, 8) .. " " .. trailer_info.winning_trailer)
-  end
-
-  local pr_file = path.join(".github/pr", normalize_pr_name(pr_name))
-
+local function do_update(owner: string, repo_name: string, pr_number: number, pr_file: string, token: string, opts?: RequestOpts): number, string
   if not path.exists(pr_file) then
     log(pr_file .. " not found, skipping")
     return 0
@@ -511,35 +372,14 @@ local function main(opts?: MainOpts): number, string
     return 1, "invalid GITHUB_PR_NUMBER"
   end
 
-  local spawn_opts: SpawnOpts = {spawn = opts.spawn, repo = opts.repo}
-  local pr_name, trailer_info = get_pr_name_from_trailer(spawn_opts)
-  if not pr_name then
-    -- fallback: check if branch introduces exactly one .github/pr/*.md file
-    local pr_files = get_pr_files_from_branch(spawn_opts)
-    if #pr_files == 1 then
-      -- extract just the filename from .github/pr/<name>.md
-      local basename = pr_files[1]:match("%.github/pr/(.+)$")
-      if basename then
-        log("auto-detected PR file from branch: " .. pr_files[1])
-        pr_name = basename
-      end
-    end
-  end
-
-  if not pr_name then
-    local first = trailer_info and trailer_info.first_sha and trailer_info.first_sha:sub(1, 8) or "unknown"
-    local last = trailer_info and trailer_info.last_sha and trailer_info.last_sha:sub(1, 8) or "unknown"
-
-    local msg = string.format(
-      "no x-cosmic-pr-name trailer found (or disabled) in last 20 commits (%s .. %s)\n\nNote: x-cosmic-pr-enable: false disables updates until a new x-cosmic-pr-name is set",
-      first,
-      last
-    )
-    return 0, msg
+  local spawn_opts: SpawnOpts = {spawn = opts.spawn, repo = opts.repo, getenv = opts.getenv}
+  local pr_file = get_pr_file_from_branch(spawn_opts)
+  if not pr_file then
+    return 0
   end
 
   local request_opts: RequestOpts = {fetch = opts.fetch, getenv = opts.getenv}
-  return do_update(owner, repo_name, pr_number, pr_name, trailer_info, token, request_opts)
+  return do_update(owner, repo_name, pr_number, pr_file, token, request_opts)
 end
 
 if cosmo.is_main() then
@@ -560,13 +400,10 @@ local record PrModule
   get_pr: function(owner: string, repo: string, pr_number: number, token: string, opts?: RequestOpts): GitHubPr, string
   append_timestamp_details: function(body: string): string
   update_pr: function(owner: string, repo: string, pr_number: number, title: string, body: string, token: string, opts?: RequestOpts): boolean, string
-  get_current_branch: function(): string
-  get_commit_sha: function(): string
   get_default_branch: function(opts?: SpawnOpts): string
-  get_pr_name_from_trailer: function(opts?: SpawnOpts): string, TrailerInfo
-  get_pr_files_from_branch: function(opts?: SpawnOpts): {string}
+  get_pr_file_from_branch: function(opts?: SpawnOpts): string
   is_github_actions: function(): boolean
-  do_update: function(owner: string, repo_name: string, pr_number: number, pr_name: string, trailer_info: TrailerInfo, token: string, opts?: RequestOpts): number, string
+  do_update: function(owner: string, repo_name: string, pr_number: number, pr_file: string, token: string, opts?: RequestOpts): number, string
   main: function(opts?: MainOpts): number, string
 end
 
@@ -576,11 +413,8 @@ return {
   get_pr = get_pr,
   append_timestamp_details = append_timestamp_details,
   update_pr = update_pr,
-  get_current_branch = get_current_branch,
-  get_commit_sha = get_commit_sha,
   get_default_branch = get_default_branch,
-  get_pr_name_from_trailer = get_pr_name_from_trailer,
-  get_pr_files_from_branch = get_pr_files_from_branch,
+  get_pr_file_from_branch = get_pr_file_from_branch,
   is_github_actions = is_github_actions,
   do_update = do_update,
   main = main,

--- a/lib/skill/test_pr.tl
+++ b/lib/skill/test_pr.tl
@@ -15,6 +15,7 @@ end
 
 local record SpawnOpts
   spawn: function({string}): SpawnHandle
+  getenv: function(string): string
 end
 
 local record MockEnv
@@ -22,6 +23,7 @@ local record MockEnv
   GITHUB_TOKEN: string
   GITHUB_REPOSITORY: string
   GITHUB_PR_NUMBER: string
+  GITHUB_BASE_REF: string
 end
 
 local record MainOpts
@@ -41,14 +43,6 @@ local type FetchFn = function(url: string, opts?: FetchOpts): number, {string:st
 local record ParsedPr
   title: string
   body: string
-end
-
-local record TrailerInfo
-  commit_count: number
-  first_sha: string
-  last_sha: string
-  winning_sha: string
-  winning_trailer: string
 end
 
 local record GitHubPr
@@ -222,51 +216,26 @@ end
 test_remote_missing_pr_number()
 
 --------------------------------------------------------------------------------
--- trailer extraction (mocked git output)
+-- get_pr_file_from_branch tests
 --------------------------------------------------------------------------------
 
-local function test_trailer_not_found()
-  local output = "abc123\ndef456\n"  -- commits with no trailers
-  local result = pr.get_pr_name_from_trailer({spawn = mock_spawn(output)} as SpawnOpts)
-  assert(result == nil, "expected no trailer")
+local function test_pr_file_from_branch_none()
+  local result = pr.get_pr_file_from_branch({spawn = mock_spawn("")} as SpawnOpts)
+  assert(result == nil, "expected nil when no files")
 end
-test_trailer_not_found()
+test_pr_file_from_branch_none()
 
-local function test_trailer_found()
-  local output = "abc123 2026-01-04-feature.md\n"
-  local result = pr.get_pr_name_from_trailer({spawn = mock_spawn(output)} as SpawnOpts)
-  assert(result == "2026-01-04-feature.md", "expected trailer value, got: " .. tostring(result))
+local function test_pr_file_from_branch_one()
+  local result = pr.get_pr_file_from_branch({spawn = mock_spawn(".github/pr/feature.md\n")} as SpawnOpts)
+  assert(result == ".github/pr/feature.md", "expected file path")
 end
-test_trailer_found()
+test_pr_file_from_branch_one()
 
-local function test_trailer_disabled()
-  -- first commit has name, second disables
-  local output = "abc123 feature.md\ndef456 false\n"
-  local result = pr.get_pr_name_from_trailer({spawn = mock_spawn(output)} as SpawnOpts)
-  assert(result == nil, "expected disabled, got: " .. tostring(result))
+local function test_pr_file_from_branch_multiple()
+  local result = pr.get_pr_file_from_branch({spawn = mock_spawn(".github/pr/a.md\n.github/pr/b.md\n")} as SpawnOpts)
+  assert(result == nil, "expected nil when multiple files")
 end
-test_trailer_disabled()
-
-local function test_trailer_reenabled()
-  -- name -> disable -> new name
-  local output = "abc123 old.md\ndef456 false\nghi789 2026-01-04-new.md\n"
-  local result = pr.get_pr_name_from_trailer({spawn = mock_spawn(output)} as SpawnOpts)
-  assert(result == "2026-01-04-new.md", "expected re-enabled with new name, got: " .. tostring(result))
-end
-test_trailer_reenabled()
-
-local function test_trailer_info_returned()
-  local output = "abc123\ndef456 feature.md\nghi789\n"
-  local result, info = pr.get_pr_name_from_trailer({spawn = mock_spawn(output)} as SpawnOpts)
-  local trailer_info = info as TrailerInfo
-  assert(result == "feature.md", "expected trailer")
-  assert(trailer_info.commit_count == 3, "expected 3 commits")
-  assert(trailer_info.first_sha == "abc123", "expected first sha")
-  assert(trailer_info.last_sha == "ghi789", "expected last sha")
-  assert(trailer_info.winning_sha == "def456", "expected winning sha")
-  assert(trailer_info.winning_trailer == "x-cosmic-pr-name: feature.md", "expected winning trailer")
-end
-test_trailer_info_returned()
+test_pr_file_from_branch_multiple()
 
 --------------------------------------------------------------------------------
 -- do_update integration
@@ -292,7 +261,7 @@ local function test_do_update_with_changes()
     return original_slurp(p)
   end
 
-  local code = pr.do_update("owner", "repo", 42, "test.md", nil, "token", {fetch = mock_fetch})
+  local code = pr.do_update("owner", "repo", 42, ".github/pr/test.md", "token", {fetch = mock_fetch})
 
   path.exists = original_exists
   cosmo.Slurp = original_slurp
@@ -302,71 +271,10 @@ end
 test_do_update_with_changes()
 
 --------------------------------------------------------------------------------
--- trailer without .md extension should still find file
+-- main() with file detection
 --------------------------------------------------------------------------------
 
-local function test_do_update_finds_file_without_extension()
-  local patch_called = false
-  local mock_fetch: FetchFn = function(_: string, opts: FetchOpts): number, {string:string}, string
-    if opts.method == "GET" then
-      return 200, {}, cosmo.EncodeJson({number = 42, title = "Old", body = "Old body"})
-    else
-      patch_called = true
-      return 200, {}, cosmo.EncodeJson({number = 42})
-    end
-  end
-
-  local original_exists = path.exists
-  local original_slurp = cosmo.Slurp
-  -- only the .md version exists
-  path.exists = function(p: string): boolean
-    if p:match("feature%-name%.md$") then return true end
-    return false
-  end
-  cosmo.Slurp = function(p: string): string
-    if p:match("feature%-name%.md$") then return "# New\n\nNew body" end
-    return nil
-  end
-
-  -- trailer value omits the .md extension
-  local code = pr.do_update("owner", "repo", 42, "feature-name", nil, "token", {fetch = mock_fetch})
-
-  path.exists = original_exists
-  cosmo.Slurp = original_slurp
-
-  assert(code == 0, "expected success when extension omitted")
-  assert(patch_called, "expected PR to be updated (PATCH called)")
-end
-test_do_update_finds_file_without_extension()
-
---------------------------------------------------------------------------------
--- get_pr_files_from_branch tests
---------------------------------------------------------------------------------
-
-local function test_pr_files_from_branch_none()
-  local result = pr.get_pr_files_from_branch({spawn = mock_spawn("")} as SpawnOpts)
-  assert(#result == 0, "expected no files")
-end
-test_pr_files_from_branch_none()
-
-local function test_pr_files_from_branch_one()
-  local result = pr.get_pr_files_from_branch({spawn = mock_spawn(".github/pr/feature.md\n")} as SpawnOpts)
-  assert(#result == 1, "expected one file")
-  assert(result[1] == ".github/pr/feature.md", "expected file path")
-end
-test_pr_files_from_branch_one()
-
-local function test_pr_files_from_branch_multiple()
-  local result = pr.get_pr_files_from_branch({spawn = mock_spawn(".github/pr/a.md\n.github/pr/b.md\n")} as SpawnOpts)
-  assert(#result == 2, "expected two files")
-end
-test_pr_files_from_branch_multiple()
-
---------------------------------------------------------------------------------
--- main() fallback to branch file detection
---------------------------------------------------------------------------------
-
-local function test_main_fallback_to_branch_file()
+local function test_main_with_single_file()
   local patch_called = false
   local mock_fetch: FetchFn = function(_: string, opts: FetchOpts): number, {string:string}, string
     if opts.method == "GET" then
@@ -393,29 +301,12 @@ local function test_main_fallback_to_branch_file()
     GITHUB_TOKEN = "token",
     GITHUB_REPOSITORY = "owner/repo",
     GITHUB_PR_NUMBER = "42",
+    GITHUB_BASE_REF = "main",
   }
-
-  -- mock spawn to return no trailer but one branch file
-  local spawn_calls: {{string}} = {}
-  local mock_spawn_fn = function(cmd: {string}): SpawnHandle
-    table.insert(spawn_calls, cmd)
-    -- first call is trailer check, second is branch file check
-    if cmd[#cmd] == ".github/pr/*.md" then
-      return {
-        read = function(_: SpawnHandle): boolean, string return true, ".github/pr/auto-feature.md\n" end,
-        wait = function(_: SpawnHandle): integer return 0 end,
-      }
-    else
-      return {
-        read = function(_: SpawnHandle): boolean, string return true, "abc123\ndef456\n" end,  -- no trailers
-        wait = function(_: SpawnHandle): integer return 0 end,
-      }
-    end
-  end
 
   local code = pr.main({
     getenv = function(k: string): string return (mock_env as {string:string})[k] end,
-    spawn = mock_spawn_fn,
+    spawn = mock_spawn(".github/pr/auto-feature.md\n"),
     fetch = mock_fetch,
   } as MainOpts)
 
@@ -423,41 +314,45 @@ local function test_main_fallback_to_branch_file()
   cosmo.Slurp = original_slurp
 
   assert(code == 0, "expected success")
-  assert(patch_called, "expected PR to be updated via fallback")
+  assert(patch_called, "expected PR to be updated")
 end
-test_main_fallback_to_branch_file()
+test_main_with_single_file()
 
-local function test_main_no_fallback_when_multiple_files()
+local function test_main_no_files()
   local mock_env: MockEnv = {
     GITHUB_ACTIONS = "true",
     GITHUB_TOKEN = "token",
     GITHUB_REPOSITORY = "owner/repo",
     GITHUB_PR_NUMBER = "42",
+    GITHUB_BASE_REF = "main",
   }
 
-  local mock_spawn_fn = function(cmd: {string}): SpawnHandle
-    if cmd[#cmd] == ".github/pr/*.md" then
-      return {
-        read = function(_: SpawnHandle): boolean, string return true, ".github/pr/a.md\n.github/pr/b.md\n" end,
-        wait = function(_: SpawnHandle): integer return 0 end,
-      }
-    else
-      return {
-        read = function(_: SpawnHandle): boolean, string return true, "abc123\n" end,  -- no trailers
-        wait = function(_: SpawnHandle): integer return 0 end,
-      }
-    end
-  end
-
-  local code, msg = pr.main({
+  local code = pr.main({
     getenv = function(k: string): string return (mock_env as {string:string})[k] end,
-    spawn = mock_spawn_fn,
+    spawn = mock_spawn(""),  -- no files
   } as MainOpts)
 
   assert(code == 0, "expected success (skipped)")
-  assert(msg:match("no x%-cosmic%-pr%-name"), "expected no trailer message")
 end
-test_main_no_fallback_when_multiple_files()
+test_main_no_files()
+
+local function test_main_multiple_files()
+  local mock_env: MockEnv = {
+    GITHUB_ACTIONS = "true",
+    GITHUB_TOKEN = "token",
+    GITHUB_REPOSITORY = "owner/repo",
+    GITHUB_PR_NUMBER = "42",
+    GITHUB_BASE_REF = "main",
+  }
+
+  local code = pr.main({
+    getenv = function(k: string): string return (mock_env as {string:string})[k] end,
+    spawn = mock_spawn(".github/pr/a.md\n.github/pr/b.md\n"),
+  } as MainOpts)
+
+  assert(code == 0, "expected success (skipped)")
+end
+test_main_multiple_files()
 
 --------------------------------------------------------------------------------
 -- get_default_branch tests


### PR DESCRIPTION
Remove trailer-based PR file detection (`x-cosmic-pr-name`) in favor of
simple file detection: if the branch adds exactly one `.github/pr/*.md`
file, use it.

## Changes

- `lib/skill/pr.tl` - remove trailer logic, simplify to file detection
- `lib/skill/test_pr.tl` - remove trailer tests, simplify test suite

## Why

The trailer approach was complex and error-prone. Merged commits containing
trailers would pollute the detection logic, causing the wrong PR file to
be selected (as seen in PR #381 where `cosmic-fallback-check.md` was
picked instead of the correct file).

The file-based approach is simpler: one PR file added = use it.