### PR TITLE
cosmic: add fetch wrapper with structured results

### DIFF
--- a/lib/cosmic/fetch.tl
+++ b/lib/cosmic/fetch.tl
@@ -42,9 +42,6 @@ local function Fetch(url: string, opts?: FetchOpts): FetchResult
     -- Fetch failed: headers_or_err contains error message
     return {
       ok = false,
-      status = nil,
-      headers = nil,
-      body = nil,
       error = tostring(headers_or_err or "unknown error"),
     }
   end
@@ -61,6 +58,7 @@ end
 
 local record fetch
   Fetch: function(url: string, opts?: FetchOpts): FetchResult
+  FetchOpts: FetchOpts
   FetchResult: FetchResult
 end
 

--- a/lib/cosmic/fetch.tl
+++ b/lib/cosmic/fetch.tl
@@ -1,0 +1,71 @@
+-- cosmic.fetch: structured wrapper for cosmo.Fetch
+--
+-- Solves the problem of accidentally discarding error messages when using:
+--   local status, _, body = cosmo.Fetch(url, opts)
+--
+-- Usage:
+--   local fetch = require("cosmic.fetch")
+--   local result = fetch.Fetch(url, opts)
+--   if not result.ok then
+--     return nil, result.error
+--   end
+--   -- use result.status, result.headers, result.body
+
+local cosmo = require("cosmo")
+
+local record FetchOpts
+  method: string
+  headers: {string:string}
+  body: string
+  maxresponse: number
+end
+
+local record FetchResult
+  ok: boolean
+  status: number
+  headers: {string:string}
+  body: string
+  error: string
+end
+
+-- Fetch wraps cosmo.Fetch to return a structured result table.
+-- On success: ok=true, status=200, headers={...}, body="..."
+-- On failure: ok=false, error="error message"
+local function Fetch(url: string, opts?: FetchOpts): FetchResult
+  local status: number
+  local headers_or_err: {string:string} | string
+  local body: string
+
+  status, headers_or_err, body = cosmo.Fetch(url, opts as {string:any})
+
+  if not status then
+    -- Fetch failed: headers_or_err contains error message
+    return {
+      ok = false,
+      status = nil,
+      headers = nil,
+      body = nil,
+      error = tostring(headers_or_err or "unknown error"),
+    }
+  end
+
+  -- Fetch succeeded: headers_or_err is the headers table
+  return {
+    ok = true,
+    status = status,
+    headers = headers_or_err as {string:string},
+    body = body,
+    error = nil,
+  }
+end
+
+local record fetch
+  Fetch: function(url: string, opts?: FetchOpts): FetchResult
+  FetchResult: FetchResult
+end
+
+local M: fetch = {
+  Fetch = Fetch,
+}
+
+return M

--- a/lib/cosmic/fetch.tl
+++ b/lib/cosmic/fetch.tl
@@ -13,14 +13,14 @@
 
 local cosmo = require("cosmo")
 
-local record FetchOpts
+local record Opts
   method: string
   headers: {string:string}
   body: string
   maxresponse: number
 end
 
-local record FetchResult
+local record Result
   ok: boolean
   status: number
   headers: {string:string}
@@ -31,7 +31,7 @@ end
 -- Fetch wraps cosmo.Fetch to return a structured result table.
 -- On success: ok=true, status=200, headers={...}, body="..."
 -- On failure: ok=false, error="error message"
-local function Fetch(url: string, opts?: FetchOpts): FetchResult
+local function Fetch(url: string, opts?: Opts): Result
   local status: number
   local headers_or_err: {string:string} | string
   local body: string
@@ -57,9 +57,9 @@ local function Fetch(url: string, opts?: FetchOpts): FetchResult
 end
 
 local record fetch
-  Fetch: function(url: string, opts?: FetchOpts): FetchResult
-  FetchOpts: FetchOpts
-  FetchResult: FetchResult
+  Fetch: function(url: string, opts?: Opts): Result
+  Opts: Opts
+  Result: Result
 end
 
 local M: fetch = {

--- a/lib/cosmic/test_fetch.tl
+++ b/lib/cosmic/test_fetch.tl
@@ -1,0 +1,63 @@
+#!/usr/bin/env run-test.lua
+local fetch = require("cosmic.fetch")
+
+local function test_module_loads()
+  assert(fetch ~= nil, "fetch module should not be nil")
+  assert(fetch.Fetch ~= nil, "fetch.Fetch should not be nil")
+  assert(type(fetch.Fetch) == "function", "fetch.Fetch should be a function")
+end
+test_module_loads()
+
+local function test_result_structure()
+  -- Test that result has correct structure
+  -- Use a guaranteed-to-fail protocol to test error handling
+  local result = fetch.Fetch("invalid://this-will-definitely-fail")
+
+  assert(result ~= nil, "result should not be nil")
+  -- Debug: print result structure
+  if result.ok then
+    io.stderr:write("DEBUG: Expected failure but got ok=true, status=" .. tostring(result.status) .. "\n")
+  end
+
+  assert(result.ok == false, "result.ok should be false for failed fetch, got: " .. tostring(result.ok))
+  assert(result.status == nil, "result.status should be nil on error")
+  assert(result.headers == nil, "result.headers should be nil on error")
+  assert(result.body == nil, "result.body should be nil on error")
+  assert(result.error ~= nil, "result.error should not be nil on failure")
+  assert(type(result.error) == "string", "result.error should be a string")
+  assert(#result.error > 0, "result.error should not be empty")
+end
+test_result_structure()
+
+-- Test with a data URL to verify success path without network dependency
+local function test_success_structure()
+  -- Use a data URL which should always work
+  local result = fetch.Fetch("data:text/plain,Hello%20World")
+
+  -- Note: cosmo.Fetch may or may not support data URLs
+  -- If it does, verify success structure
+  if result.ok then
+    assert(result.status ~= nil, "result.status should be set on success")
+    assert(result.headers ~= nil, "result.headers should be set on success")
+    assert(type(result.headers) == "table", "result.headers should be a table")
+    assert(result.body ~= nil, "result.body should be set on success")
+    assert(result.error == nil, "result.error should be nil on success")
+  else
+    -- If data URLs aren't supported, at least verify error structure
+    assert(result.error ~= nil, "result.error should be set on failure")
+  end
+end
+test_success_structure()
+
+-- Test that error messages are preserved (the main point of this wrapper)
+local function test_error_preservation()
+  local result = fetch.Fetch("invalid://guaranteed-failure")
+
+  -- The key feature: error message should be accessible and non-empty
+  assert(result.error ~= nil, "error should be preserved")
+  assert(type(result.error) == "string", "error should be a string")
+  assert(#result.error > 0, "error should not be empty")
+  -- Should not be "nil" string which was the original problem
+  assert(result.error ~= "nil", "error should not be 'nil' string")
+end
+test_error_preservation()

--- a/lib/cosmic/test_fetch.tl
+++ b/lib/cosmic/test_fetch.tl
@@ -14,11 +14,6 @@ local function test_result_structure()
   local result = fetch.Fetch("invalid://this-will-definitely-fail")
 
   assert(result ~= nil, "result should not be nil")
-  -- Debug: print result structure
-  if result.ok then
-    io.stderr:write("DEBUG: Expected failure but got ok=true, status=" .. tostring(result.status) .. "\n")
-  end
-
   assert(result.ok == false, "result.ok should be false for failed fetch, got: " .. tostring(result.ok))
   assert(result.status == nil, "result.status should be nil on error")
   assert(result.headers == nil, "result.headers should be nil on error")
@@ -61,3 +56,23 @@ local function test_error_preservation()
   assert(result.error ~= "nil", "error should not be 'nil' string")
 end
 test_error_preservation()
+
+-- Test that HTTP error statuses (4xx, 5xx) still return ok=true
+-- because the HTTP request itself succeeded
+local function test_http_error_status()
+  -- Use httpbin's 404 endpoint - skip if network unavailable
+  local result = fetch.Fetch("https://httpbin.org/status/404")
+
+  if not result.ok then
+    -- Network failure - skip this test
+    io.stderr:write("SKIP: test_http_error_status (network unavailable)\n")
+    return
+  end
+
+  -- HTTP 404 is still a successful HTTP request
+  assert(result.ok == true, "ok should be true for HTTP error status")
+  assert(result.status == 404, "status should be 404, got: " .. tostring(result.status))
+  assert(result.headers ~= nil, "headers should be present")
+  assert(result.error == nil, "error should be nil on HTTP success")
+end
+test_http_error_status()


### PR DESCRIPTION
Implements `cosmic.fetch.Fetch` wrapper that returns a structured table with `ok`, `status`, `headers`, `body`, and `error` keys. This solves the problem of accidentally discarding error messages when using:

```lua
local status, _, body = cosmo.Fetch(url, opts)
```

The wrapper ensures error messages are always accessible via `result.error`, preventing the common mistake of printing "nil" instead of the actual error.

## Usage

```lua
local fetch = require("cosmic.fetch")
local result = fetch.Fetch(url, opts)
if not result.ok then
  return nil, result.error
end
-- use result.status, result.headers, result.body
```

## Exports

- `fetch.Fetch(url, opts?)` - the wrapper function
- `fetch.Opts` - type for options table
- `fetch.Result` - type for result table

## Behavior

- **Network/protocol errors**: `ok=false`, `error` contains message
- **HTTP responses (including 4xx/5xx)**: `ok=true`, `status` contains HTTP code