### PR TITLE
test: add TMP variable for configurable temp directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ export PATH := $(CURDIR)/$(o)/bin:$(PATH)
 export STAGE_O := $(CURDIR)/$(o)/staged
 export FETCH_O := $(CURDIR)/$(o)/fetched
 
+## TMP: temp directory for tests (default: /tmp, use TMP=~/tmp for more space)
+TMP ?= /tmp
+export TMPDIR := $(TMP)
+
 uname_s := $(shell uname -s)
 uname_m := $(shell uname -m)
 os := $(if $(filter Darwin,$(uname_s)),darwin,linux)
@@ -191,7 +195,7 @@ export NO_COLOR := 1
 
 # Test rule: .tl tests depend on compiled .lua (Make handles compilation)
 $(o)/%.tl.test.ok: .PLEDGE = stdio rpath wpath cpath proc exec
-$(o)/%.tl.test.ok: .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwc:$(o) rwc:/tmp rx:/usr rx:/proc r:/etc r:/dev/null
+$(o)/%.tl.test.ok: .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwc:$(o) rwc:$(TMP) rx:/usr rx:/proc r:/etc r:/dev/null
 $(o)/%.tl.test.ok: $(o)/%.lua $(test_files) $(checker_files) | $(bootstrap_files)
 	@mkdir -p $(@D)
 	@[ -x $< ] || chmod a+x $<

--- a/lib/build/make-help.snap
+++ b/lib/build/make-help.snap
@@ -19,4 +19,5 @@ Targets:
   ci                  Run full CI pipeline (astgrep, teal, test, build)
 
 Options:
+  TMP                 TMP: temp directory for tests (default: /tmp, use TMP=~/tmp for more space)
   filter-only         Filter targets by pattern (make test only='skill')

--- a/lib/test/run-test.tl
+++ b/lib/test/run-test.tl
@@ -9,7 +9,8 @@ global TEST_TMPDIR: string
 global TEST_DIR: string
 
 local function run_test(test: string): boolean, string, string, string
-  TEST_TMPDIR = unix.mkdtemp("/tmp/test_XXXXXX")
+  local tmpbase = os.getenv("TMPDIR") or "/tmp"
+  TEST_TMPDIR = unix.mkdtemp(path.join(tmpbase, "test_XXXXXX"))
   unix.setenv("TEST_TMPDIR", TEST_TMPDIR)
   TEST_DIR = os.getenv("TEST_DIR")
 


### PR DESCRIPTION
## Summary
- Adds TMP variable to Makefile for configuring temp directory
- Test runner uses TMPDIR environment variable
- Allows `make test TMP=~/tmp` for environments with limited /tmp space (e.g., 512MB tmpfs)

## Test plan
- [x] `make test TMP=/home/sprite/tmp` passes