### PR TITLE
zsh: use whereami emoji in prompt

### DIFF
--- a/.github/pr/zsh-prompt-emoji.md
+++ b/.github/pr/zsh-prompt-emoji.md
@@ -1,0 +1,7 @@
+# zsh: use whereami emoji in prompt
+
+Replaces the simple `%#` prompt with the emoji from the WHEREAMI variable.
+
+## Changes
+
+- `.zshrc` - change PS1 to extract and display emoji from WHEREAMI using `${WHEREAMI##* }`

--- a/.zshrc
+++ b/.zshrc
@@ -1,6 +1,6 @@
 export STRIPE_DO_NOT_MANAGE=1
 
-export PS1='%# '
+export PS1='${WHEREAMI##* } '
 set -o vi
 
 # Set terminal title


### PR DESCRIPTION
Replaces the simple `%#` prompt with the emoji from the WHEREAMI variable.

## Changes

- `.zshrc` - change PS1 to extract and display emoji from WHEREAMI using `${WHEREAMI##* }`

<!-- pr-update-history -->
<details><summary>Update history</summary>

- Updated: 2026-01-18T14:25:32Z
</details>