### PR TITLE
build: add sprite CLI 3p module

### DIFF
--- a/.github/pr/add-sprite.md
+++ b/.github/pr/add-sprite.md
@@ -1,0 +1,10 @@
+# build: add sprite CLI 3p module
+
+Add the Sprites CLI binary as a 3p module.
+
+## Changes
+
+- `3p/sprite/version.lua` - version 0.0.1-rc30 with platform-specific SHAs
+- `3p/sprite/cook.mk` - module definition
+- `3p/sprite/test_sprite.tl` - version check test
+- `Makefile` - include sprite module

--- a/3p/sprite/cook.mk
+++ b/3p/sprite/cook.mk
@@ -1,0 +1,3 @@
+modules += sprite
+sprite_version := 3p/sprite/version.lua
+sprite_tests := 3p/sprite/test_sprite.tl

--- a/3p/sprite/test_sprite.tl
+++ b/3p/sprite/test_sprite.tl
@@ -1,0 +1,16 @@
+#!/usr/bin/env run-test.lua
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+
+global TEST_DIR: string
+
+local bin = path.join(TEST_DIR, "bin", "sprite")
+
+local function test_version()
+  local ok, got = spawn({ bin, "--version" }):read()
+  assert(ok, "sprite --version failed")
+  local want = "0.0.1"
+  assert((got as string):find(want, 1, true), "checking sprite, want: " .. want .. " got: " .. (got as string))
+end
+test_version()

--- a/3p/sprite/version.lua
+++ b/3p/sprite/version.lua
@@ -1,0 +1,27 @@
+return {
+  version = "0.0.1-rc30",
+  format = "tar.gz",
+  strip_components = 1,
+  install = {
+    ["sprite"] = "bin/sprite",
+  },
+  url = "https://sprites-binaries.t3.storage.dev/client/v{version}/sprite-{arch}.tar.gz",
+  platforms = {
+    ["darwin-arm64"] = {
+      arch = "darwin-arm64",
+      sha = "baf3dafc2452d8755d537e5a2c7779b38523de22f6cd6cbea4c27c04b82946cb",
+    },
+    ["darwin-x86_64"] = {
+      arch = "darwin-amd64",
+      sha = "8b62f0afaf426bca3edca81b4a247d2b4210491beef4cdcdafe6d5735cbb575a",
+    },
+    ["linux-arm64"] = {
+      arch = "linux-arm64",
+      sha = "19a38cef766cfecf45ea714a93568ac5b72a0e175ab80948ccc909325df50d12",
+    },
+    ["linux-x86_64"] = {
+      arch = "linux-amd64",
+      sha = "9b6f4192987061133a8fb6aa8a0cc21202dace7799ce814240112aa721118305",
+    },
+  },
+}

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ include 3p/comrak/cook.mk
 include 3p/delta/cook.mk
 include 3p/ruff/cook.mk
 include 3p/sqruff/cook.mk
+include 3p/sprite/cook.mk
 include 3p/superhtml/cook.mk
 include 3p/marksman/cook.mk
 include 3p/duckdb/cook.mk


### PR DESCRIPTION
Add the Sprites CLI binary as a 3p module.

## Changes

- `3p/sprite/version.lua` - version 0.0.1-rc30 with platform-specific SHAs
- `3p/sprite/cook.mk` - module definition
- `3p/sprite/test_sprite.tl` - version check test
- `Makefile` - include sprite module

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-18T04:08:35Z
</details>