### PR TITLE
clasp: suppress bun output in CI

### DIFF
--- a/.github/pr/suppress-bun-output.md
+++ b/.github/pr/suppress-bun-output.md
@@ -1,0 +1,7 @@
+# clasp: suppress bun output in CI
+
+Redirect stdout from `bun install` and `bun build --compile` to `/dev/null` to keep CI logs clean.
+
+## Changes
+
+- `3p/clasp/cook.mk` - add `>/dev/null` to bun install and bun build commands

--- a/3p/clasp/cook.mk
+++ b/3p/clasp/cook.mk
@@ -19,5 +19,5 @@ $(clasp_bin): $$(clasp_staged) $$(bun_staged) $(clasp_lock)
 	@mkdir -p $(@D)
 	@rm -f $(clasp_dir)/package-lock.json
 	@cp $(clasp_lock) $(clasp_dir)/bun.lock
-	@cd $(clasp_dir) && $(CURDIR)/$(bun_dir)/bin/bun install --ignore-scripts --frozen-lockfile
-	@cd $(clasp_dir) && $(CURDIR)/$(bun_dir)/bin/bun build --compile src/index.ts --outfile $(CURDIR)/$@
+	@cd $(clasp_dir) && $(CURDIR)/$(bun_dir)/bin/bun install --ignore-scripts --frozen-lockfile >/dev/null
+	@cd $(clasp_dir) && $(CURDIR)/$(bun_dir)/bin/bun build --compile src/index.ts --outfile $(CURDIR)/$@ >/dev/null


### PR DESCRIPTION
Redirect stdout from `bun install` and `bun build --compile` to `/dev/null` to keep CI logs clean.

## Changes

- `3p/clasp/cook.mk` - add `>/dev/null` to bun install and bun build commands

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-18T04:28:00Z
</details>