### PR TITLE
skills: consolidate dev skill, rename cleanshot to screenshot

### DIFF
--- a/.claude/skills/screenshot/SKILL.md
+++ b/.claude/skills/screenshot/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: cleanshot
+name: screenshot
 description: Take screenshots, screen recordings, scrolling captures, and OCR text recognition using CleanShot X. Use when user requests screenshots, captures, screen recording, OCR, text extraction, or image annotation.
 allowed-tools: [Bash]
 ---

--- a/.github/pr/combine-dev-skill.md
+++ b/.github/pr/combine-dev-skill.md
@@ -1,9 +1,10 @@
-# skills: combine branch and review-feedback into dev skill
+# skills: consolidate dev skill, rename cleanshot to screenshot
 
-Consolidates the branch and review-feedback skills into a single dev skill for better discoverability.
+Consolidates the branch and review-feedback skills into a single dev skill. Also renames cleanshot to screenshot to avoid clashing with `/clear`.
 
 ## Changes
 
-- `.claude/skills/dev/SKILL.md` - new combined skill with branching and review feedback sections
-- `.claude/skills/branch/` - removed
-- `.claude/skills/review-feedback/` - removed
+- `.claude/skills/dev/SKILL.md` - combined skill with branching and review feedback sections
+- `.claude/skills/branch/` - removed (merged into dev)
+- `.claude/skills/review-feedback/` - removed (merged into dev)
+- `.claude/skills/screenshot/` - renamed from cleanshot


### PR DESCRIPTION
## Summary

- Consolidates branch and review-feedback skills into a single dev skill for better discoverability
- Renames cleanshot skill to screenshot to avoid clashing with `/clear`

## Test plan

- [ ] Verify `/dev` skill loads and contains both branching and review feedback sections
- [ ] Verify `/screenshot` works (not `/cleanshot`)
- [ ] Verify `/sc` expands to `/screenshot` instead of conflicting with `/clear`