### PR TITLE
box: improve bootstrap error visibility

### DIFF
--- a/.github/pr/box-bootstrap-logging.md
+++ b/.github/pr/box-bootstrap-logging.md
@@ -1,0 +1,10 @@
+# box: improve bootstrap error visibility
+
+Bootstrap failures were silent - the remote output wasn't shown, and fetch errors lost the actual error message.
+
+## Changes
+
+- `lib/box/sprite.tl` - Pass stdout/stderr through to terminal during exec so bootstrap output is visible
+- `lib/box/bootstrap.tl` - Capture and report actual Fetch error (was discarding with `_`)
+- `lib/box/bootstrap.tl` - Log download URL for debugging
+- `lib/box/bootstrap.tl` - Increase maxresponse from 200MB to 250MB (home binary is 221MB)

--- a/lib/box/bootstrap.tl
+++ b/lib/box/bootstrap.tl
@@ -66,12 +66,15 @@ local function fetch_text(url: string): string, string
 end
 
 local function fetch_binary(url: string): string, string
-  local status, _, body = cosmo.Fetch(url, {
+  local status, headers_or_err, body = cosmo.Fetch(url, {
     headers = {["User-Agent"] = "curl/8.0"},
-    maxresponse = 200 * 1024 * 1024,
+    maxresponse = 250 * 1024 * 1024,
   })
-  if not status or status ~= 200 then
-    return nil, "fetch failed: " .. tostring(status)
+  if not status then
+    return nil, "fetch failed: " .. tostring(headers_or_err or "unknown error")
+  end
+  if status ~= 200 then
+    return nil, "fetch failed: HTTP " .. tostring(status)
   end
   return body
 end
@@ -130,7 +133,7 @@ local function download_home(release: Release, platform: string, expected_sha: s
     return nil, asset_name .. " not found in release"
   end
 
-  io.stderr:write("downloading " .. asset_name .. "...\n")
+  io.stderr:write("downloading " .. asset_name .. " from " .. asset.browser_download_url .. "\n")
   local body, err = fetch_binary(asset.browser_download_url)
   if not body then
     return nil, err

--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -49,7 +49,10 @@ local function ssh(name: string, ...: string): backend.Result
 end
 
 local function exec(name: string, cmd: string): backend.Result
-  local handle = spawn({"sprite", "exec", "-s", name, "--", "bash", "-c", cmd})
+  local handle = spawn({"sprite", "exec", "-s", name, "--", "bash", "-c", cmd}, {
+    stdout = 1,  -- pass through to terminal
+    stderr = 2,
+  })
   if not handle then
     return err("sprite binary not found")
   end


### PR DESCRIPTION
Bootstrap failures were silent - the remote output wasn't shown, and fetch errors lost the actual error message.

## Changes

- `lib/box/sprite.tl` - Pass stdout/stderr through to terminal during exec so bootstrap output is visible
- `lib/box/bootstrap.tl` - Capture and report actual Fetch error (was discarding with `_`)
- `lib/box/bootstrap.tl` - Log download URL for debugging
- `lib/box/bootstrap.tl` - Increase maxresponse from 200MB to 250MB (home binary is 221MB)

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-18T14:26:40Z
</details>