### PR TITLE
test: ensure TMPDIR is set for spawned processes

### DIFF
--- a/lib/test/run-test.tl
+++ b/lib/test/run-test.tl
@@ -12,6 +12,8 @@ local function run_test(test: string): boolean, string, string, string
   local tmpbase = os.getenv("TMPDIR") or "/tmp"
   TEST_TMPDIR = unix.mkdtemp(path.join(tmpbase, "test_XXXXXX"))
   unix.setenv("TEST_TMPDIR", TEST_TMPDIR)
+  -- Ensure spawned processes use the test's temp directory
+  unix.setenv("TMPDIR", TEST_TMPDIR)
   TEST_DIR = os.getenv("TEST_DIR")
 
   -- create temp files for capturing output


### PR DESCRIPTION
## Summary
- Ensures spawned processes (like the home binary) use the test's temp directory
- Previously, only TEST_TMPDIR was set, causing spawned processes to inherit the parent TMPDIR
- Fixes home unpack test failure when TMPDIR points to non-existent directory

Related to #415 which added configurable temp directories for tests.

## Test plan
- [x] `make test TMP=~/tmp` passes when ~/tmp doesn't exist yet