### PR TITLE
ghostty: unbind cmd+shift+{h,j,k,l} for nvim splits

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -38,6 +38,10 @@ keybind = cmd+h=unbind
 keybind = cmd+t=unbind
 keybind = cmd+shift+right_bracket=unbind
 keybind = cmd+shift+left_bracket=unbind
+keybind = cmd+shift+h=unbind
+keybind = cmd+shift+j=unbind
+keybind = cmd+shift+k=unbind
+keybind = cmd+shift+l=unbind
 
 keybind = cmd+digit_1=unbind
 keybind = cmd+digit_2=unbind

--- a/.github/pr/ghostty-unbind-split-keys.md
+++ b/.github/pr/ghostty-unbind-split-keys.md
@@ -1,0 +1,7 @@
+# ghostty: unbind cmd+shift+{h,j,k,l} for nvim splits
+
+Unbind cmd+shift+{h,j,k,l} in Ghostty so these keys pass through to nvim for window splitting.
+
+## Changes
+
+- `.config/ghostty/config` - add unbinds for cmd+shift+h/j/k/l to allow nvim `<D-S-*>` split keybindings to work


### PR DESCRIPTION
Unbind cmd+shift+{h,j,k,l} in Ghostty so these keys pass through to nvim for window splitting.

## Changes

- `.config/ghostty/config` - add unbinds for cmd+shift+h/j/k/l to allow nvim `<D-S-*>` split keybindings to work