### PR TITLE
appscript: add calendar event colorizer

### DIFF
--- a/.github/pr/appscript-build.md
+++ b/.github/pr/appscript-build.md
@@ -1,0 +1,12 @@
+# appscript: add build and test machinery
+
+Add build module for Google Apps Script files, extracted from wcm/calendar-color-rules.
+
+## Changes
+
+- `lib/appscript/cook.mk` - build rules for .gs files and JavaScript tests
+- `lib/appscript/run-test.js` - test runner with Google Apps Script mocks
+- `lib/appscript/appsscript.json` - manifest with Calendar and People API scopes
+- `lib/appscript/.claspignore` - files to exclude from clasp push
+- `lib/cook.mk` - include appscript module
+- `lib/home/cook.mk` - add .js, .json, .claspignore wildcards to dots_lib

--- a/.github/pr/appscript-colorize.md
+++ b/.github/pr/appscript-colorize.md
@@ -1,0 +1,17 @@
+# appscript: add calendar event colorizer
+
+Google Apps Script to auto-color calendar events based on rules.
+
+## Changes
+
+- `lib/appscript/colorize.gs` - auto-color events based on type:
+  - OOO/async events (lavender/sage)
+  - Interviews (grape)
+  - Focus blocks (blueberry)
+  - 1:1s (banana)
+  - Group meetings - organizer vs guest (graphite/peacock)
+  - Uses People API to detect Google Groups vs individuals
+  - Caches group lookups for 6 hours
+  - RSVP comment overrides (#ignore, #1:1, #group, #solo)
+  - `setup()` - creates hourly trigger and runs initial colorize
+- `lib/appscript/colorize.test.js` - tests for rules and event type detection

--- a/lib/appscript/.claspignore
+++ b/lib/appscript/.claspignore
@@ -1,0 +1,10 @@
+# Config files
+.clasp.json
+.clasp.json.example
+.claspignore
+
+# Build files
+*.md
+cook.mk
+test_*.tl
+test_*.lua

--- a/lib/appscript/appsscript.json
+++ b/lib/appscript/appsscript.json
@@ -1,0 +1,25 @@
+{
+  "timeZone": "America/Los_Angeles",
+  "dependencies": {
+    "enabledAdvancedServices": [
+      {
+        "userSymbol": "People",
+        "version": "v1",
+        "serviceId": "peopleapi"
+      },
+      {
+        "userSymbol": "Calendar",
+        "version": "v3",
+        "serviceId": "calendar"
+      }
+    ]
+  },
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/directory.readonly",
+    "https://www.googleapis.com/auth/script.scriptapp"
+  ]
+}

--- a/lib/appscript/colorize.gs
+++ b/lib/appscript/colorize.gs
@@ -1,0 +1,257 @@
+const GROUP_CACHE_TTL = 21600; // 6 hours
+const MAX_RUNTIME_MS = 180000; // 3 minutes
+
+// Check if email is a group (not a person) using People API
+function isGroup(email) {
+  if (email.includes('@resource.calendar.google.com')) {
+    return false;
+  }
+
+  const cache = CacheService.getScriptCache();
+  const cacheKey = 'grp_v3_' + email.toLowerCase();
+
+  const cached = cache.get(cacheKey);
+  if (cached !== null) {
+    return cached === 'true';
+  }
+
+  let result = false;
+  try {
+    const response = People.People.searchDirectoryPeople({
+      query: email,
+      readMask: 'emailAddresses',
+      sources: ['DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE']
+    });
+    const found = response.people && response.people.some(p =>
+      p.emailAddresses && p.emailAddresses.some(e =>
+        e.value.toLowerCase() === email.toLowerCase()
+      )
+    );
+    result = !found; // not found as person = group
+  } catch (e) {
+    result = false;
+  }
+
+  cache.put(cacheKey, String(result), GROUP_CACHE_TTL);
+  return result;
+}
+
+// Get comment override from RSVP response
+function getCommentOverride(event) {
+  try {
+    const eventId = event.getId().split('@')[0];
+    const calEvent = Calendar.Events.get('primary', eventId);
+    if (calEvent.attendees) {
+      const self = calEvent.attendees.find(a => a.self);
+      if (self && self.comment) {
+        const comment = self.comment.toLowerCase();
+        if (comment.includes('#ignore')) return 'ignore';
+        if (comment.includes('#1:1') || comment.includes('#1x1')) return '1:1';
+        if (comment.includes('#group')) return 'group';
+        if (comment.includes('#solo')) return 'solo';
+      }
+    }
+  } catch (e) {
+    // ignore
+  }
+  return null;
+}
+
+// Analyze attendees: returns { individuals, groups, hasGroups }
+function analyzeAttendees(event) {
+  const myEmail = Session.getActiveUser().getEmail().toLowerCase();
+
+  // Build set of all attendees: guests + organizer
+  const emails = new Set();
+  for (const guest of event.getGuestList()) {
+    emails.add(guest.getEmail().toLowerCase());
+  }
+  const creators = event.getCreators();
+  if (creators.length > 0) {
+    emails.add(creators[0].toLowerCase());
+  }
+
+  let individuals = 0;
+  let groups = 0;
+
+  for (const email of emails) {
+    if (email === myEmail) continue;
+    if (email.includes('@resource.calendar.google.com')) continue;
+
+    if (isGroup(email)) {
+      groups++;
+    } else {
+      individuals++;
+    }
+  }
+
+  return { individuals, groups, hasGroups: groups > 0 };
+}
+
+// Determine event type: 'solo', '1:1', 'group'
+function getEventType(event) {
+  const { individuals, hasGroups } = analyzeAttendees(event);
+
+  // group = 2+ individuals OR any groups
+  if (individuals >= 2 || hasGroups) {
+    return 'group';
+  }
+  // 1:1 = exactly 1 other individual
+  if (individuals === 1) {
+    return '1:1';
+  }
+  // solo = just you
+  return 'solo';
+}
+
+const RULES = [
+  // Title-based rules (checked first)
+  {
+    name: 'out-of-office',
+    match: (event) => {
+      const title = event.getTitle().toLowerCase();
+      return title === 'out of office' || title.startsWith('ooo');
+    },
+    colorId: '1' // lavender
+  },
+  {
+    name: 'async',
+    match: (event) => {
+      const title = event.getTitle().toLowerCase();
+      return title.includes('[async]');
+    },
+    colorId: '2' // sage
+  },
+  {
+    name: 'interview',
+    match: (event) => {
+      const title = event.getTitle().toLowerCase();
+      return title.includes('interview');
+    },
+    colorId: '3' // grape
+  },
+  {
+    name: 'focus-block',
+    match: (event) => {
+      const title = event.getTitle();
+      const guests = event.getGuestList();
+      return title === 'Busy' && guests.length === 0;
+    },
+    colorId: '9' // blueberry
+  },
+  // Attendee-based rules
+  {
+    name: '1:1',
+    match: (event) => getEventType(event) === '1:1',
+    colorId: '5' // banana
+  },
+  {
+    name: 'group-organizer',
+    match: (event) => getEventType(event) === 'group' && event.isOwnedByMe(),
+    colorId: '8' // graphite
+  },
+  {
+    name: 'group-guest',
+    match: (event) => getEventType(event) === 'group' && !event.isOwnedByMe(),
+    colorId: '7' // peacock
+  }
+  // solo events: no rule, keep default color
+];
+
+function colorize() {
+  const startTime = Date.now();
+  const calendar = CalendarApp.getDefaultCalendar();
+  const now = new Date();
+
+  // Start of current week (Sunday)
+  const startOfWeek = new Date(now);
+  startOfWeek.setDate(now.getDate() - now.getDay());
+  startOfWeek.setHours(0, 0, 0, 0);
+
+  // End of 4th week (current + 3 more)
+  const endDate = new Date(startOfWeek);
+  endDate.setDate(startOfWeek.getDate() + 28);
+
+  const events = calendar.getEvents(startOfWeek, endDate);
+
+  // Shuffle with seeded RNG (changes each hour)
+  const seed = Math.floor(Date.now() / 3600000);
+  const seededRandom = (function(s) {
+    return function() {
+      s = (s * 1103515245 + 12345) & 0x7fffffff;
+      return s / 0x7fffffff;
+    };
+  })(seed);
+  for (let i = events.length - 1; i > 0; i--) {
+    const j = Math.floor(seededRandom() * (i + 1));
+    [events[i], events[j]] = [events[j], events[i]];
+  }
+
+  let updated = 0;
+
+  for (const event of events) {
+    if (Date.now() - startTime > MAX_RUNTIME_MS) {
+      Logger.log(`Hit max runtime (${MAX_RUNTIME_MS}ms)`);
+      break;
+    }
+
+    const title = event.getTitle();
+
+    // Check comment override
+    const override = getCommentOverride(event);
+    if (override === 'ignore') {
+      continue;
+    }
+
+    // Find matching rule
+    for (const rule of RULES) {
+      let matches = false;
+
+      // Comment overrides for type
+      if (override === '1:1' && rule.name === '1:1') {
+        matches = true;
+      } else if (override === 'group') {
+        if (rule.name === 'group-organizer' && event.isOwnedByMe()) matches = true;
+        if (rule.name === 'group-guest' && !event.isOwnedByMe()) matches = true;
+      } else if (!override) {
+        matches = rule.match(event);
+      }
+
+      if (matches) {
+        if (event.getColor() !== rule.colorId) {
+          event.setColor(rule.colorId);
+          Logger.log(`"${title}" -> ${rule.name}`);
+          updated++;
+        }
+        break;
+      }
+    }
+  }
+
+  Logger.log(`Updated ${updated}/${events.length} events`);
+  return updated;
+}
+
+function createTrigger() {
+  const triggers = ScriptApp.getProjectTriggers();
+  for (const trigger of triggers) {
+    if (trigger.getHandlerFunction() === 'colorize') {
+      ScriptApp.deleteTrigger(trigger);
+    }
+  }
+
+  ScriptApp.newTrigger('colorize')
+    .timeBased()
+    .everyHours(1)
+    .create();
+
+  Logger.log('Created hourly trigger for colorize');
+}
+
+function setup() {
+  createTrigger();
+  colorize();
+}
+
+// For testing
+return { RULES, isGroup, getEventType };

--- a/lib/appscript/colorize.test.js
+++ b/lib/appscript/colorize.test.js
@@ -1,0 +1,72 @@
+// Tests for colorize.gs - calendar event color coding
+
+const colorize = loadGsFile("colorize.gs");
+
+log("colorize.gs:");
+
+runTest("RULES has expected count", () => {
+  assert(colorize.RULES.length >= 7, "should have at least 7 rules");
+});
+
+runTest("out-of-office rule matches OOO", () => {
+  const rule = colorize.RULES.find(r => r.name === "out-of-office");
+  assert(rule.match({ getTitle: () => "OOO" }), "should match OOO");
+});
+
+runTest("out-of-office rule matches 'Out of Office'", () => {
+  const rule = colorize.RULES.find(r => r.name === "out-of-office");
+  assert(rule.match({ getTitle: () => "Out of Office" }), "should match Out of Office");
+});
+
+runTest("async rule matches [async]", () => {
+  const rule = colorize.RULES.find(r => r.name === "async");
+  assert(rule.match({ getTitle: () => "[async] Review" }), "should match [async]");
+});
+
+runTest("interview rule matches interview", () => {
+  const rule = colorize.RULES.find(r => r.name === "interview");
+  assert(rule.match({ getTitle: () => "Technical Interview" }), "should match interview");
+});
+
+runTest("focus-block matches Busy with no guests", () => {
+  const rule = colorize.RULES.find(r => r.name === "focus-block");
+  const event = { getTitle: () => "Busy", getGuestList: () => [] };
+  assert(rule.match(event), "should match Busy with no guests");
+});
+
+runTest("focus-block does not match Busy with guests", () => {
+  const rule = colorize.RULES.find(r => r.name === "focus-block");
+  const event = { getTitle: () => "Busy", getGuestList: () => [{}] };
+  assert(!rule.match(event), "should not match Busy with guests");
+});
+
+runTest("isGroup: resource calendars are not groups", () => {
+  assert(!colorize.isGroup("room@resource.calendar.google.com"), "resource should not be group");
+});
+
+runTest("getEventType: solo with no attendees", () => {
+  const event = {
+    getGuestList: () => [],
+    getCreators: () => ["test@example.com"],
+  };
+  assertEqual(colorize.getEventType(event), "solo", "type");
+});
+
+runTest("getEventType: 1:1 with one other person", () => {
+  const event = {
+    getGuestList: () => [{ getEmail: () => "other@example.com" }],
+    getCreators: () => ["test@example.com"],
+  };
+  assertEqual(colorize.getEventType(event), "1:1", "type");
+});
+
+runTest("getEventType: group with 2+ others", () => {
+  const event = {
+    getGuestList: () => [
+      { getEmail: () => "a@example.com" },
+      { getEmail: () => "b@example.com" },
+    ],
+    getCreators: () => ["test@example.com"],
+  };
+  assertEqual(colorize.getEventType(event), "group", "type");
+});

--- a/lib/appscript/cook.mk
+++ b/lib/appscript/cook.mk
@@ -1,0 +1,24 @@
+modules += appscript
+appscript_files := $(o)/lib/appscript/appsscript.json
+appscript_files += $(patsubst lib/appscript/%.gs,$(o)/lib/appscript/%.gs,$(wildcard lib/appscript/*.gs))
+appscript_tests := $(wildcard lib/appscript/*.test.js)
+appscript_deps := clasp bun
+
+appscript_runner := lib/appscript/run-test.js
+
+$(o)/lib/appscript/%.gs: lib/appscript/%.gs
+	@mkdir -p $(@D)
+	@cp $< $@
+
+$(o)/lib/appscript/appsscript.json: lib/appscript/appsscript.json
+	@mkdir -p $(@D)
+	@cp $< $@
+
+$(o)/lib/appscript/.claspignore: lib/appscript/.claspignore
+	@mkdir -p $(@D)
+	@cp $< $@
+
+# JavaScript test rule for appscript
+$(o)/lib/appscript/%.test.js.test.ok: lib/appscript/%.test.js $(appscript_runner) $(appscript_files) $$(bun_staged)
+	@mkdir -p $(@D)
+	-@$(bun_dir)/bin/bun run $(appscript_runner) $< > $@

--- a/lib/appscript/run-test.js
+++ b/lib/appscript/run-test.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env bun
+// Test runner for appscript - runs a single test file
+// Usage: bun run run-test.js <test-file.test.js>
+// Output format (compatible with test reporter):
+//   pass (or fail: message)
+//   ## stdout
+//   <stdout>
+//   ## stderr
+//   <stderr>
+
+import { dirname, join, resolve } from "path";
+
+const srcDir = dirname(import.meta.path);
+const testFileArg = process.argv[2];
+const testFile = testFileArg ? resolve(testFileArg) : null;
+
+if (!testFile) {
+  console.log("fail: no test file specified");
+  console.log("");
+  console.log("## stdout");
+  console.log("");
+  console.log("usage: run-test.js <test-file.test.js>");
+  console.log("## stderr");
+  console.log("");
+  process.exit(0);
+}
+
+// Test state
+let failures = [];
+let stdout = [];
+
+// Export test utilities to global scope
+globalThis.TEST_SRCDIR = srcDir;
+globalThis.TEST_FAILURES = failures;
+globalThis.TEST_STDOUT = stdout;
+
+globalThis.log = function(msg) {
+  stdout.push(msg);
+};
+
+globalThis.assert = function(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+globalThis.assertEqual = function(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${expected}, got ${actual}`);
+  }
+};
+
+globalThis.runTest = function(name, fn) {
+  try {
+    fn();
+    log(`  ✓ ${name}`);
+  } catch (e) {
+    failures.push(`${name}: ${e.message}`);
+    log(`  ✗ ${name}: ${e.message}`);
+  }
+};
+
+// Setup mocks for Google Apps Script globals
+globalThis.CalendarApp = {
+  getDefaultCalendar: () => ({
+    getEvents: () => [],
+    createEvent: () => ({}),
+  }),
+};
+
+globalThis.ScriptApp = {
+  getProjectTriggers: () => [],
+  deleteTrigger: () => {},
+  newTrigger: () => ({
+    timeBased: () => ({
+      everyHours: () => ({ create: () => {} }),
+    }),
+    forUserCalendar: () => ({
+      onEventUpdated: () => ({ create: () => {} }),
+    }),
+  }),
+};
+
+globalThis.Logger = { log: () => {} };
+globalThis.Utilities = { sleep: () => {} };
+
+globalThis.CacheService = {
+  getScriptCache: () => ({
+    get: () => null,
+    put: () => {},
+  }),
+};
+
+globalThis.People = {
+  People: {
+    searchDirectoryPeople: (opts) => {
+      const email = opts.query;
+      if (email && !email.includes("@resource.calendar.google.com")) {
+        return {
+          people: [{
+            emailAddresses: [{ value: email }]
+          }]
+        };
+      }
+      return { people: [] };
+    },
+  },
+};
+
+globalThis.Calendar = {
+  Events: {
+    get: () => ({ attendees: [] }),
+  },
+};
+
+globalThis.Session = {
+  getActiveUser: () => ({
+    getEmail: () => "test@example.com",
+  }),
+};
+
+globalThis.mockProperties = {};
+globalThis.PropertiesService = {
+  getScriptProperties: () => ({
+    getProperty: (key) => mockProperties[key] || null,
+    setProperty: (key, value) => { mockProperties[key] = value; },
+  }),
+};
+
+// Helper to load a .gs file and return its exports
+import { readFileSync } from "fs";
+
+globalThis.loadGsFile = function(filename) {
+  const code = readFileSync(join(srcDir, filename), "utf-8");
+  return new Function(code)();
+};
+
+// Run the test file
+try {
+  await import(testFile);
+} catch (e) {
+  failures.push(`import error: ${e.message}`);
+}
+
+// Output results
+console.log(failures.length === 0 ? "pass" : `fail: ${failures.length} test(s) failed`);
+console.log("");
+console.log("## stdout");
+console.log("");
+console.log(stdout.join("\n"));
+console.log("## stderr");
+console.log("");
+
+// Always exit 0 - reporter determines pass/fail from output
+process.exit(0);

--- a/lib/cook.mk
+++ b/lib/cook.mk
@@ -24,6 +24,7 @@ o/teal/lib/%.lua: lib/%.tl $(types_files) lib/cosmic/tl-gen.lua | $(bootstrap_fi
 	@$(bootstrap_cosmic) lib/cosmic/tl-gen.lua -- $< -o $@
 
 include lib/aerosnap/cook.mk
+include lib/appscript/cook.mk
 include lib/box/cook.mk
 include lib/build/cook.mk
 include lib/checker/cook.mk

--- a/lib/home/cook.mk
+++ b/lib/home/cook.mk
@@ -54,9 +54,10 @@ dots_bin := $(wildcard bin/*)
 # lib/ sources (comprehensive wildcards)
 dots_lib := lib/cook.mk $(wildcard lib/*.lua) $(wildcard lib/*.tl) \
     $(wildcard lib/*/cook.mk) $(wildcard lib/*/*.lua) $(wildcard lib/*/*.tl) \
+    $(wildcard lib/*/*.js) $(wildcard lib/*/*.json) \
     $(wildcard lib/*/*.snap) $(wildcard lib/*/*/*.lua) $(wildcard lib/*/*/*.tl) \
     $(wildcard lib/types/*.d.tl) $(wildcard lib/types/*/*.d.tl) \
-    $(wildcard lib/*/.args) $(wildcard lib/*/MANIFEST.txt)
+    $(wildcard lib/*/.args) $(wildcard lib/*/.claspignore) $(wildcard lib/*/MANIFEST.txt)
 
 home_built := $(o)/home/.built
 


### PR DESCRIPTION
Google Apps Script to auto-color calendar events based on rules.

## Changes

- `lib/appscript/colorize.gs` - auto-color events based on type:
  - OOO/async events (lavender/sage)
  - Interviews (grape)
  - Focus blocks (blueberry)
  - 1:1s (banana)
  - Group meetings - organizer vs guest (graphite/peacock)
  - Uses People API to detect Google Groups vs individuals
  - Caches group lookups for 6 hours
  - RSVP comment overrides (#ignore, #1:1, #group, #solo)
  - `setup()` - creates hourly trigger and runs initial colorize
- `lib/appscript/colorize.test.js` - tests for rules and event type detection