### PR TITLE
claude: fix bin symlink for installed binaries

### DIFF
--- a/.github/pr/fix-claude-bin-symlink.md
+++ b/.github/pr/fix-claude-bin-symlink.md
@@ -1,0 +1,11 @@
+# claude: fix bin symlink for installed binaries
+
+The Claude install puts binaries at `~/.local/share/claude/{version}-{sha}/bin/claude`, but the wrapper's `scan_for_atomic_install()` was looking in the wrong path and the stable fallback path needed a symlink.
+
+Also creates a default `~/.claude.json` config file on first install.
+
+## Changes
+
+- `lib/claude/main.tl` - fix `scan_for_atomic_install()` to look in `bin/` subdirectory
+- `lib/box/claude.tl` - create `bin` -> `{version}-{sha}/bin` symlink after install
+- `lib/box/claude.tl` - create default `~/.claude.json` with theme and settings

--- a/lib/box/claude.tl
+++ b/lib/box/claude.tl
@@ -80,6 +80,29 @@ local function install(): boolean, string
     return false, "failed to write claude binary"
   end
 
+  -- Create bin -> {version}-{sha}/bin symlink for stable path
+  local share_dir = path.join(home, ".local", "share", "claude")
+  local bin_link = path.join(share_dir, "bin")
+  local link_target = version_info.version .. "-" .. short_sha .. "/bin"
+  unix.unlink(bin_link)
+  unix.symlink(link_target, bin_link)
+
+  -- Create default ~/.claude.json if it doesn't exist
+  local claude_json = path.join(home, ".claude.json")
+  if not unix.stat(claude_json) then
+    local default_config = {
+      numStartups = 4,
+      installMethod = "unknown",
+      autoUpdates = true,
+      theme = "dark-daltonized",
+      hasCompletedOnboarding = true,
+      lastOnboardingVersion = version_info.version,
+      bypassPermissionsModeAccepted = true,
+      lastReleaseNotesSeen = version_info.version,
+    }
+    cosmo.Barf(claude_json, cosmo.EncodeJson(default_config) .. "\n", tonumber("0644", 8))
+  end
+
   io.stderr:write("claude " .. version_info.version .. " installed\n")
   return true
 end

--- a/lib/claude/main.tl
+++ b/lib/claude/main.tl
@@ -107,7 +107,7 @@ local function scan_for_atomic_install(): string
     if name ~= "." and name ~= ".." then
       local version = name:match("^([%d%.]+)%-")
       if version then
-        local bin_path = path.join(share_dir, name, "claude")
+        local bin_path = path.join(share_dir, name, "bin", "claude")
         if unix.stat(bin_path) then
           if not latest_version or version > latest_version then
             latest_version = version


### PR DESCRIPTION
The Claude install puts binaries at `~/.local/share/claude/{version}-{sha}/bin/claude`, but the wrapper's `scan_for_atomic_install()` was looking in the wrong path and the stable fallback path needed a symlink.

Also creates a default `~/.claude.json` config file on first install.

## Changes

- `lib/claude/main.tl` - fix `scan_for_atomic_install()` to look in `bin/` subdirectory
- `lib/box/claude.tl` - create `bin` -> `{version}-{sha}/bin` symlink after install
- `lib/box/claude.tl` - create default `~/.claude.json` with theme and settings

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-18T01:55:15Z
</details>