### PR TITLE
bootstrap: fix macOS platform detection

### DIFF
--- a/.github/pr/fix-macos-platform-detection.md
+++ b/.github/pr/fix-macos-platform-detection.md
@@ -1,0 +1,8 @@
+# bootstrap: fix macOS platform detection
+
+`cosmo.GetHostOs()` returns `XNU` (the kernel name) on macOS, not `OSX`.
+This caused bootstrap to fail on macOS with "unexpected platform: xnu-arm64".
+
+## Changes
+
+- `lib/home/bootstrap.tl` - handle both `xnu` and `osx` when normalizing to `darwin`

--- a/lib/home/bootstrap.tl
+++ b/lib/home/bootstrap.tl
@@ -27,9 +27,9 @@ local function detect_platform(): string, string
     return nil, "unable to detect platform"
   end
 
-  -- normalize os: LINUX -> linux, OSX -> darwin
+  -- normalize os: LINUX -> linux, XNU/OSX -> darwin
   os_name = os_name:lower()
-  if os_name == "osx" then
+  if os_name == "xnu" or os_name == "osx" then
     os_name = "darwin"
   end
 


### PR DESCRIPTION
`cosmo.GetHostOs()` returns `XNU` (the kernel name) on macOS, not `OSX`.
This caused bootstrap to fail on macOS with "unexpected platform: xnu-arm64".

## Changes

- `lib/home/bootstrap.tl` - handle both `xnu` and `osx` when normalizing to `darwin`

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-17T18:44:51Z
</details>