### PR TITLE
box: add marketplace config to seeded claude.json

### DIFF
--- a/.github/pr/claude-marketplace-config.md
+++ b/.github/pr/claude-marketplace-config.md
@@ -1,0 +1,7 @@
+# box: add marketplace config to seeded claude.json
+
+Add marketplace auto-install flags to the default claude.json config so boxes don't attempt to auto-install marketplace extensions.
+
+## Changes
+
+- `lib/box/claude.tl` - add officialMarketplaceAutoInstallAttempted and officialMarketplaceAutoInstalled flags to seeded config

--- a/lib/box/claude.tl
+++ b/lib/box/claude.tl
@@ -99,6 +99,8 @@ local function install(): boolean, string
       lastOnboardingVersion = version_info.version,
       bypassPermissionsModeAccepted = true,
       lastReleaseNotesSeen = version_info.version,
+      officialMarketplaceAutoInstallAttempted = true,
+      officialMarketplaceAutoInstalled = true,
     }
     cosmo.Barf(claude_json, cosmo.EncodeJson(default_config) .. "\n", tonumber("0644", 8))
   end


### PR DESCRIPTION
Add marketplace auto-install flags to the default claude.json config so boxes don't attempt to auto-install marketplace extensions.

## Changes

- `lib/box/claude.tl` - add officialMarketplaceAutoInstallAttempted and officialMarketplaceAutoInstalled flags to seeded config