### PR TITLE
whereami: show sprite name in hostname

### DIFF
--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -12,6 +12,7 @@ local ENV_PATH <const> = "/zip/env.lua"
 local record ParsedArgs
   backend_type: string  -- "sprite", "mac", or path to backend file
   name: string          -- box name
+  kind: string          -- backend kind (for local-run mode)
   cmd: string           -- "new", "run", "ssh", "zap", "list", or nil for all-in-one
   env_path: string      -- path to env.lua
   local_run: boolean    -- running remotely after upload
@@ -99,7 +100,11 @@ local function parse_args(args: {string}): ParsedArgs
           result.name = v
         end
       elseif i == 2 then
-        result.cmd = v
+        if result.local_run then
+          result.kind = v
+        else
+          result.cmd = v
+        end
       else
         table.insert(result.extra_args, v)
       end
@@ -275,8 +280,8 @@ local function cmd_run(be: backend_mod.Backend, name: string, env_path: string):
     return false, "upload failed: " .. (result.err or "unknown")
   end
 
-  -- Run bootstrap on remote (pass name for env.lua function support)
-  result = be.exec(name, "chmod +x /tmp/box && /tmp/box --local-run " .. name)
+  -- Run bootstrap on remote (pass name and kind for env.lua function support)
+  result = be.exec(name, "chmod +x /tmp/box && /tmp/box --local-run " .. name .. " " .. be.name)
   cleanup()
   if not result.ok then
     return false, "bootstrap failed: " .. (result.err or "unknown")
@@ -311,7 +316,7 @@ local function cmd_list(be: backend_mod.Backend): boolean, string
   return true
 end
 
-local function cmd_local_run(name: string): integer, string
+local function cmd_local_run(name: string, kind: string): integer, string
   -- Running on remote after upload
   -- Load env from /zip/env.lua (zipped into self before upload)
   local ok, env_chunk = pcall(dofile, ENV_PATH)
@@ -331,7 +336,7 @@ local function cmd_local_run(name: string): integer, string
   end
 
   local run = require("box.run")
-  return run.bootstrap(env)
+  return run.bootstrap(env, name, kind)
 end
 
 local function main(args: {string}): integer, string
@@ -342,7 +347,7 @@ local function main(args: {string}): integer, string
 
   -- Handle local-run mode (running on remote)
   if parsed.local_run then
-    return cmd_local_run(parsed.name or "")
+    return cmd_local_run(parsed.name or "", parsed.kind or "")
   end
 
   -- Validate args

--- a/lib/box/run.tl
+++ b/lib/box/run.tl
@@ -143,9 +143,17 @@ local function run_bootstrap(): boolean, string
   return true
 end
 
-local function write_env(): boolean, string
+local function get_box_dir(): string
   local home = os.getenv("HOME")
   if not home then
+    return nil
+  end
+  return path.join(home, ".config", "box")
+end
+
+local function write_env(): boolean, string
+  local box_dir = get_box_dir()
+  if not box_dir then
     return false, "HOME not set"
   end
 
@@ -154,8 +162,7 @@ local function write_env(): boolean, string
     return true -- no env.lua in zip, skip
   end
 
-  local env_path = path.join(home, ".config", "box", "env.lua")
-  local ok, err = write_file(env_path, content, tonumber("0600", 8))
+  local ok, err = write_file(path.join(box_dir, "env.lua"), content, tonumber("0600", 8))
   if not ok then
     return false, "failed to write env.lua: " .. (err or "unknown")
   end
@@ -163,13 +170,42 @@ local function write_env(): boolean, string
   return true
 end
 
-local function bootstrap(env: backend.Env): integer, string
+local function write_box_info(name: string, kind: string): boolean, string
+  local box_dir = get_box_dir()
+  if not box_dir then
+    return false, "HOME not set"
+  end
+
+  if name and name ~= "" then
+    local ok, err = write_file(path.join(box_dir, "name"), name .. "\n", tonumber("0644", 8))
+    if not ok then
+      return false, "failed to write name: " .. (err or "unknown")
+    end
+  end
+
+  if kind and kind ~= "" then
+    local ok, err = write_file(path.join(box_dir, "kind"), kind .. "\n", tonumber("0644", 8))
+    if not ok then
+      return false, "failed to write kind: " .. (err or "unknown")
+    end
+  end
+
+  return true
+end
+
+local function bootstrap(env: backend.Env, name: string, kind: string): integer, string
   io.stderr:write("==> running bootstrap\n")
 
   -- Step 0: Write env.lua to ~/.config/box/env.lua
   local ok, err = write_env()
   if not ok then
     io.stderr:write("warning: " .. (err or "failed to write env") .. "\n")
+  end
+
+  -- Step 0.5: Write box name and kind
+  ok, err = write_box_info(name, kind)
+  if not ok then
+    io.stderr:write("warning: " .. (err or "failed to write box info") .. "\n")
   end
 
   -- Step 1: Download and unpack home

--- a/lib/whereami/init.tl
+++ b/lib/whereami/init.tl
@@ -1,5 +1,6 @@
 local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
+local path = require("cosmo.path")
 
 local function trim(s: string): string
   return s:match('^%s*(.-)%s*$')
@@ -84,8 +85,39 @@ local function get_short_hostname(): string
   return nil
 end
 
+local function get_box_dir(): string
+  local home = os.getenv("HOME")
+  if not home then
+    return nil
+  end
+  return path.join(home, ".config", "box")
+end
+
+local function get_box_name(): string
+  local box_dir = get_box_dir()
+  if not box_dir then
+    return nil
+  end
+  return read_file(path.join(box_dir, "name"))
+end
+
+local function get_box_kind(): string
+  local box_dir = get_box_dir()
+  if not box_dir then
+    return nil
+  end
+  return read_file(path.join(box_dir, "kind"))
+end
+
 local function get(): string
   local identifier = ''
+
+  -- Check for box name and kind first (stored during box bootstrap)
+  local box_name = get_box_name()
+  local box_kind = get_box_kind()
+  if box_name and box_name ~= '' and box_kind and box_kind ~= '' then
+    return box_name .. "." .. box_kind
+  end
 
   local conf_dir = find_conf_dir()
   if conf_dir then

--- a/lib/whereami/test_whereami.tl
+++ b/lib/whereami/test_whereami.tl
@@ -1,3 +1,6 @@
+local unix = require('cosmo.unix')
+local path = require('cosmo.path')
+local cosmo = require('cosmo')
 local whereami = require('whereami')
 
 local function test_whereami_get()
@@ -27,3 +30,37 @@ local function test_whereami_codespaces_format()
   assert(result:match('^repo | .+'), "codespaces result should match 'repo | ...' pattern")
 end
 test_whereami_codespaces_format()
+
+local function test_whereami_box_name_kind()
+  local tmpdir = os.getenv("TEST_TMPDIR")
+  if not tmpdir then
+    print("skipping test_whereami_box_name_kind (no TEST_TMPDIR)")
+    return
+  end
+
+  -- Create fake home with .config/box/{name,kind}
+  local fake_home = path.join(tmpdir, "home")
+  local box_dir = path.join(fake_home, ".config", "box")
+  unix.makedirs(box_dir)
+  cosmo.Barf(path.join(box_dir, "name"), "mybox\n")
+  cosmo.Barf(path.join(box_dir, "kind"), "sprite\n")
+
+  -- Swap HOME, reload module, test, restore
+  local orig_home = os.getenv("HOME")
+  unix.setenv("HOME", fake_home)
+
+  -- Clear cached module to pick up new HOME
+  package.loaded["whereami"] = nil
+  local fresh_whereami = require("whereami")
+
+  local result = fresh_whereami.get()
+  assert(result == "mybox.sprite", "expected 'mybox.sprite', got '" .. result .. "'")
+
+  local with_emoji = fresh_whereami.get_with_emoji()
+  assert(with_emoji:match("^mybox%.sprite ."), "expected 'mybox.sprite <emoji>', got '" .. with_emoji .. "'")
+
+  -- Restore
+  unix.setenv("HOME", orig_home)
+  package.loaded["whereami"] = nil
+end
+test_whereami_box_name_kind()


### PR DESCRIPTION
## Summary
- Store box name and kind to ~/.config/box/{name,kind} during bootstrap
- Add get_box_dir() helper to consolidate path construction
- Read both in whereami and format as <name>.<kind> <emoji>
- Add test for box name/kind functionality

## Test plan
- [x] make test passes
- [x] test_whereami_box_name_kind verifies name.kind format
- [ ] Bootstrap a new sprite and verify whereami shows <name>.sprite