### PR TITLE
skills: add dev-workflow skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,32 +2,6 @@
 
 - ALWAYS consider available skills. Almost every session will involve one or more skills, and the most relevant skills should be evident early in the session.
 
-## Pull request descriptions
-
-**CRITICAL: You MUST create and maintain a PR description file for every branch.**
-
-This file describes what's happening on the branch. Update it before every push.
-
-1. Create `.github/pr/<slug>.md` with a descriptive slug (e.g., `add-auth-logging.md`, `fix-parser-edge-case.md`)
-2. Use this format:
-
-```markdown
-# component: verb explanation
-
-Brief description of what this change does and why.
-
-## Changes
-
-- `path/to/file.lua` - what it does
-- `path/to/other.lua` - what it does
-```
-
-**Guidelines:**
-- Choose a descriptive, kebab-case slug
-- Title format: `component: verb explanation` (sentence case)
-- Keep descriptions concise but include key decisions and tradeoffs
-- **Update the file before every push** to reflect the current state of the branch
-
 ## Writing
 
 - Always use sentence case

--- a/.claude/skills/dev-workflow/SKILL.md
+++ b/.claude/skills/dev-workflow/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: dev-workflow
+description: Development workflow for this repository. Run `make help` to see available targets.
+allowed-tools: [Bash, Read]
+---
+
+# Development workflow
+
+This project uses a Makefile-based build system.
+
+## Getting started
+
+Run `make help` to see all available targets and understand the build workflow.
+
+```bash
+make help
+```

--- a/.claude/skills/dev-workflow/SKILL.md
+++ b/.claude/skills/dev-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-workflow
 description: Development workflow for this repository. Run `make help` to see available targets.
-allowed-tools: [Bash, Read]
+allowed-tools: [Bash, Read, Write, Edit]
 ---
 
 # Development workflow
@@ -15,3 +15,29 @@ Run `make help` to see all available targets and understand the build workflow.
 ```bash
 make help
 ```
+
+## Pull request descriptions
+
+**CRITICAL: You MUST create and maintain a PR description file for every branch.**
+
+This file describes what's happening on the branch. Update it before every push.
+
+1. Create `.github/pr/<slug>.md` with a descriptive slug (e.g., `add-auth-logging.md`, `fix-parser-edge-case.md`)
+2. Use this format:
+
+```markdown
+# component: verb explanation
+
+Brief description of what this change does and why.
+
+## Changes
+
+- `path/to/file.lua` - what it does
+- `path/to/other.lua` - what it does
+```
+
+**Guidelines:**
+- Choose a descriptive, kebab-case slug
+- Title format: `component: verb explanation` (sentence case)
+- Keep descriptions concise but include key decisions and tradeoffs
+- **Update the file before every push** to reflect the current state of the branch

--- a/.github/pr/add-dev-workflow-skill.md
+++ b/.github/pr/add-dev-workflow-skill.md
@@ -1,7 +1,8 @@
 # skills: add dev-workflow skill
 
-Adds a simple skill to help developers discover the build workflow.
+Adds a skill for the development workflow, consolidating PR description guidelines from CLAUDE.md.
 
 ## Changes
 
-- `.claude/skills/dev-workflow/SKILL.md` - new skill that encourages running `make help`
+- `.claude/skills/dev-workflow/SKILL.md` - new skill with `make help` guidance and PR description format
+- `.claude/CLAUDE.md` - remove PR description section (moved to skill)

--- a/.github/pr/add-dev-workflow-skill.md
+++ b/.github/pr/add-dev-workflow-skill.md
@@ -1,0 +1,7 @@
+# skills: add dev-workflow skill
+
+Adds a simple skill to help developers discover the build workflow.
+
+## Changes
+
+- `.claude/skills/dev-workflow/SKILL.md` - new skill that encourages running `make help`


### PR DESCRIPTION
Adds a skill for the development workflow, consolidating PR description guidelines from CLAUDE.md.

## Changes

- `.claude/skills/dev-workflow/SKILL.md` - new skill with `make help` guidance and PR description format
- `.claude/CLAUDE.md` - remove PR description section (moved to skill)