### PR TITLE
home: always bundle nvim with plugins

### DIFF
--- a/.github/pr/home-nvim-bundle.md
+++ b/.github/pr/home-nvim-bundle.md
@@ -1,0 +1,8 @@
+# home: always bundle nvim with plugins
+
+Makes nvim always include bundled plugins (mini.nvim, lspconfig, treesitter, conform) so mini.hues colorscheme works based on WHEREAMI.
+
+## Changes
+
+- `lib/home/cook.mk` - override generic nvim zip rule to use bundle instead of raw staged binary; remove separate home-release target
+- `.config/nvim/plugin/terminal.tl` - disable OSC passthrough which causes terminal blocking in server mode

--- a/lib/home/cook.mk
+++ b/lib/home/cook.mk
@@ -78,10 +78,11 @@ $(o)/.config/nvim/%.lua: .config/nvim/%.tl $$(tl_files) $$(bootstrap_files) | $$
 
 # Always use bundled nvim (with plugins)
 # Override generic zip rule for nvim to use bundle instead of raw staged
-$(o)/nvim/.zip: $(nvim_bundle) $$(cosmos_staged)
+# Use secondary expansion for nvim_bundle since 3p/nvim/cook.mk is included after this file
+$(o)/nvim/.zip: $$(nvim_bundle) $$(cosmos_staged)
 	@rm -rf $(@D)/.zip-staging
 	@mkdir -p $(@D)/.zip-staging/.local/share/nvim
-	@versioned_name=$$(basename $$(readlink -f $(nvim_staged)))-bundled && \
+	@versioned_name=$$(basename $$(readlink -f $(nvim_staged))) && \
 		cp -r $(nvim_bundle_out) $(@D)/.zip-staging/.local/share/nvim/$$versioned_name && \
 		for item in $(@D)/.zip-staging/.local/share/nvim/$$versioned_name/*; do \
 			ln -sf $$versioned_name/$$(basename $$item) $(@D)/.zip-staging/.local/share/nvim/$$(basename $$item); \


### PR DESCRIPTION
Makes nvim always include bundled plugins (mini.nvim, lspconfig, treesitter, conform) so mini.hues colorscheme works based on WHEREAMI.

## Changes

- `lib/home/cook.mk` - override generic nvim zip rule to use bundle instead of raw staged binary; remove separate home-release target
- `.config/nvim/plugin/terminal.tl` - disable OSC passthrough which causes terminal blocking in server mode

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-18T15:04:08Z
</details>