### PR TITLE
spawn: fix fd passthrough when fd equals target

### DIFF
--- a/.github/pr/spawn-fd-passthrough.md
+++ b/.github/pr/spawn-fd-passthrough.md
@@ -1,0 +1,11 @@
+# spawn: fix fd passthrough when fd equals target
+
+When passing `stdout = 1` or `stderr = 2` to spawn(), the code would:
+1. Close the target fd (e.g., `close(1)`)
+2. Try to dup the same fd (e.g., `dup(1)`)
+
+This fails because the fd was just closed. The fix skips close/dup when the fd is already the correct target.
+
+## Changes
+
+- `lib/cosmic/spawn.tl` - Skip close/dup when opts.stdin == 0, opts.stdout == 1, or opts.stderr == 2

--- a/lib/cosmic/spawn.tl
+++ b/lib/cosmic/spawn.tl
@@ -92,28 +92,40 @@ local function spawn(argv: {string}, opts?: SpawnOpts): SpawnHandle, string
 
   local pid = unix.fork()
   if pid == 0 then
-    unix.close(0)
+    -- stdin (fd 0)
     if stdin_is_fd then
-      unix.dup(opts.stdin as number)
+      if opts.stdin ~= 0 then
+        unix.close(0)
+        unix.dup(opts.stdin as number)
+      end
     else
+      unix.close(0)
       unix.close(stdin_w)
       unix.dup(stdin_r)
       unix.close(stdin_r)
     end
 
-    unix.close(1)
+    -- stdout (fd 1)
     if stdout_is_fd then
-      unix.dup(opts.stdout as number)
+      if opts.stdout ~= 1 then
+        unix.close(1)
+        unix.dup(opts.stdout as number)
+      end
     else
+      unix.close(1)
       unix.close(stdout_r)
       unix.dup(stdout_w)
       unix.close(stdout_w)
     end
 
-    unix.close(2)
+    -- stderr (fd 2)
     if stderr_is_fd then
-      unix.dup(opts.stderr as number)
+      if opts.stderr ~= 2 then
+        unix.close(2)
+        unix.dup(opts.stderr as number)
+      end
     else
+      unix.close(2)
       unix.close(stderr_r)
       unix.dup(stderr_w)
       unix.close(stderr_w)

--- a/lib/cosmic/test_spawn.tl
+++ b/lib/cosmic/test_spawn.tl
@@ -90,3 +90,51 @@ local function test_read_captures_output()
   assert(out == "line1\nline2\n", "expected 'line1\\nline2\\n', got '" .. tostring(out) .. "'")
 end
 test_read_captures_output()
+
+local function test_fd_passthrough_stdout()
+  -- passing stdout=1 means "inherit parent's stdout, don't capture"
+  -- this tests the fix for close(1); dup(1) which fails when fd equals target
+  local tmp_file = path.join(TEST_TMPDIR, "passthrough_test")
+  local script = string.format([[
+    local f = io.open(%q, "w")
+    f:write("written")
+    f:close()
+    io.write("to stdout")
+  ]], tmp_file)
+
+  local handle = spawn({lua_bin, "-e", script}, {stdout = 1})
+  assert(handle ~= nil, "handle should not be nil")
+  local exit_code = handle:wait()
+  assert(exit_code == 0, "expected exit code 0, got " .. tostring(exit_code))
+
+  -- verify the script actually ran by checking the file it wrote
+  local f = io.open(tmp_file, "r")
+  assert(f ~= nil, "script should have created file")
+  local content = f:read("*a")
+  f:close()
+  assert(content == "written", "expected 'written', got '" .. tostring(content) .. "'")
+end
+test_fd_passthrough_stdout()
+
+local function test_fd_passthrough_stderr()
+  -- passing stderr=2 means "inherit parent's stderr, don't capture"
+  local tmp_file = path.join(TEST_TMPDIR, "passthrough_stderr_test")
+  local script = string.format([[
+    local f = io.open(%q, "w")
+    f:write("written")
+    f:close()
+    io.stderr:write("to stderr")
+  ]], tmp_file)
+
+  local handle = spawn({lua_bin, "-e", script}, {stderr = 2})
+  assert(handle ~= nil, "handle should not be nil")
+  local exit_code = handle:wait()
+  assert(exit_code == 0, "expected exit code 0, got " .. tostring(exit_code))
+
+  local f = io.open(tmp_file, "r")
+  assert(f ~= nil, "script should have created file")
+  local content = f:read("*a")
+  f:close()
+  assert(content == "written", "expected 'written', got '" .. tostring(content) .. "'")
+end
+test_fd_passthrough_stderr()


### PR DESCRIPTION
When passing `stdout = 1` or `stderr = 2` to spawn(), the code would:
1. Close the target fd (e.g., `close(1)`)
2. Try to dup the same fd (e.g., `dup(1)`)

This fails because the fd was just closed. The fix skips close/dup when the fd is already the correct target.

## Changes

- `lib/cosmic/spawn.tl` - Skip close/dup when opts.stdin == 0, opts.stdout == 1, or opts.stderr == 2

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-18T15:02:50Z
</details>