### PR TITLE
nvim: enable direct teal file loading

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -1,0 +1,7 @@
+-- nvim bootstrap: load teal, then require teal config
+local config_dir = vim.fn.stdpath("config")
+local home = vim.fn.fnamemodify(config_dir, ":h:h")
+package.path = config_dir .. "/?.lua;" .. config_dir .. "/?/init.lua;" .. home .. "/lib/?.lua;" .. home .. "/lib/3p/?.lua;" .. package.path
+
+require("tl").loader()
+require("init")  -- loads .config/nvim/init.tl

--- a/.config/nvim/init.tl
+++ b/.config/nvim/init.tl
@@ -2,9 +2,7 @@
 -- ast-grep ignore: neovim runtime
 -- nvim configuration entry point
 
--- Add lua paths
 local home = vim.fn.expand("~")
-package.path = home .. "/lib/?.lua;" .. home .. "/lib/3p/?.lua;" .. package.path
 
 -- Add bundled site directory (relative to nvim binary) to packpath
 local version_dir = vim.fn.fnamemodify(vim.v.progpath, ":h:h")

--- a/3p/nvim/cook.mk
+++ b/3p/nvim/cook.mk
@@ -6,7 +6,7 @@ nvim_deps := nvim-conform nvim-mini nvim-lspconfig nvim-treesitter nvim-parsers
 nvim_tests := 3p/nvim/test_nvim.tl
 
 # Bundle tests run during release (need full bundle)
-nvim_release_tests := 3p/nvim/test_packpath.tl 3p/nvim/test_treesitter.tl
+nvim_release_tests := $(filter-out $(nvim_tests),$(wildcard 3p/nvim/test_*.tl))
 nvim_release_tested := $(patsubst %,$(o)/%.release.ok,$(nvim_release_tests))
 
 # Bundle output - used by home binary and release tests
@@ -37,7 +37,7 @@ $(nvim_bundle): $$(nvim_staged) $$(nvim-conform_staged) $$(nvim-mini_staged) $$(
 nvim-release-tests: $(nvim_release_tested)
 
 # Release tests: depend on compiled .lua (Make handles compilation)
-$(o)/3p/nvim/%.tl.release.ok: $(o)/3p/nvim/%.lua $(nvim_bundle) | $(bootstrap_files)
+$(o)/3p/nvim/%.tl.release.ok: $(o)/3p/nvim/%.lua $(nvim_bundle) $$(tl_staged) | $(bootstrap_files)
 	@mkdir -p $(@D)
 	@[ -x $< ] || chmod a+x $<
-	@TEST_DIR=$(nvim_bundle_out) $(test_runner) $< > $@
+	@TEST_DIR=$(nvim_bundle_out) TL_DIR=$(tl_dir) $(test_runner) $< > $@

--- a/3p/nvim/test_teal.tl
+++ b/3p/nvim/test_teal.tl
@@ -1,0 +1,68 @@
+#!/usr/bin/env run-test.lua
+
+local spawn = require("cosmic.spawn")
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+
+global TEST_DIR: string
+global TEST_TMPDIR: string
+
+-- Test that the teal library is available in the bundle
+local function test_teal_library_exists()
+  local tl_staged = os.getenv("TL_DIR")
+  assert(tl_staged, "TL_DIR environment variable not set")
+
+  local tl_lib = path.join(tl_staged, "tl.lua")
+  assert(unix.stat(tl_lib), "tl.lua should exist at: " .. tl_lib)
+
+  print("✓ teal library is available")
+end
+test_teal_library_exists()
+
+-- Test that nvim can load teal via require("tl").loader()
+local function test_nvim_can_load_teal()
+  local nvim = path.join(TEST_DIR, "bin", "nvim")
+
+  -- Create a simple test that loads teal
+  local test_script = path.join(TEST_TMPDIR, "test.lua")
+  local f = io.open(test_script, "w")
+  assert(f, "failed to create test script")
+
+  -- Copy tl.lua to a location nvim can find it
+  local tl_staged = os.getenv("TL_DIR")
+  local tl_dest = path.join(TEST_TMPDIR, "tl.lua")
+  local ok = spawn({"cp", path.join(tl_staged, "tl.lua"), tl_dest}):wait()
+  assert(ok, "failed to copy tl.lua")
+
+  -- Write test script that loads teal and writes result to file
+  local result_file = path.join(TEST_TMPDIR, "teal-test-result.txt")
+  f:write([[
+package.path = "]] .. TEST_TMPDIR .. [[/?.lua;" .. package.path
+local tl = require("tl")
+tl.loader()
+
+-- Write result to file
+local f = io.open("]] .. result_file .. [[", "w")
+if f then
+  f:write("TEAL_LOADER_LOADED\n")
+  f:close()
+end
+]])
+  f:close()
+
+  -- Run nvim with the test script
+  local ok = spawn({ nvim, "--headless", "-l", test_script, "+qa" }):wait()
+  assert(ok, "nvim failed to run test script")
+
+  -- Check result file
+  local result_f = io.open(result_file, "r")
+  assert(result_f, "result file not created - teal loader may have failed to load")
+  local content = result_f:read("*a")
+  result_f:close()
+
+  assert(content:find("TEAL_LOADER_LOADED", 1, true),
+    "expected teal loader to load, got: " .. content)
+
+  print("✓ nvim can load and initialize teal loader")
+end
+test_nvim_can_load_teal()


### PR DESCRIPTION
## Summary
- Add init.lua bootstrap that loads teal loader before requiring init.tl
- Ship .tl source files directly instead of compiling to .lua at build time
- Bundle tl.lua into ~/lib/3p/ for runtime teal loading
- Add integration test verifying nvim can load and initialize teal

## Test plan
- [x] Verify dotfiles.zip contains init.lua, init.tl, and plugin/*.tl (no compiled .lua)
- [x] Verify lib/3p/tl.lua is bundled
- [x] Run release tests with `make test-release`