### PR TITLE
nvim: disable OSC passthrough autocommand

### DIFF
--- a/.config/nvim/plugin/terminal.tl
+++ b/.config/nvim/plugin/terminal.tl
@@ -75,12 +75,12 @@ map('t', '<D-q>', '<C-\\><C-n><cmd>enew|bd #<cr>', { noremap = true, silent = tr
 
 -- OSC passthrough: forward escape sequences from nested terminals to host terminal
 -- Requires: https://github.com/whilp/neovim/pull/4
-vim.api.nvim_create_autocmd('TermRequest', {
-  group = vim.api.nvim_create_augroup('osc_passthrough', { clear = true }),
-  callback = function(args)
-    local seq = args.data.sequence
-    if seq and seq:match('^\027%]') then
-      vim.api.nvim_ui_send(seq)
-    end
-  end,
-})
+-- vim.api.nvim_create_autocmd('TermRequest', {
+--   group = vim.api.nvim_create_augroup('osc_passthrough', { clear = true }),
+--   callback = function(args)
+--     local seq = args.data.sequence
+--     if seq and seq:match('^\027%]') then
+--       vim.api.nvim_ui_send(seq)
+--     end
+--   end,
+-- })

--- a/.github/pr/disable-osc-passthrough.md
+++ b/.github/pr/disable-osc-passthrough.md
@@ -1,0 +1,7 @@
+# nvim: disable OSC passthrough autocommand
+
+Temporarily disables the OSC passthrough autocommand group in nvim terminal config.
+
+## Changes
+
+- `.config/nvim/plugin/terminal.tl` - comment out osc_passthrough augroup


### PR DESCRIPTION
Temporarily disables the OSC passthrough autocommand group in nvim terminal config.

## Changes

- `.config/nvim/plugin/terminal.tl` - comment out osc_passthrough augroup