### PR TITLE
nvim: add safety guards to OSC passthrough code

### DIFF
--- a/.config/nvim/plugin/terminal.tl
+++ b/.config/nvim/plugin/terminal.tl
@@ -73,14 +73,15 @@ end, { desc = 'Move to window right' })
 -- Terminal buffer management
 map('t', '<D-q>', '<C-\\><C-n><cmd>enew|bd #<cr>', { noremap = true, silent = true, desc = 'Close current terminal buffer' })
 
--- OSC passthrough: forward escape sequences from nested terminals to host terminal
--- Requires: https://github.com/whilp/neovim/pull/4
+-- TODO: OSC passthrough causes terminal blocking in server mode
+-- See: https://github.com/whilp/neovim/pull/4
 -- vim.api.nvim_create_autocmd('TermRequest', {
 --   group = vim.api.nvim_create_augroup('osc_passthrough', { clear = true }),
 --   callback = function(args)
+--     if #vim.api.nvim_list_uis() == 0 then return end
 --     local seq = args.data.sequence
 --     if seq and seq:match('^\027%]') then
---       vim.api.nvim_ui_send(seq)
+--       pcall(vim.api.nvim_ui_send, seq)
 --     end
 --   end,
 -- })


### PR DESCRIPTION
## Summary
- Add UI check (`#vim.api.nvim_list_uis() == 0`) to skip when headless
- Wrap `nvim_ui_send` in pcall to prevent errors
- Update comment to explain the server mode issue

Code remains commented out pending upstream fix.

## Test plan
- [x] Code is commented out, no runtime behavior change