### PR TITLE
cosmos: bump to 2026.01.18

### DIFF
--- a/.github/pr/bump-cosmos.md
+++ b/.github/pr/bump-cosmos.md
@@ -1,7 +1,7 @@
-# cosmos: bump to 2026.01.14-dff272e74
+# cosmos: bump to 2026.01.18
 
-Update cosmos dependency to the latest release from 2026.01.08-e226a5d6a.
+Updates cosmos to latest release.
 
 ## Changes
 
-- `3p/cosmos/version.lua` - update version and SHA256 hash for latest release
+- `3p/cosmos/version.lua` - bump version and sha

--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format="zip",
-  platforms={["*"]={sha="661d9b89b1742f258edccd76dadc78ee6fbd5f8cfc980f28a800542229639357"}},
+  platforms={["*"]={sha="5f10a044d5f12406e3c83b3ec3d8345309e59feffb1b1443d406aad3591d5363"}},
   strip_components=0,
   url="https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version="2026.01.14-dff272e74"
+  version="2026.01.18-9df0a3c58"
 }


### PR DESCRIPTION
Updates cosmos to latest release.

## Changes

- `3p/cosmos/version.lua` - bump version and sha