### PR TITLE
nvim: hide cmdline when not in use

### DIFF
--- a/.config/nvim/plugin/interface.tl
+++ b/.config/nvim/plugin/interface.tl
@@ -29,6 +29,43 @@ end
 opt.wildmenu = true
 opt.wildmode = "longest:full,full"
 
+-- Hide cmdline when not in use
+opt.cmdheight = 0
+
+local cmdline_group = vim.api.nvim_create_augroup("cmdline_height", { clear = true })
+
+local function set_cmdheight(val: integer)
+  if opt.cmdheight:get() ~= val then
+    opt.cmdheight = val
+    vim.cmd.redrawstatus()
+  end
+end
+
+vim.api.nvim_create_autocmd("CmdlineEnter", {
+  group = cmdline_group,
+  callback = function()
+    if vim.fn.getcmdtype() == ":" then
+      set_cmdheight(1)
+    end
+  end,
+})
+
+vim.api.nvim_create_autocmd("CmdlineChanged", {
+  group = cmdline_group,
+  callback = function()
+    if vim.fn.getcmdtype() == ":" and vim.fn.getcmdline() == "" then
+      set_cmdheight(0)
+    end
+  end,
+})
+
+vim.api.nvim_create_autocmd("CmdlineLeave", {
+  group = cmdline_group,
+  callback = function()
+    set_cmdheight(0)
+  end,
+})
+
 -- Color scheme (syntax handled by treesitter)
 -- Applied by mini.hues.setup() in mini.lua
 vim.cmd.filetype("plugin indent on")

--- a/.github/pr/hide-cmdline-nvim.md
+++ b/.github/pr/hide-cmdline-nvim.md
@@ -1,0 +1,7 @@
+# nvim: hide cmdline when not in use
+
+Adds autocommands to dynamically show/hide the command line based on usage.
+
+## Changes
+
+- `.config/nvim/plugin/interface.tl` - set cmdheight=0 by default, show when entering ":" command mode, hide on leave or empty input


### PR DESCRIPTION
Adds autocommands to dynamically show/hide the command line based on usage.

## Changes

- `.config/nvim/plugin/interface.tl` - set cmdheight=0 by default, show when entering ":" command mode, hide on leave or empty input

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-18T13:30:10Z
</details>