### PR TITLE
home: add bootstrap binary

### DIFF
--- a/.github/pr/sprite-bootstrap.md
+++ b/.github/pr/sprite-bootstrap.md
@@ -1,0 +1,27 @@
+# home: add bootstrap binary
+
+Add a lightweight cosmopolitan binary that bootstraps a new environment by
+downloading and unpacking the home bundle from whilp/world releases.
+
+## Changes
+
+- `lib/home/bootstrap.tl` - bootstrap source: detects platform, downloads home-<platform>, verifies SHA256, runs unpack
+- `lib/home/test_bootstrap.tl` - tests for platform detection
+- `lib/home/cook.mk` - build rule for bootstrap binary
+- `.github/workflows/release.yml` - upload bootstrap artifact
+- `Makefile` - include bootstrap in release assets
+
+## Usage
+
+The bootstrap binary is meant to be curled and executed on a fresh machine:
+
+```bash
+curl -fsSL <bootstrap-url> -o /tmp/bootstrap && chmod +x /tmp/bootstrap && /tmp/bootstrap
+```
+
+It will:
+1. Detect platform (linux-x86_64, linux-arm64, darwin-arm64)
+2. Fetch latest release from whilp/world
+3. Download home-<platform> and SHA256SUMS
+4. Verify checksum
+5. Run `home unpack --force ~/`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - id: make-check-test-build
         shell: bash -x {0}
-        run: bin/make -j check test build bootstrap
+        run: bin/make -j check test build
 
       - id: make-test-release
         shell: bash -x {0}
@@ -43,19 +43,14 @@ jobs:
           name: home-${{ matrix.platform }}
           path: o/bin/home
 
-      - id: upload-cosmic
+      - id: upload-cosmopolitan
         if: matrix.platform == 'linux-x86_64'
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
-          name: cosmic
-          path: o/bin/cosmic
-
-      - id: upload-bootstrap
-        if: matrix.platform == 'linux-x86_64'
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
-        with:
-          name: bootstrap
-          path: o/bin/bootstrap
+          name: cosmopolitan
+          path: |
+            o/bin/cosmic
+            o/bin/bootstrap
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - id: make-check-test-build
         shell: bash -x {0}
-        run: bin/make -j check test build
+        run: bin/make -j check test build bootstrap
 
       - id: make-test-release
         shell: bash -x {0}
@@ -49,6 +49,13 @@ jobs:
         with:
           name: cosmic
           path: o/bin/cosmic
+
+      - id: upload-bootstrap
+        if: matrix.platform == 'linux-x86_64'
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        with:
+          name: bootstrap
+          path: o/bin/bootstrap
 
   release:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -277,8 +277,8 @@ bump: $(all_updated)
 	done
 
 .PHONY: build
-## Build home and cosmic binaries
-build: home cosmic
+## Build home, cosmic, and bootstrap binaries
+build: home cosmic bootstrap
 
 .PHONY: release
 ## Create release artifacts (CI only)
@@ -287,8 +287,8 @@ release:
 	@cp artifacts/home-darwin-arm64/home release/home-darwin-arm64
 	@cp artifacts/home-linux-arm64/home release/home-linux-arm64
 	@cp artifacts/home-linux-x86_64/home release/home-linux-x86_64
-	@cp artifacts/cosmic/cosmic release/cosmic-lua
-	@cp artifacts/bootstrap/bootstrap release/bootstrap
+	@cp artifacts/cosmopolitan/cosmic release/cosmic-lua
+	@cp artifacts/cosmopolitan/bootstrap release/bootstrap
 	@chmod +x release/*
 	@tag="$$(date -u +%Y-%m-%d)-$${GITHUB_SHA::7}"; \
 	(cd release && sha256sum home-* cosmic-lua bootstrap > SHA256SUMS && cat SHA256SUMS); \

--- a/Makefile
+++ b/Makefile
@@ -288,13 +288,14 @@ release:
 	@cp artifacts/home-linux-arm64/home release/home-linux-arm64
 	@cp artifacts/home-linux-x86_64/home release/home-linux-x86_64
 	@cp artifacts/cosmic/cosmic release/cosmic-lua
+	@cp artifacts/bootstrap/bootstrap release/bootstrap
 	@chmod +x release/*
 	@tag="$$(date -u +%Y-%m-%d)-$${GITHUB_SHA::7}"; \
-	(cd release && sha256sum home-* cosmic-lua > SHA256SUMS && cat SHA256SUMS); \
+	(cd release && sha256sum home-* cosmic-lua bootstrap > SHA256SUMS && cat SHA256SUMS); \
 	gh release create "$$tag" \
 		$${PRERELEASE_FLAG} \
 		--title "$$tag" \
-		release/home-* release/cosmic-lua release/SHA256SUMS
+		release/home-* release/cosmic-lua release/bootstrap release/SHA256SUMS
 
 ci_stages := astgrep teal test build
 

--- a/lib/build/make-help.snap
+++ b/lib/build/make-help.snap
@@ -14,7 +14,7 @@ Targets:
   check-test-coverage Verify all test files are declared in cook.mk
   update              Check for dependency updates
   bump                Apply dependency updates (use with only=<module>)
-  build               Build home and cosmic binaries
+  build               Build home, cosmic, and bootstrap binaries
   release             Create release artifacts (CI only)
   ci                  Run full CI pipeline (astgrep, teal, test, build)
 

--- a/lib/home/bootstrap.tl
+++ b/lib/home/bootstrap.tl
@@ -1,0 +1,220 @@
+-- home/bootstrap.tl: download and unpack home from whilp/world releases
+--
+-- Detects platform, downloads home-<platform>, verifies SHA256, runs unpack.
+
+local cosmo = require("cosmo")
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
+local spawn = require("cosmic.spawn")
+
+local REPO <const> = "whilp/world"
+local API_URL <const> = "https://api.github.com"
+
+local record ReleaseAsset
+  name: string
+  browser_download_url: string
+end
+
+local record Release
+  tag_name: string
+  assets: {ReleaseAsset}
+end
+
+local function detect_platform(): string, string
+  local os_name = cosmo.GetHostOs()
+  local isa = cosmo.GetHostIsa()
+
+  if not os_name or not isa then
+    return nil, "unable to detect platform"
+  end
+
+  -- normalize os: LINUX -> linux, OSX -> darwin
+  os_name = os_name:lower()
+  if os_name == "osx" then
+    os_name = "darwin"
+  end
+
+  -- normalize arch: X86_64 -> x86_64, AARCH64 -> arm64
+  isa = isa:lower()
+  if isa == "aarch64" then
+    isa = "arm64"
+  end
+
+  return os_name .. "-" .. isa
+end
+
+local function fetch_json(url: string): any, string
+  local status, _, body = cosmo.Fetch(url, {
+    headers = {
+      ["User-Agent"] = "curl/8.0",
+      ["Accept"] = "application/vnd.github+json",
+    },
+  })
+  if not status or status ~= 200 then
+    return nil, "fetch failed: " .. tostring(status)
+  end
+  return cosmo.DecodeJson(body)
+end
+
+local function fetch_text(url: string): string, string
+  local status, _, body = cosmo.Fetch(url, {
+    headers = {["User-Agent"] = "curl/8.0"},
+  })
+  if not status or status ~= 200 then
+    return nil, "fetch failed: " .. tostring(status)
+  end
+  return body
+end
+
+local function fetch_binary(url: string): string, string
+  local status, _, body = cosmo.Fetch(url, {
+    headers = {["User-Agent"] = "curl/8.0"},
+    maxresponse = 200 * 1024 * 1024,
+  })
+  if not status or status ~= 200 then
+    return nil, "fetch failed: " .. tostring(status)
+  end
+  return body
+end
+
+local function get_latest_release(): Release, string
+  local url = API_URL .. "/repos/" .. REPO .. "/releases/latest"
+  local data, err = fetch_json(url)
+  if not data then
+    return nil, err
+  end
+  return data as Release
+end
+
+local function parse_sha256sums(content: string): {string:string}
+  local sums: {string:string} = {}
+  for line in content:gmatch("[^\n]+") do
+    local sha, name = line:match("^(%x+)%s+(.+)$")
+    if sha and name then
+      sums[name] = sha
+    end
+  end
+  return sums
+end
+
+local function find_asset(release: Release, name: string): ReleaseAsset
+  for _, asset in ipairs(release.assets) do
+    if asset.name == name then
+      return asset
+    end
+  end
+  return nil
+end
+
+local function main(): number
+  local home_dir = os.getenv("HOME")
+  if not home_dir then
+    io.stderr:write("error: HOME not set\n")
+    return 1
+  end
+
+  -- detect platform
+  local platform, err = detect_platform()
+  if not platform then
+    io.stderr:write("error: " .. err .. "\n")
+    return 1
+  end
+  io.stderr:write("platform: " .. platform .. "\n")
+
+  -- get latest release
+  io.stderr:write("fetching latest release...\n")
+  local release: Release
+  release, err = get_latest_release()
+  if not release then
+    io.stderr:write("error: " .. err .. "\n")
+    return 1
+  end
+  io.stderr:write("release: " .. release.tag_name .. "\n")
+
+  -- download SHA256SUMS
+  local sums_asset = find_asset(release, "SHA256SUMS")
+  if not sums_asset then
+    io.stderr:write("error: SHA256SUMS not found in release\n")
+    return 1
+  end
+
+  io.stderr:write("fetching SHA256SUMS...\n")
+  local sums_content: string
+  sums_content, err = fetch_text(sums_asset.browser_download_url)
+  if not sums_content then
+    io.stderr:write("error: " .. err .. "\n")
+    return 1
+  end
+
+  local sums = parse_sha256sums(sums_content)
+
+  -- find home asset for platform
+  local asset_name = "home-" .. platform
+  local expected_sha = sums[asset_name]
+  if not expected_sha then
+    io.stderr:write("error: no SHA256 for " .. asset_name .. "\n")
+    io.stderr:write("available assets:\n")
+    for name, _ in pairs(sums) do
+      io.stderr:write("  " .. name .. "\n")
+    end
+    return 1
+  end
+
+  local home_asset = find_asset(release, asset_name)
+  if not home_asset then
+    io.stderr:write("error: " .. asset_name .. " not found in release\n")
+    return 1
+  end
+
+  -- download home binary
+  io.stderr:write("downloading " .. asset_name .. "...\n")
+  local body: string
+  body, err = fetch_binary(home_asset.browser_download_url)
+  if not body then
+    io.stderr:write("error: " .. err .. "\n")
+    return 1
+  end
+  io.stderr:write("downloaded " .. tostring(#body) .. " bytes\n")
+
+  -- verify SHA256
+  local actual_sha = cosmo.EncodeHex(cosmo.Sha256(body)):lower()
+  if actual_sha ~= expected_sha then
+    io.stderr:write("error: SHA256 mismatch\n")
+    io.stderr:write("  expected: " .. expected_sha .. "\n")
+    io.stderr:write("  actual:   " .. actual_sha .. "\n")
+    return 1
+  end
+  io.stderr:write("SHA256 verified\n")
+
+  -- write to temp file
+  local tmp_dir = os.getenv("TMPDIR") or "/tmp"
+  local home_bin = path.join(tmp_dir, "home-" .. release.tag_name)
+
+  local fd = unix.open(home_bin, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("0755", 8))
+  if not fd or fd < 0 then
+    io.stderr:write("error: failed to create " .. home_bin .. "\n")
+    return 1
+  end
+  unix.write(fd, body)
+  unix.close(fd)
+
+  -- run unpack
+  io.stderr:write("unpacking to " .. home_dir .. "...\n")
+  local exit_code = spawn({home_bin, "unpack", "--force", home_dir}):wait()
+  if exit_code ~= 0 then
+    io.stderr:write("error: unpack failed with exit code " .. tostring(exit_code) .. "\n")
+    return 1
+  end
+
+  io.stderr:write("bootstrap complete\n")
+  return 0
+end
+
+if cosmo.is_main() then
+  os.exit(main())
+end
+
+return {
+  detect_platform = detect_platform,
+  main = main,
+}

--- a/lib/home/bootstrap.tl
+++ b/lib/home/bootstrap.tl
@@ -3,7 +3,6 @@
 -- Detects platform, downloads home-<platform>, verifies SHA256, runs unpack.
 
 local cosmo = require("cosmo")
-local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local spawn = require("cosmic.spawn")
 
@@ -77,13 +76,13 @@ local function fetch_binary(url: string): string, string
   return body
 end
 
-local function get_latest_release(): Release, string
-  local url = API_URL .. "/repos/" .. REPO .. "/releases/latest"
-  local data, err = fetch_json(url)
-  if not data then
-    return nil, err
+local function find_asset(release: Release, name: string): ReleaseAsset
+  for _, asset in ipairs(release.assets) do
+    if asset.name == name then
+      return asset
+    end
   end
-  return data as Release
+  return nil
 end
 
 local function parse_sha256sums(content: string): {string:string}
@@ -97,113 +96,120 @@ local function parse_sha256sums(content: string): {string:string}
   return sums
 end
 
-local function find_asset(release: Release, name: string): ReleaseAsset
-  for _, asset in ipairs(release.assets) do
-    if asset.name == name then
-      return asset
-    end
+local function get_release(): Release, string
+  io.stderr:write("fetching latest release...\n")
+  local url = API_URL .. "/repos/" .. REPO .. "/releases/latest"
+  local data, err = fetch_json(url)
+  if not data then
+    return nil, err
   end
-  return nil
+  local release = data as Release
+  io.stderr:write("release: " .. release.tag_name .. "\n")
+  return release
 end
 
-local function main(): number
-  local home_dir = os.getenv("HOME")
-  if not home_dir then
-    io.stderr:write("error: HOME not set\n")
-    return 1
-  end
-
-  -- detect platform
-  local platform, err = detect_platform()
-  if not platform then
-    io.stderr:write("error: " .. err .. "\n")
-    return 1
-  end
-  io.stderr:write("platform: " .. platform .. "\n")
-
-  -- get latest release
-  io.stderr:write("fetching latest release...\n")
-  local release: Release
-  release, err = get_latest_release()
-  if not release then
-    io.stderr:write("error: " .. err .. "\n")
-    return 1
-  end
-  io.stderr:write("release: " .. release.tag_name .. "\n")
-
-  -- download SHA256SUMS
+local function get_checksums(release: Release): {string:string}, string
   local sums_asset = find_asset(release, "SHA256SUMS")
   if not sums_asset then
-    io.stderr:write("error: SHA256SUMS not found in release\n")
-    return 1
+    return nil, "SHA256SUMS not found in release"
   end
 
   io.stderr:write("fetching SHA256SUMS...\n")
-  local sums_content: string
-  sums_content, err = fetch_text(sums_asset.browser_download_url)
-  if not sums_content then
-    io.stderr:write("error: " .. err .. "\n")
-    return 1
+  local content, err = fetch_text(sums_asset.browser_download_url)
+  if not content then
+    return nil, err
   end
 
-  local sums = parse_sha256sums(sums_content)
+  return parse_sha256sums(content)
+end
 
-  -- find home asset for platform
+local function download_home(release: Release, platform: string, expected_sha: string): string, string
   local asset_name = "home-" .. platform
-  local expected_sha = sums[asset_name]
-  if not expected_sha then
-    io.stderr:write("error: no SHA256 for " .. asset_name .. "\n")
-    io.stderr:write("available assets:\n")
-    for name, _ in pairs(sums) do
-      io.stderr:write("  " .. name .. "\n")
-    end
-    return 1
+  local asset = find_asset(release, asset_name)
+  if not asset then
+    return nil, asset_name .. " not found in release"
   end
 
-  local home_asset = find_asset(release, asset_name)
-  if not home_asset then
-    io.stderr:write("error: " .. asset_name .. " not found in release\n")
-    return 1
-  end
-
-  -- download home binary
   io.stderr:write("downloading " .. asset_name .. "...\n")
-  local body: string
-  body, err = fetch_binary(home_asset.browser_download_url)
+  local body, err = fetch_binary(asset.browser_download_url)
   if not body then
-    io.stderr:write("error: " .. err .. "\n")
-    return 1
+    return nil, err
   end
   io.stderr:write("downloaded " .. tostring(#body) .. " bytes\n")
 
-  -- verify SHA256
   local actual_sha = cosmo.EncodeHex(cosmo.Sha256(body)):lower()
   if actual_sha ~= expected_sha then
-    io.stderr:write("error: SHA256 mismatch\n")
-    io.stderr:write("  expected: " .. expected_sha .. "\n")
-    io.stderr:write("  actual:   " .. actual_sha .. "\n")
-    return 1
+    return nil, "SHA256 mismatch: expected " .. expected_sha .. ", got " .. actual_sha
   end
   io.stderr:write("SHA256 verified\n")
 
-  -- write to temp file
-  local tmp_dir = os.getenv("TMPDIR") or "/tmp"
-  local home_bin = path.join(tmp_dir, "home-" .. release.tag_name)
+  return body
+end
 
-  local fd = unix.open(home_bin, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, tonumber("0755", 8))
-  if not fd or fd < 0 then
-    io.stderr:write("error: failed to create " .. home_bin .. "\n")
-    return 1
+local function write_binary(data: string, dest: string): boolean, string
+  if not cosmo.Barf(dest, data, tonumber("0755", 8)) then
+    return false, "failed to write " .. dest
   end
-  unix.write(fd, body)
-  unix.close(fd)
+  return true
+end
 
-  -- run unpack
+local function run_unpack(home_bin: string, home_dir: string): boolean, string
   io.stderr:write("unpacking to " .. home_dir .. "...\n")
   local exit_code = spawn({home_bin, "unpack", "--force", home_dir}):wait()
   if exit_code ~= 0 then
-    io.stderr:write("error: unpack failed with exit code " .. tostring(exit_code) .. "\n")
-    return 1
+    return false, "unpack failed with exit code " .. tostring(exit_code)
+  end
+  return true
+end
+
+local function main(): number, string
+  local home_dir = os.getenv("HOME")
+  if not home_dir then
+    return 1, "HOME not set"
+  end
+
+  local platform, err = detect_platform()
+  if not platform then
+    return 1, err
+  end
+  io.stderr:write("platform: " .. platform .. "\n")
+
+  local release: Release
+  release, err = get_release()
+  if not release then
+    return 1, err
+  end
+
+  local sums: {string:string}
+  sums, err = get_checksums(release)
+  if not sums then
+    return 1, err
+  end
+
+  local asset_name = "home-" .. platform
+  local expected_sha = sums[asset_name]
+  if not expected_sha then
+    return 1, "no SHA256 for " .. asset_name
+  end
+
+  local body: string
+  body, err = download_home(release, platform, expected_sha)
+  if not body then
+    return 1, err
+  end
+
+  local tmp_dir = os.getenv("TMPDIR") or "/tmp"
+  local home_bin = path.join(tmp_dir, "home-" .. release.tag_name)
+
+  local ok: boolean
+  ok, err = write_binary(body, home_bin)
+  if not ok then
+    return 1, err
+  end
+
+  ok, err = run_unpack(home_bin, home_dir)
+  if not ok then
+    return 1, err
   end
 
   io.stderr:write("bootstrap complete\n")
@@ -211,7 +217,11 @@ local function main(): number
 end
 
 if cosmo.is_main() then
-  os.exit(main())
+  local code, err = main()
+  if err then
+    io.stderr:write("error: " .. err .. "\n")
+  end
+  os.exit(code)
 end
 
 return {

--- a/lib/home/cook.mk
+++ b/lib/home/cook.mk
@@ -6,7 +6,7 @@ home_bin := $(o)/bin/home
 # only include home_bin in home_files; home_libs are explicit prereqs of home_bin
 # but shouldn't inherit home_deps (which would require staging 20+ tools for linting)
 home_files := $(home_bin)
-home_tests := lib/home/test_main.tl lib/home/test_versioned.tl lib/home/test_bootstrap.tl
+home_tests := $(wildcard lib/home/test_*.tl)
 home_tl_files := lib/home/main.tl lib/home/gen-manifest.tl lib/home/bootstrap.tl $(wildcard lib/home/setup/*.tl) $(wildcard lib/home/mac/*.tl)
 
 # 3p tools to bundle (nvim handled specially for bundled version)

--- a/lib/home/cook.mk
+++ b/lib/home/cook.mk
@@ -6,8 +6,8 @@ home_bin := $(o)/bin/home
 # only include home_bin in home_files; home_libs are explicit prereqs of home_bin
 # but shouldn't inherit home_deps (which would require staging 20+ tools for linting)
 home_files := $(home_bin)
-home_tests := lib/home/test_main.tl lib/home/test_versioned.tl
-home_tl_files := lib/home/main.tl lib/home/gen-manifest.tl $(wildcard lib/home/setup/*.tl) $(wildcard lib/home/mac/*.tl)
+home_tests := lib/home/test_main.tl lib/home/test_versioned.tl lib/home/test_bootstrap.tl
+home_tl_files := lib/home/main.tl lib/home/gen-manifest.tl lib/home/bootstrap.tl $(wildcard lib/home/setup/*.tl) $(wildcard lib/home/mac/*.tl)
 
 # 3p tools to bundle (nvim handled specially for bundled version)
 home_3p_tools := ast-grep biome comrak delta duckdb gh marksman rg ruff shfmt sqruff stylua superhtml tree-sitter uv
@@ -85,6 +85,29 @@ $(home_bin): $(home_libs) $(home_tl_lua) $(home_nvim_tl_compiled) $(o)/home/dotf
 home: $(home_bin)
 
 .PHONY: home
+
+# Bootstrap binary: lightweight binary for sprite bootstrap
+bootstrap_bin := $(o)/bin/bootstrap
+bootstrap_built := $(o)/bootstrap/.built
+bootstrap_main := $(o)/lib/home/bootstrap.lua
+bootstrap_spawn := $(o)/lib/cosmic/spawn.lua
+
+$(bootstrap_bin): $(bootstrap_main) $(bootstrap_spawn) $$(cosmos_staged)
+	@rm -rf $(bootstrap_built)
+	@mkdir -p $(bootstrap_built)/.lua/cosmic $(@D)
+	@$(cp) $(bootstrap_spawn) $(bootstrap_built)/.lua/cosmic/
+	@$(cp) $(cosmos_lua) $@
+	@chmod +x $@
+	@cd $(bootstrap_built) && $(CURDIR)/$(cosmos_zip) -qr $(CURDIR)/$@ .lua
+	@$(cosmos_zip) -qj $@ $(bootstrap_main)
+	@rm -rf $(bootstrap_built)
+
+bootstrap: $(bootstrap_bin)
+
+.PHONY: bootstrap
+
+# bootstrap test depends on the bootstrap binary
+$(o)/lib/home/test_bootstrap.tl.test.ok: $(bootstrap_bin)
 
 # home-release: rebuild home with nvim bundle (used by test-release)
 .PHONY: home-release

--- a/lib/home/test_bootstrap.tl
+++ b/lib/home/test_bootstrap.tl
@@ -1,0 +1,58 @@
+-- test_bootstrap.tl: tests for sprite bootstrap module
+
+local cosmo = require("cosmo")
+local path = require("cosmo.path")
+
+local bootstrap = require("home.bootstrap")
+
+--------------------------------------------------------------------------------
+-- detect_platform tests
+--------------------------------------------------------------------------------
+
+local function test_detect_platform()
+  local platform, err = bootstrap.detect_platform()
+  assert(platform, "expected platform, got error: " .. tostring(err))
+
+  -- platform should be os-arch format (arch may contain underscore like x86_64)
+  assert(platform:match("^%w+%-[%w_]+$"), "expected os-arch format, got: " .. platform)
+
+  -- should be one of the known platforms
+  local known = {
+    ["linux-x86_64"] = true,
+    ["linux-arm64"] = true,
+    ["darwin-arm64"] = true,
+    ["darwin-x86_64"] = true,
+  }
+  assert(known[platform], "unexpected platform: " .. platform)
+
+  io.stderr:write("detected platform: " .. platform .. "\n")
+end
+test_detect_platform()
+
+--------------------------------------------------------------------------------
+-- bootstrap binary tests (requires TEST_BIN)
+--------------------------------------------------------------------------------
+
+local TEST_BIN = os.getenv("TEST_BIN")
+if TEST_BIN then
+  local spawn = require("cosmic.spawn")
+  local bootstrap_bin = path.join(TEST_BIN, "bootstrap")
+
+  local function test_bootstrap_binary_exists()
+    local st = require("cosmo.unix").stat(bootstrap_bin)
+    assert(st, "bootstrap binary not found at " .. bootstrap_bin)
+  end
+  test_bootstrap_binary_exists()
+
+  local function test_bootstrap_help()
+    -- bootstrap with no network should fail gracefully
+    -- just verify it runs and produces output
+    local handle = spawn({bootstrap_bin})
+    local exit_code = handle:wait()
+    -- will fail because it can't fetch release, but that's expected
+    assert(exit_code ~= nil, "expected exit code")
+  end
+  test_bootstrap_help()
+end
+
+print("all bootstrap tests passed")


### PR DESCRIPTION
Add a lightweight cosmopolitan binary that bootstraps a new environment by
downloading and unpacking the home bundle from whilp/world releases.

## Changes

- `lib/home/bootstrap.tl` - bootstrap source: detects platform, downloads home-<platform>, verifies SHA256, runs unpack
- `lib/home/test_bootstrap.tl` - tests for platform detection
- `lib/home/cook.mk` - build rule for bootstrap binary
- `.github/workflows/release.yml` - upload bootstrap artifact
- `Makefile` - include bootstrap in release assets

## Usage

The bootstrap binary is meant to be curled and executed on a fresh machine:

```bash
curl -fsSL <bootstrap-url> -o /tmp/bootstrap && chmod +x /tmp/bootstrap && /tmp/bootstrap
```

It will:
1. Detect platform (linux-x86_64, linux-arm64, darwin-arm64)
2. Fetch latest release from whilp/world
3. Download home-<platform> and SHA256SUMS
4. Verify checksum
5. Run `home unpack --force ~/`

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-17T18:38:53Z
</details>