### PR TITLE
appscript: add busy calendar filler

### DIFF
--- a/.github/pr/appscript-build.md
+++ b/.github/pr/appscript-build.md
@@ -1,0 +1,12 @@
+# appscript: add build and test machinery
+
+Add build module for Google Apps Script files, extracted from wcm/calendar-color-rules.
+
+## Changes
+
+- `lib/appscript/cook.mk` - build rules for .gs files and JavaScript tests
+- `lib/appscript/run-test.js` - test runner with Google Apps Script mocks
+- `lib/appscript/appsscript.json` - manifest with Calendar and People API scopes
+- `lib/appscript/.claspignore` - files to exclude from clasp push
+- `lib/cook.mk` - include appscript module
+- `lib/home/cook.mk` - add .js, .json, .claspignore wildcards to dots_lib

--- a/.github/pr/appscript-busy.md
+++ b/.github/pr/appscript-busy.md
@@ -1,0 +1,14 @@
+# appscript: add busy calendar filler
+
+Google Apps Script to fill calendar gaps with "Busy" blocks.
+
+## Changes
+
+- `lib/appscript/busy.gs` - fill calendar gaps with busy events:
+  - Creates 25 or 50 minute "Busy" blocks in free time slots
+  - Works within configurable working hours (default 9-5, M-F)
+  - Current week: fills all gaps
+  - Next week: leaves 2 hours open
+  - Later weeks: leaves 4 hours open
+  - `setupBusyFill()` - creates 4-hour trigger and runs initial fill
+- `lib/appscript/busy.test.js` - tests for time utilities and gap finding

--- a/lib/appscript/.claspignore
+++ b/lib/appscript/.claspignore
@@ -1,0 +1,10 @@
+# Config files
+.clasp.json
+.clasp.json.example
+.claspignore
+
+# Build files
+*.md
+cook.mk
+test_*.tl
+test_*.lua

--- a/lib/appscript/appsscript.json
+++ b/lib/appscript/appsscript.json
@@ -1,0 +1,25 @@
+{
+  "timeZone": "America/Los_Angeles",
+  "dependencies": {
+    "enabledAdvancedServices": [
+      {
+        "userSymbol": "People",
+        "version": "v1",
+        "serviceId": "peopleapi"
+      },
+      {
+        "userSymbol": "Calendar",
+        "version": "v3",
+        "serviceId": "calendar"
+      }
+    ]
+  },
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/directory.readonly",
+    "https://www.googleapis.com/auth/script.scriptapp"
+  ]
+}

--- a/lib/appscript/busy.gs
+++ b/lib/appscript/busy.gs
@@ -1,0 +1,306 @@
+const BUSY_TITLE = 'Busy';
+const DEFAULT_WORK_START_HOUR = 9;
+const DEFAULT_WORK_END_HOUR = 17;
+const NEXT_WEEK_OPEN_MINUTES = 120; // 2 hours
+const LATER_WEEK_OPEN_MINUTES = 240; // 4 hours
+
+function getWorkingHours() {
+  return {
+    startHour: DEFAULT_WORK_START_HOUR,
+    endHour: DEFAULT_WORK_END_HOUR
+  };
+}
+
+function isWorkingDay(date) {
+  const day = date.getDay();
+  return day >= 1 && day <= 5;
+}
+
+function getWeekStart(date) {
+  const d = new Date(date);
+  d.setDate(d.getDate() - d.getDay());
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function getDateRange() {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const weekStart = getWeekStart(today);
+
+  // Current week + 3 more weeks
+  const endDate = new Date(weekStart);
+  endDate.setDate(weekStart.getDate() + 28);
+
+  return { start: weekStart, end: endDate };
+}
+
+function deleteExistingBusyEvents(calendar, startDate, endDate) {
+  const events = calendar.getEvents(startDate, endDate);
+  let deleted = 0;
+
+  for (const event of events) {
+    if (event.getTitle() === BUSY_TITLE && event.getGuestList().length === 0) {
+      event.deleteEvent();
+      deleted++;
+    }
+  }
+
+  Logger.log(`Deleted ${deleted} existing Busy events`);
+  return deleted;
+}
+
+function roundUpToSlot(date) {
+  const result = new Date(date);
+  const minutes = result.getMinutes();
+
+  if (minutes === 0 || minutes === 30) {
+    return result;
+  }
+
+  if (minutes < 30) {
+    result.setMinutes(30, 0, 0);
+  } else {
+    result.setMinutes(0, 0, 0);
+    result.setHours(result.getHours() + 1);
+  }
+
+  return result;
+}
+
+function roundDownToSlot(date) {
+  const result = new Date(date);
+  const minutes = result.getMinutes();
+
+  if (minutes < 30) {
+    result.setMinutes(0, 0, 0);
+  } else {
+    result.setMinutes(30, 0, 0);
+  }
+
+  return result;
+}
+
+function findGaps(events, dayStart, dayEnd) {
+  const gaps = [];
+
+  const sorted = events
+    .filter(e => e.getStartTime() < dayEnd && e.getEndTime() > dayStart)
+    .sort((a, b) => a.getStartTime() - b.getStartTime());
+
+  let currentTime = new Date(dayStart);
+
+  for (const event of sorted) {
+    const eventStart = event.getStartTime();
+    const eventEnd = event.getEndTime();
+
+    const clampedStart = eventStart < dayStart ? dayStart : eventStart;
+    const clampedEnd = eventEnd > dayEnd ? dayEnd : eventEnd;
+
+    if (currentTime < clampedStart) {
+      gaps.push({
+        start: new Date(currentTime),
+        end: new Date(clampedStart)
+      });
+    }
+
+    if (clampedEnd > currentTime) {
+      currentTime = new Date(clampedEnd);
+    }
+  }
+
+  if (currentTime < dayEnd) {
+    gaps.push({
+      start: new Date(currentTime),
+      end: new Date(dayEnd)
+    });
+  }
+
+  return gaps;
+}
+
+function getUsableGapMinutes(gap) {
+  const slotStart = roundUpToSlot(gap.start);
+  const slotEnd = roundDownToSlot(gap.end);
+  const minutes = (slotEnd - slotStart) / (1000 * 60);
+  return Math.max(0, minutes);
+}
+
+function fillGapWithBusyEvents(calendar, gap, maxMinutes) {
+  const events = [];
+  let slotStart = roundUpToSlot(gap.start);
+  const slotEnd = roundDownToSlot(gap.end);
+  let minutesFilled = 0;
+
+  while (slotStart < slotEnd) {
+    if (maxMinutes !== null && minutesFilled >= maxMinutes) {
+      break;
+    }
+
+    const remainingInGap = (slotEnd - slotStart) / (1000 * 60);
+    const remainingAllowed = maxMinutes !== null ? maxMinutes - minutesFilled : Infinity;
+
+    let duration;
+    if (remainingInGap >= 50 && remainingAllowed >= 50) {
+      duration = 50;
+    } else if (remainingInGap >= 25 && remainingAllowed >= 25) {
+      duration = 25;
+    } else {
+      break;
+    }
+
+    const eventEnd = new Date(slotStart.getTime() + duration * 60 * 1000);
+
+    const event = calendar.createEvent(BUSY_TITLE, slotStart, eventEnd);
+    events.push(event);
+    minutesFilled += duration;
+
+    slotStart = new Date(eventEnd);
+
+    if (slotStart.getMinutes() !== 0 && slotStart.getMinutes() !== 30) {
+      slotStart = roundUpToSlot(slotStart);
+    }
+  }
+
+  return { events, minutesFilled };
+}
+
+function fillBusyEvents() {
+  const startTime = Date.now();
+  const calendar = CalendarApp.getDefaultCalendar();
+  const { startHour, endHour } = getWorkingHours();
+  const { start: rangeStart, end: rangeEnd } = getDateRange();
+  const now = new Date();
+  const currentWeekStart = getWeekStart(now);
+  const nextWeekStart = new Date(currentWeekStart);
+  nextWeekStart.setDate(nextWeekStart.getDate() + 7);
+
+  Logger.log(`Filling busy events from ${rangeStart} to ${rangeEnd}`);
+  Logger.log(`Working hours: ${startHour}:00 - ${endHour}:00`);
+
+  deleteExistingBusyEvents(calendar, rangeStart, rangeEnd);
+  Utilities.sleep(1000);
+
+  // Group days by week
+  const weekDays = new Map();
+  const current = new Date(rangeStart);
+
+  while (current < rangeEnd) {
+    if (isWorkingDay(current)) {
+      const weekStart = getWeekStart(current).getTime();
+      if (!weekDays.has(weekStart)) {
+        weekDays.set(weekStart, []);
+      }
+      weekDays.get(weekStart).push(new Date(current));
+    }
+    current.setDate(current.getDate() + 1);
+  }
+
+  let totalCreated = 0;
+
+  for (const [weekStartMs, days] of weekDays) {
+    const isCurrentWeek = weekStartMs === currentWeekStart.getTime();
+    const isNextWeek = weekStartMs === nextWeekStart.getTime();
+    const weekLabel = new Date(weekStartMs).toDateString();
+
+    // Collect all gaps for this week
+    const weekGaps = [];
+
+    for (const day of days) {
+      const dayStart = new Date(day);
+      dayStart.setHours(startHour, 0, 0, 0);
+
+      const dayEnd = new Date(day);
+      dayEnd.setHours(endHour, 0, 0, 0);
+
+      if (dayEnd < now) {
+        continue;
+      }
+
+      let effectiveStart = dayStart;
+      if (day.toDateString() === now.toDateString() && now > dayStart) {
+        effectiveStart = roundUpToSlot(now);
+      }
+
+      if (effectiveStart >= dayEnd) {
+        continue;
+      }
+
+      const existingEvents = calendar.getEvents(dayStart, dayEnd)
+        .filter(e => !e.isAllDayEvent())
+        .filter(e => !(e.getTitle() === BUSY_TITLE && e.getGuestList().length === 0));
+
+      const gaps = findGaps(existingEvents, effectiveStart, dayEnd);
+      for (const gap of gaps) {
+        weekGaps.push({ gap, day });
+      }
+    }
+
+    // Calculate total usable gap time
+    let totalGapMinutes = 0;
+    for (const { gap } of weekGaps) {
+      totalGapMinutes += getUsableGapMinutes(gap);
+    }
+
+    // Determine how much to fill
+    let minutesToFill;
+    let openMinutes;
+    if (isCurrentWeek) {
+      minutesToFill = totalGapMinutes;
+      Logger.log(`Week of ${weekLabel} (current): filling all ${totalGapMinutes} minutes`);
+    } else if (isNextWeek) {
+      openMinutes = Math.min(totalGapMinutes, NEXT_WEEK_OPEN_MINUTES);
+      minutesToFill = totalGapMinutes - openMinutes;
+      Logger.log(`Week of ${weekLabel} (next): ${totalGapMinutes} min gaps, filling ${minutesToFill}, leaving ${openMinutes} open`);
+    } else {
+      openMinutes = Math.min(totalGapMinutes, LATER_WEEK_OPEN_MINUTES);
+      minutesToFill = totalGapMinutes - openMinutes;
+      Logger.log(`Week of ${weekLabel}: ${totalGapMinutes} min gaps, filling ${minutesToFill}, leaving ${openMinutes} open`);
+    }
+
+    // Fill gaps until we hit the limit
+    let minutesFilled = 0;
+    for (const { gap, day } of weekGaps) {
+      if (minutesFilled >= minutesToFill) {
+        break;
+      }
+
+      const remaining = minutesToFill - minutesFilled;
+      const { events, minutesFilled: filled } = fillGapWithBusyEvents(calendar, gap, isCurrentWeek ? null : remaining);
+      totalCreated += events.length;
+      minutesFilled += filled;
+
+      if (events.length > 0) {
+        Logger.log(`  ${day.toDateString()}: created ${events.length} events (${filled} min)`);
+      }
+    }
+  }
+
+  const elapsed = Date.now() - startTime;
+  Logger.log(`Created ${totalCreated} Busy events in ${elapsed}ms`);
+  return totalCreated;
+}
+
+function createBusyFillTrigger() {
+  const triggers = ScriptApp.getProjectTriggers();
+  for (const trigger of triggers) {
+    if (trigger.getHandlerFunction() === 'fillBusyEvents') {
+      ScriptApp.deleteTrigger(trigger);
+    }
+  }
+
+  ScriptApp.newTrigger('fillBusyEvents')
+    .timeBased()
+    .everyHours(4)
+    .create();
+
+  Logger.log('Created 4-hour trigger for fillBusyEvents');
+}
+
+function setupBusyFill() {
+  createBusyFillTrigger();
+  fillBusyEvents();
+}
+
+// For testing
+return { getWorkingHours, isWorkingDay, getWeekStart, roundUpToSlot, roundDownToSlot, findGaps };

--- a/lib/appscript/busy.test.js
+++ b/lib/appscript/busy.test.js
@@ -1,0 +1,75 @@
+// Tests for busy.gs - calendar busy block filling
+
+const busy = loadGsFile("busy.gs");
+
+log("busy.gs:");
+
+runTest("getWorkingHours returns defaults", () => {
+  const h = busy.getWorkingHours();
+  assertEqual(h.startHour, 9, "startHour");
+  assertEqual(h.endHour, 17, "endHour");
+});
+
+runTest("isWorkingDay: monday is working day", () => {
+  assert(busy.isWorkingDay(new Date("2024-01-08")), "monday should be working day");
+});
+
+runTest("isWorkingDay: saturday is not working day", () => {
+  assert(!busy.isWorkingDay(new Date("2024-01-13")), "saturday should not be working day");
+});
+
+runTest("getWeekStart returns sunday at midnight", () => {
+  const wed = new Date("2024-01-10T15:30:00");
+  const start = busy.getWeekStart(wed);
+  assertEqual(start.getDay(), 0, "day");
+  assertEqual(start.getHours(), 0, "hours");
+});
+
+runTest("roundUpToSlot: 0 stays at 0", () => {
+  const d = new Date("2024-01-10T10:00:00");
+  const r = busy.roundUpToSlot(d);
+  assertEqual(r.getMinutes(), 0, "minutes");
+});
+
+runTest("roundUpToSlot: 15 rounds to 30", () => {
+  const d = new Date("2024-01-10T10:15:00");
+  const r = busy.roundUpToSlot(d);
+  assertEqual(r.getMinutes(), 30, "minutes");
+});
+
+runTest("roundUpToSlot: 45 rounds to next hour", () => {
+  const d = new Date("2024-01-10T10:45:00");
+  const r = busy.roundUpToSlot(d);
+  assertEqual(r.getMinutes(), 0, "minutes");
+  assertEqual(r.getHours(), 11, "hours");
+});
+
+runTest("roundDownToSlot: 15 rounds to 0", () => {
+  const d = new Date("2024-01-10T10:15:00");
+  const r = busy.roundDownToSlot(d);
+  assertEqual(r.getMinutes(), 0, "minutes");
+});
+
+runTest("roundDownToSlot: 45 rounds to 30", () => {
+  const d = new Date("2024-01-10T10:45:00");
+  const r = busy.roundDownToSlot(d);
+  assertEqual(r.getMinutes(), 30, "minutes");
+});
+
+runTest("findGaps: no events returns full day", () => {
+  const start = new Date("2024-01-10T09:00:00");
+  const end = new Date("2024-01-10T17:00:00");
+  const gaps = busy.findGaps([], start, end);
+  assertEqual(gaps.length, 1, "gap count");
+});
+
+runTest("findGaps: one event creates two gaps", () => {
+  const start = new Date("2024-01-10T09:00:00");
+  const end = new Date("2024-01-10T17:00:00");
+  const events = [{
+    getStartTime: () => new Date("2024-01-10T12:00:00"),
+    getEndTime: () => new Date("2024-01-10T13:00:00"),
+  }];
+  const gaps = busy.findGaps(events, start, end);
+  assertEqual(gaps.length, 2, "gap count");
+});

--- a/lib/appscript/cook.mk
+++ b/lib/appscript/cook.mk
@@ -1,0 +1,24 @@
+modules += appscript
+appscript_files := $(o)/lib/appscript/appsscript.json
+appscript_files += $(patsubst lib/appscript/%.gs,$(o)/lib/appscript/%.gs,$(wildcard lib/appscript/*.gs))
+appscript_tests := $(wildcard lib/appscript/*.test.js)
+appscript_deps := clasp bun
+
+appscript_runner := lib/appscript/run-test.js
+
+$(o)/lib/appscript/%.gs: lib/appscript/%.gs
+	@mkdir -p $(@D)
+	@cp $< $@
+
+$(o)/lib/appscript/appsscript.json: lib/appscript/appsscript.json
+	@mkdir -p $(@D)
+	@cp $< $@
+
+$(o)/lib/appscript/.claspignore: lib/appscript/.claspignore
+	@mkdir -p $(@D)
+	@cp $< $@
+
+# JavaScript test rule for appscript
+$(o)/lib/appscript/%.test.js.test.ok: lib/appscript/%.test.js $(appscript_runner) $(appscript_files) $$(bun_staged)
+	@mkdir -p $(@D)
+	-@$(bun_dir)/bin/bun run $(appscript_runner) $< > $@

--- a/lib/appscript/run-test.js
+++ b/lib/appscript/run-test.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env bun
+// Test runner for appscript - runs a single test file
+// Usage: bun run run-test.js <test-file.test.js>
+// Output format (compatible with test reporter):
+//   pass (or fail: message)
+//   ## stdout
+//   <stdout>
+//   ## stderr
+//   <stderr>
+
+import { dirname, join, resolve } from "path";
+
+const srcDir = dirname(import.meta.path);
+const testFileArg = process.argv[2];
+const testFile = testFileArg ? resolve(testFileArg) : null;
+
+if (!testFile) {
+  console.log("fail: no test file specified");
+  console.log("");
+  console.log("## stdout");
+  console.log("");
+  console.log("usage: run-test.js <test-file.test.js>");
+  console.log("## stderr");
+  console.log("");
+  process.exit(0);
+}
+
+// Test state
+let failures = [];
+let stdout = [];
+
+// Export test utilities to global scope
+globalThis.TEST_SRCDIR = srcDir;
+globalThis.TEST_FAILURES = failures;
+globalThis.TEST_STDOUT = stdout;
+
+globalThis.log = function(msg) {
+  stdout.push(msg);
+};
+
+globalThis.assert = function(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+globalThis.assertEqual = function(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${expected}, got ${actual}`);
+  }
+};
+
+globalThis.runTest = function(name, fn) {
+  try {
+    fn();
+    log(`  ✓ ${name}`);
+  } catch (e) {
+    failures.push(`${name}: ${e.message}`);
+    log(`  ✗ ${name}: ${e.message}`);
+  }
+};
+
+// Setup mocks for Google Apps Script globals
+globalThis.CalendarApp = {
+  getDefaultCalendar: () => ({
+    getEvents: () => [],
+    createEvent: () => ({}),
+  }),
+};
+
+globalThis.ScriptApp = {
+  getProjectTriggers: () => [],
+  deleteTrigger: () => {},
+  newTrigger: () => ({
+    timeBased: () => ({
+      everyHours: () => ({ create: () => {} }),
+    }),
+    forUserCalendar: () => ({
+      onEventUpdated: () => ({ create: () => {} }),
+    }),
+  }),
+};
+
+globalThis.Logger = { log: () => {} };
+globalThis.Utilities = { sleep: () => {} };
+
+globalThis.CacheService = {
+  getScriptCache: () => ({
+    get: () => null,
+    put: () => {},
+  }),
+};
+
+globalThis.People = {
+  People: {
+    searchDirectoryPeople: (opts) => {
+      const email = opts.query;
+      if (email && !email.includes("@resource.calendar.google.com")) {
+        return {
+          people: [{
+            emailAddresses: [{ value: email }]
+          }]
+        };
+      }
+      return { people: [] };
+    },
+  },
+};
+
+globalThis.Calendar = {
+  Events: {
+    get: () => ({ attendees: [] }),
+  },
+};
+
+globalThis.Session = {
+  getActiveUser: () => ({
+    getEmail: () => "test@example.com",
+  }),
+};
+
+globalThis.mockProperties = {};
+globalThis.PropertiesService = {
+  getScriptProperties: () => ({
+    getProperty: (key) => mockProperties[key] || null,
+    setProperty: (key, value) => { mockProperties[key] = value; },
+  }),
+};
+
+// Helper to load a .gs file and return its exports
+import { readFileSync } from "fs";
+
+globalThis.loadGsFile = function(filename) {
+  const code = readFileSync(join(srcDir, filename), "utf-8");
+  return new Function(code)();
+};
+
+// Run the test file
+try {
+  await import(testFile);
+} catch (e) {
+  failures.push(`import error: ${e.message}`);
+}
+
+// Output results
+console.log(failures.length === 0 ? "pass" : `fail: ${failures.length} test(s) failed`);
+console.log("");
+console.log("## stdout");
+console.log("");
+console.log(stdout.join("\n"));
+console.log("## stderr");
+console.log("");
+
+// Always exit 0 - reporter determines pass/fail from output
+process.exit(0);

--- a/lib/cook.mk
+++ b/lib/cook.mk
@@ -24,6 +24,7 @@ o/teal/lib/%.lua: lib/%.tl $(types_files) lib/cosmic/tl-gen.lua | $(bootstrap_fi
 	@$(bootstrap_cosmic) lib/cosmic/tl-gen.lua -- $< -o $@
 
 include lib/aerosnap/cook.mk
+include lib/appscript/cook.mk
 include lib/box/cook.mk
 include lib/build/cook.mk
 include lib/checker/cook.mk

--- a/lib/home/cook.mk
+++ b/lib/home/cook.mk
@@ -54,9 +54,10 @@ dots_bin := $(wildcard bin/*)
 # lib/ sources (comprehensive wildcards)
 dots_lib := lib/cook.mk $(wildcard lib/*.lua) $(wildcard lib/*.tl) \
     $(wildcard lib/*/cook.mk) $(wildcard lib/*/*.lua) $(wildcard lib/*/*.tl) \
+    $(wildcard lib/*/*.js) $(wildcard lib/*/*.json) \
     $(wildcard lib/*/*.snap) $(wildcard lib/*/*/*.lua) $(wildcard lib/*/*/*.tl) \
     $(wildcard lib/types/*.d.tl) $(wildcard lib/types/*/*.d.tl) \
-    $(wildcard lib/*/.args) $(wildcard lib/*/MANIFEST.txt)
+    $(wildcard lib/*/.args) $(wildcard lib/*/.claspignore) $(wildcard lib/*/MANIFEST.txt)
 
 home_built := $(o)/home/.built
 


### PR DESCRIPTION
Google Apps Script to fill calendar gaps with "Busy" blocks.

## Changes

- `lib/appscript/busy.gs` - fill calendar gaps with busy events:
  - Creates 25 or 50 minute "Busy" blocks in free time slots
  - Works within configurable working hours (default 9-5, M-F)
  - Current week: fills all gaps
  - Next week: leaves 2 hours open
  - Later weeks: leaves 4 hours open
  - `setupBusyFill()` - creates 4-hour trigger and runs initial fill
- `lib/appscript/busy.test.js` - tests for time utilities and gap finding