### PR TITLE
appscript: add auto-accept calendar invites

### DIFF
--- a/.github/pr/appscript-auto-accept.md
+++ b/.github/pr/appscript-auto-accept.md
@@ -1,0 +1,12 @@
+# appscript: add auto-accept calendar invites
+
+Google Apps Script to automatically accept calendar invites from a configured email address.
+
+## Changes
+
+- `lib/appscript/auto-accept.gs` - auto-accept invites from a configured calendar:
+  - `setOtherCalendar(email)` - configure which sender to auto-accept
+  - `setupAutoAccept()` - create hourly and calendar-change triggers
+  - Auto-accepts INVITED/MAYBE events from the configured organizer
+- `lib/appscript/auto-accept.test.js` - tests for property storage
+- `lib/appscript/.claspignore` - add test files to ignore list

--- a/lib/appscript/.clasp.json
+++ b/lib/appscript/.clasp.json
@@ -1,0 +1,16 @@
+{
+  "scriptId": "1rOTbx7sifvKj1hUjfZw31jwmcVgl3BQ11tOtW82FApz_6oDDPJ5hvrYb",
+  "rootDir": "",
+  "scriptExtensions": [
+    ".js",
+    ".gs"
+  ],
+  "htmlExtensions": [
+    ".html"
+  ],
+  "jsonExtensions": [
+    ".json"
+  ],
+  "filePushOrder": [],
+  "skipSubdirectories": false
+}

--- a/lib/appscript/.claspignore
+++ b/lib/appscript/.claspignore
@@ -6,5 +6,9 @@
 # Build files
 *.md
 cook.mk
+
+# Test files
+run-test.js
+*.test.js
 test_*.tl
 test_*.lua

--- a/lib/appscript/auto-accept.gs
+++ b/lib/appscript/auto-accept.gs
@@ -1,0 +1,89 @@
+const OTHER_CALENDAR_PROP = 'other_calendar_email';
+
+function getOtherCalendar() {
+  return PropertiesService.getScriptProperties().getProperty(OTHER_CALENDAR_PROP);
+}
+
+function setOtherCalendar(email) {
+  PropertiesService.getScriptProperties().setProperty(OTHER_CALENDAR_PROP, email);
+  Logger.log(`Set other calendar to: ${email}`);
+}
+
+function autoAcceptOtherCalendarInvites() {
+  const otherEmail = getOtherCalendar();
+  if (!otherEmail) {
+    Logger.log('No other calendar configured. Run setOtherCalendar(email) first.');
+    return;
+  }
+
+  const calendar = CalendarApp.getDefaultCalendar();
+  const now = new Date();
+  const fourWeeksOut = new Date(now.getTime() + 28 * 24 * 60 * 60 * 1000);
+
+  const events = calendar.getEvents(now, fourWeeksOut);
+  let accepted = 0;
+
+  for (const event of events) {
+    const organizer = event.getCreators()[0];
+    if (organizer && organizer.toLowerCase() === otherEmail.toLowerCase()) {
+      const status = event.getMyStatus();
+      if (status === CalendarApp.GuestStatus.INVITED ||
+          status === CalendarApp.GuestStatus.MAYBE) {
+        event.setMyStatus(CalendarApp.GuestStatus.YES);
+        Logger.log(`Accepted: ${event.getTitle()} on ${event.getStartTime()}`);
+        accepted++;
+      }
+    }
+  }
+
+  Logger.log(`Auto-accepted ${accepted} events from ${otherEmail}`);
+  return accepted;
+}
+
+function createAutoAcceptTrigger() {
+  const triggers = ScriptApp.getProjectTriggers();
+  for (const trigger of triggers) {
+    if (trigger.getHandlerFunction() === 'autoAcceptOtherCalendarInvites') {
+      ScriptApp.deleteTrigger(trigger);
+    }
+  }
+
+  ScriptApp.newTrigger('autoAcceptOtherCalendarInvites')
+    .timeBased()
+    .everyHours(1)
+    .create();
+
+  Logger.log('Created hourly trigger for autoAcceptOtherCalendarInvites');
+}
+
+function onCalendarChangeAutoAccept(e) {
+  autoAcceptOtherCalendarInvites();
+}
+
+function createAutoAcceptCalendarTrigger() {
+  const triggers = ScriptApp.getProjectTriggers();
+  for (const trigger of triggers) {
+    if (trigger.getHandlerFunction() === 'onCalendarChangeAutoAccept') {
+      ScriptApp.deleteTrigger(trigger);
+    }
+  }
+
+  ScriptApp.newTrigger('onCalendarChangeAutoAccept')
+    .forUserCalendar(Session.getActiveUser().getEmail())
+    .onEventUpdated()
+    .create();
+
+  Logger.log('Created calendar change trigger for auto-accept');
+}
+
+function setupAutoAccept() {
+  const otherEmail = getOtherCalendar();
+  if (!otherEmail) {
+    Logger.log('ERROR: Run setOtherCalendar("your@other.email") first');
+    return;
+  }
+
+  createAutoAcceptTrigger();
+  createAutoAcceptCalendarTrigger();
+  autoAcceptOtherCalendarInvites();
+}

--- a/lib/appscript/auto-accept.test.js
+++ b/lib/appscript/auto-accept.test.js
@@ -1,0 +1,146 @@
+// Tests for auto-accept.gs - auto-accept calendar invites
+
+const autoAccept = loadGsFile("auto-accept.gs");
+
+log("auto-accept.gs:");
+
+// Property storage tests
+runTest("getOtherCalendar returns null when not set", () => {
+  delete mockProperties["other_calendar_email"];
+  assertEqual(autoAccept.getOtherCalendar(), null, "should be null");
+});
+
+runTest("setOtherCalendar stores email", () => {
+  autoAccept.setOtherCalendar("other@example.com");
+  assertEqual(mockProperties["other_calendar_email"], "other@example.com", "stored value");
+});
+
+runTest("getOtherCalendar returns stored value", () => {
+  mockProperties["other_calendar_email"] = "stored@example.com";
+  assertEqual(autoAccept.getOtherCalendar(), "stored@example.com", "retrieved value");
+});
+
+// autoAcceptOtherCalendarInvites tests
+runTest("autoAccept returns early when no email configured", () => {
+  delete mockProperties["other_calendar_email"];
+  mockCalendarEvents = [];
+  const result = autoAccept.autoAcceptOtherCalendarInvites();
+  assertEqual(result, undefined, "should return undefined");
+});
+
+runTest("autoAccept returns 0 when no events", () => {
+  mockProperties["other_calendar_email"] = "organizer@example.com";
+  mockCalendarEvents = [];
+  const result = autoAccept.autoAcceptOtherCalendarInvites();
+  assertEqual(result, 0, "should return 0");
+});
+
+runTest("autoAccept accepts INVITED event from configured organizer", () => {
+  mockProperties["other_calendar_email"] = "organizer@example.com";
+  const event = createMockEvent({
+    organizer: "organizer@example.com",
+    status: CalendarApp.GuestStatus.INVITED,
+    title: "Test Meeting",
+  });
+  mockCalendarEvents = [event];
+
+  const result = autoAccept.autoAcceptOtherCalendarInvites();
+  assertEqual(result, 1, "should accept 1 event");
+  assertEqual(event._getSetStatus(), CalendarApp.GuestStatus.YES, "status should be YES");
+});
+
+runTest("autoAccept accepts MAYBE event from configured organizer", () => {
+  mockProperties["other_calendar_email"] = "organizer@example.com";
+  const event = createMockEvent({
+    organizer: "organizer@example.com",
+    status: CalendarApp.GuestStatus.MAYBE,
+  });
+  mockCalendarEvents = [event];
+
+  const result = autoAccept.autoAcceptOtherCalendarInvites();
+  assertEqual(result, 1, "should accept 1 event");
+  assertEqual(event._getSetStatus(), CalendarApp.GuestStatus.YES, "status should be YES");
+});
+
+runTest("autoAccept ignores already accepted events", () => {
+  mockProperties["other_calendar_email"] = "organizer@example.com";
+  const event = createMockEvent({
+    organizer: "organizer@example.com",
+    status: CalendarApp.GuestStatus.YES,
+  });
+  mockCalendarEvents = [event];
+
+  const result = autoAccept.autoAcceptOtherCalendarInvites();
+  assertEqual(result, 0, "should accept 0 events");
+});
+
+runTest("autoAccept ignores events from other organizers", () => {
+  mockProperties["other_calendar_email"] = "organizer@example.com";
+  const event = createMockEvent({
+    organizer: "someone-else@example.com",
+    status: CalendarApp.GuestStatus.INVITED,
+  });
+  mockCalendarEvents = [event];
+
+  const result = autoAccept.autoAcceptOtherCalendarInvites();
+  assertEqual(result, 0, "should accept 0 events");
+  assertEqual(event._getSetStatus(), CalendarApp.GuestStatus.INVITED, "status unchanged");
+});
+
+runTest("autoAccept matches organizer case-insensitively", () => {
+  mockProperties["other_calendar_email"] = "Organizer@Example.com";
+  const event = createMockEvent({
+    organizer: "organizer@example.com",
+    status: CalendarApp.GuestStatus.INVITED,
+  });
+  mockCalendarEvents = [event];
+
+  const result = autoAccept.autoAcceptOtherCalendarInvites();
+  assertEqual(result, 1, "should accept 1 event");
+});
+
+runTest("autoAccept handles events with no organizer", () => {
+  mockProperties["other_calendar_email"] = "organizer@example.com";
+  const event = createMockEvent({
+    status: CalendarApp.GuestStatus.INVITED,
+  });
+  mockCalendarEvents = [event];
+
+  const result = autoAccept.autoAcceptOtherCalendarInvites();
+  assertEqual(result, 0, "should accept 0 events");
+});
+
+runTest("autoAccept processes multiple events correctly", () => {
+  mockProperties["other_calendar_email"] = "organizer@example.com";
+  const event1 = createMockEvent({
+    organizer: "organizer@example.com",
+    status: CalendarApp.GuestStatus.INVITED,
+  });
+  const event2 = createMockEvent({
+    organizer: "organizer@example.com",
+    status: CalendarApp.GuestStatus.MAYBE,
+  });
+  const event3 = createMockEvent({
+    organizer: "other@example.com",
+    status: CalendarApp.GuestStatus.INVITED,
+  });
+  const event4 = createMockEvent({
+    organizer: "organizer@example.com",
+    status: CalendarApp.GuestStatus.YES,
+  });
+  mockCalendarEvents = [event1, event2, event3, event4];
+
+  const result = autoAccept.autoAcceptOtherCalendarInvites();
+  assertEqual(result, 2, "should accept 2 events");
+  assertEqual(event1._getSetStatus(), CalendarApp.GuestStatus.YES, "event1 accepted");
+  assertEqual(event2._getSetStatus(), CalendarApp.GuestStatus.YES, "event2 accepted");
+  assertEqual(event3._getSetStatus(), CalendarApp.GuestStatus.INVITED, "event3 unchanged");
+  assertEqual(event4._getSetStatus(), CalendarApp.GuestStatus.YES, "event4 unchanged");
+});
+
+// setupAutoAccept tests
+runTest("setupAutoAccept returns early when no email configured", () => {
+  delete mockProperties["other_calendar_email"];
+  // Should not throw
+  autoAccept.setupAutoAccept();
+});

--- a/lib/appscript/cook.mk
+++ b/lib/appscript/cook.mk
@@ -17,6 +17,11 @@ $(o)/lib/appscript/appsscript.json: lib/appscript/appsscript.json
 	@mkdir -p $(@D)
 	@cp $< $@
 
+.PHONY: appscript-push
+## Push appscript files to Google Apps Script
+appscript-push: $(patsubst %,$(o)/%.bun.ok,$(appscript_buns)) $$(clasp_bin)
+	@cd lib/appscript && $(CURDIR)/$(clasp_bin) push --force
+
 # JavaScript test rule for appscript
 $(o)/lib/appscript/%.test.js.test.ok: lib/appscript/%.test.js $(appscript_runner) $(appscript_files) $$(bun_staged)
 	@mkdir -p $(@D)

--- a/lib/appscript/cook.mk
+++ b/lib/appscript/cook.mk
@@ -1,10 +1,13 @@
 modules += appscript
 appscript_files := $(o)/lib/appscript/appsscript.json
 appscript_files += $(patsubst lib/appscript/%.gs,$(o)/lib/appscript/%.gs,$(wildcard lib/appscript/*.gs))
+appscript_tests := $(wildcard lib/appscript/*.test.js)
 appscript_deps := clasp bun
 
 # gs files to check
 appscript_buns := $(wildcard lib/appscript/*.gs)
+
+appscript_runner := lib/appscript/run-test.js
 
 $(o)/lib/appscript/%.gs: lib/appscript/%.gs
 	@mkdir -p $(@D)
@@ -13,3 +16,8 @@ $(o)/lib/appscript/%.gs: lib/appscript/%.gs
 $(o)/lib/appscript/appsscript.json: lib/appscript/appsscript.json
 	@mkdir -p $(@D)
 	@cp $< $@
+
+# JavaScript test rule for appscript
+$(o)/lib/appscript/%.test.js.test.ok: lib/appscript/%.test.js $(appscript_runner) $(appscript_files) $$(bun_staged)
+	@mkdir -p $(@D)
+	-@$(bun_dir)/bin/bun run $(appscript_runner) $< > $@

--- a/lib/appscript/run-test.js
+++ b/lib/appscript/run-test.js
@@ -61,11 +61,32 @@ globalThis.runTest = function(name, fn) {
 };
 
 // Setup mocks for Google Apps Script globals
+globalThis.mockCalendarEvents = [];
 globalThis.CalendarApp = {
+  GuestStatus: {
+    INVITED: "INVITED",
+    MAYBE: "MAYBE",
+    YES: "YES",
+    NO: "NO",
+    OWNER: "OWNER",
+  },
   getDefaultCalendar: () => ({
-    getEvents: () => [],
+    getEvents: () => mockCalendarEvents,
     createEvent: () => ({}),
   }),
+};
+
+// Factory to create mock calendar events
+globalThis.createMockEvent = function(opts = {}) {
+  let myStatus = opts.status || CalendarApp.GuestStatus.INVITED;
+  return {
+    getCreators: () => opts.organizer ? [opts.organizer] : [],
+    getMyStatus: () => myStatus,
+    setMyStatus: (status) => { myStatus = status; },
+    getTitle: () => opts.title || "Test Event",
+    getStartTime: () => opts.startTime || new Date(),
+    _getSetStatus: () => myStatus,  // for test assertions
+  };
 };
 
 globalThis.ScriptApp = {

--- a/lib/home/cook.mk
+++ b/lib/home/cook.mk
@@ -57,7 +57,7 @@ dots_lib := lib/cook.mk $(wildcard lib/*.lua) $(wildcard lib/*.tl) \
     $(wildcard lib/*/*.js) $(wildcard lib/*/*.gs) $(wildcard lib/*/*.json) \
     $(wildcard lib/*/*.snap) $(wildcard lib/*/*/*.lua) $(wildcard lib/*/*/*.tl) \
     $(wildcard lib/types/*.d.tl) $(wildcard lib/types/*/*.d.tl) \
-    $(wildcard lib/*/.args) $(wildcard lib/*/.claspignore) $(wildcard lib/*/MANIFEST.txt) \
+    $(wildcard lib/*/.args) $(wildcard lib/*/.clasp.json) $(wildcard lib/*/.claspignore) $(wildcard lib/*/MANIFEST.txt) \
     $(wildcard lib/box/*-backend)
 
 home_built := $(o)/home/.built

--- a/lib/home/cook.mk
+++ b/lib/home/cook.mk
@@ -54,7 +54,7 @@ dots_bin := $(wildcard bin/*)
 # lib/ sources (comprehensive wildcards)
 dots_lib := lib/cook.mk $(wildcard lib/*.lua) $(wildcard lib/*.tl) \
     $(wildcard lib/*/cook.mk) $(wildcard lib/*/*.lua) $(wildcard lib/*/*.tl) \
-    $(wildcard lib/*/*.js) $(wildcard lib/*/*.json) \
+    $(wildcard lib/*/*.js) $(wildcard lib/*/*.gs) $(wildcard lib/*/*.json) \
     $(wildcard lib/*/*.snap) $(wildcard lib/*/*/*.lua) $(wildcard lib/*/*/*.tl) \
     $(wildcard lib/types/*.d.tl) $(wildcard lib/types/*/*.d.tl) \
     $(wildcard lib/*/.args) $(wildcard lib/*/.claspignore) $(wildcard lib/*/MANIFEST.txt) \


### PR DESCRIPTION
Google Apps Script to automatically accept calendar invites from a configured email address.

## Changes

- `lib/appscript/auto-accept.gs` - auto-accept invites from a configured calendar:
  - `setOtherCalendar(email)` - configure which sender to auto-accept
  - `setupAutoAccept()` - create hourly and calendar-change triggers
  - Auto-accepts INVITED/MAYBE events from the configured organizer
- `lib/appscript/auto-accept.test.js` - tests for property storage
- `lib/appscript/.claspignore` - add test files to ignore list