### PR TITLE
Refactor to use new cosmic.fetch API

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,8 +32,11 @@ jobs:
       - name: fetch base branch
         run: git fetch origin $GITHUB_BASE_REF --depth=1
 
+      - name: build cosmic
+        run: bin/make o/bin/cosmic
+
       - id: update-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_NUMBER: ${{ github.event.number }}
-        run: ./bin/cosmic -e 'require("lib.skill.pr").main()'
+        run: ./o/bin/cosmic -e 'require("lib.skill.pr").main()'

--- a/lib/box/bootstrap.tl
+++ b/lib/box/bootstrap.tl
@@ -5,6 +5,7 @@
 local cosmo = require("cosmo")
 local path = require("cosmo.path")
 local spawn = require("cosmic.spawn")
+local fetch = require("cosmic.fetch")
 
 local REPO <const> = "whilp/world"
 local API_URL <const> = "https://api.github.com"
@@ -43,40 +44,46 @@ local function detect_platform(): string, string
 end
 
 local function fetch_json(url: string): any, string
-  local status, _, body = cosmo.Fetch(url, {
+  local result = fetch.Fetch(url, {
     headers = {
       ["User-Agent"] = "curl/8.0",
       ["Accept"] = "application/vnd.github+json",
     },
   })
-  if not status or status ~= 200 then
-    return nil, "fetch failed: " .. tostring(status)
+  if not result.ok then
+    return nil, "fetch failed: " .. result.error
   end
-  return cosmo.DecodeJson(body)
+  if result.status ~= 200 then
+    return nil, "fetch failed: HTTP " .. tostring(result.status)
+  end
+  return cosmo.DecodeJson(result.body)
 end
 
 local function fetch_text(url: string): string, string
-  local status, _, body = cosmo.Fetch(url, {
+  local result = fetch.Fetch(url, {
     headers = {["User-Agent"] = "curl/8.0"},
   })
-  if not status or status ~= 200 then
-    return nil, "fetch failed: " .. tostring(status)
+  if not result.ok then
+    return nil, "fetch failed: " .. result.error
   end
-  return body
+  if result.status ~= 200 then
+    return nil, "fetch failed: HTTP " .. tostring(result.status)
+  end
+  return result.body
 end
 
 local function fetch_binary(url: string): string, string
-  local status, headers_or_err, body = cosmo.Fetch(url, {
+  local result = fetch.Fetch(url, {
     headers = {["User-Agent"] = "curl/8.0"},
     maxresponse = 250 * 1024 * 1024,
   })
-  if not status then
-    return nil, "fetch failed: " .. tostring(headers_or_err or "unknown error")
+  if not result.ok then
+    return nil, "fetch failed: " .. result.error
   end
-  if status ~= 200 then
-    return nil, "fetch failed: HTTP " .. tostring(status)
+  if result.status ~= 200 then
+    return nil, "fetch failed: HTTP " .. tostring(result.status)
   end
-  return body
+  return result.body
 end
 
 local function find_asset(release: Release, name: string): ReleaseAsset

--- a/lib/box/claude.tl
+++ b/lib/box/claude.tl
@@ -2,6 +2,7 @@
 local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
+local fetch = require("cosmic.fetch")
 
 local record ClaudeVersionPlatform
   sha: string
@@ -63,20 +64,23 @@ local function install(): boolean, string
 
   io.stderr:write("installing claude " .. version_info.version .. "...\n")
 
-  local status, _, body = cosmo.Fetch(url, {maxresponse = 300 * 1024 * 1024})
-  if not status or status ~= 200 then
-    return false, "failed to download claude"
+  local result = fetch.Fetch(url, {maxresponse = 300 * 1024 * 1024})
+  if not result.ok then
+    return false, "failed to download claude: " .. result.error
+  end
+  if result.status ~= 200 then
+    return false, "failed to download claude: HTTP " .. tostring(result.status)
   end
 
   -- Verify SHA256
-  local actual_sha = cosmo.EncodeHex(cosmo.Sha256(body)):lower()
+  local actual_sha = cosmo.EncodeHex(cosmo.Sha256(result.body)):lower()
   if actual_sha ~= platform_info.sha then
     return false, "claude checksum mismatch"
   end
 
   -- Write binary
   unix.makedirs(bin_dir)
-  if not cosmo.Barf(claude_bin, body, tonumber("0755", 8)) then
+  if not cosmo.Barf(claude_bin, result.body, tonumber("0755", 8)) then
     return false, "failed to write claude binary"
   end
 

--- a/lib/build/build-fetch.tl
+++ b/lib/build/build-fetch.tl
@@ -43,10 +43,11 @@ local function build_url(spec: VersionSpec, platform: string): string, string
 end
 
 local function download(url: string): string, string
-  local result = fetch.FetchWithRetry(url, {
+  local result = fetch.Fetch(url, {
     headers = {["User-Agent"] = "curl/8.0"},
     maxresponse = 100 * 1024 * 1024,
-  }, {max_attempts = 8})
+    max_attempts = 8,
+  })
 
   if not result.ok then return nil, "fetch failed: " .. result.error end
   if result.status ~= 200 then return nil, "fetch status " .. tostring(result.status) end

--- a/lib/build/build-fetch.tl
+++ b/lib/build/build-fetch.tl
@@ -17,11 +17,6 @@ local record VersionSpec
   platforms: {string:PlatformSpec}
 end
 
-local record FetchOpts
-  headers: {string:string}
-  maxresponse: number
-end
-
 local function interpolate(template: string, vars: {string:string}): string
   return template:gsub("{([%w_]+)}", function(key: string): string
     return vars[key] or ""
@@ -48,18 +43,12 @@ local function build_url(spec: VersionSpec, platform: string): string, string
 end
 
 local function download(url: string): string, string
-  local result: require("cosmic.fetch").Result
-  local last_err: string
-  local opts: FetchOpts = {headers = {["User-Agent"] = "curl/8.0"}, maxresponse = 100 * 1024 * 1024}
+  local result = fetch.FetchWithRetry(url, {
+    headers = {["User-Agent"] = "curl/8.0"},
+    maxresponse = 100 * 1024 * 1024,
+  }, {max_attempts = 8})
 
-  for attempt = 1, 8 do
-    result = fetch.Fetch(url, opts as {string:any})
-    if result.ok then break end
-    last_err = result.error
-    if attempt < 8 then unix.nanosleep(math.min(30, 2 ^ attempt), 0) end
-  end
-
-  if not result.ok then return nil, "fetch failed: " .. last_err end
+  if not result.ok then return nil, "fetch failed: " .. result.error end
   if result.status ~= 200 then return nil, "fetch status " .. tostring(result.status) end
   return result.body
 end

--- a/lib/build/build-fetch.tl
+++ b/lib/build/build-fetch.tl
@@ -3,6 +3,7 @@
 local cosmo = require("cosmo")
 local path = require("cosmo.path")
 local unix = require("cosmo.unix")
+local fetch = require("cosmic.fetch")
 
 local record PlatformSpec
   sha: string
@@ -47,22 +48,20 @@ local function build_url(spec: VersionSpec, platform: string): string, string
 end
 
 local function download(url: string): string, string
-  local status: number
-  local headers: {string:string}
-  local body: string
+  local result: require("cosmic.fetch").Result
   local last_err: string
   local opts: FetchOpts = {headers = {["User-Agent"] = "curl/8.0"}, maxresponse = 100 * 1024 * 1024}
 
   for attempt = 1, 8 do
-    status, headers, body = cosmo.Fetch(url, opts as {string:any})
-    if status then break end
-    last_err = tostring(headers or "unknown")
+    result = fetch.Fetch(url, opts as {string:any})
+    if result.ok then break end
+    last_err = result.error
     if attempt < 8 then unix.nanosleep(math.min(30, 2 ^ attempt), 0) end
   end
 
-  if not status then return nil, "fetch failed: " .. last_err end
-  if status ~= 200 then return nil, "fetch status " .. tostring(status) end
-  return body
+  if not result.ok then return nil, "fetch failed: " .. last_err end
+  if result.status ~= 200 then return nil, "fetch status " .. tostring(result.status) end
+  return result.body
 end
 
 local function verify_sha256(content: string, expected: string): boolean, string

--- a/lib/build/check-update.tl
+++ b/lib/build/check-update.tl
@@ -3,6 +3,7 @@
 local cosmo = require("cosmo")
 local getopt = require("cosmo.getopt")
 local common = require("checker.common")
+local fetch = require("cosmic.fetch")
 
 local record GithubAsset
   name: string
@@ -26,23 +27,29 @@ local record Config
 end
 
 local function fetch_json(url: string): any, string
-  local status, _, body = cosmo.Fetch(url, {
+  local result = fetch.Fetch(url, {
     headers = {["User-Agent"] = "curl/8.0", ["Accept"] = "application/vnd.github+json"},
   })
-  if status ~= 200 then
-    return nil, "fetch failed: " .. tostring(status)
+  if not result.ok then
+    return nil, "fetch failed: " .. result.error
   end
-  return cosmo.DecodeJson(body)
+  if result.status ~= 200 then
+    return nil, "fetch failed: HTTP " .. tostring(result.status)
+  end
+  return cosmo.DecodeJson(result.body)
 end
 
 local function fetch_text(url: string): string, string
-  local status, _, body = cosmo.Fetch(url, {
+  local result = fetch.Fetch(url, {
     headers = {["User-Agent"] = "curl/8.0"},
   })
-  if status ~= 200 then
-    return nil, "fetch failed: " .. tostring(status)
+  if not result.ok then
+    return nil, "fetch failed: " .. result.error
   end
-  return body
+  if result.status ~= 200 then
+    return nil, "fetch failed: HTTP " .. tostring(result.status)
+  end
+  return result.body
 end
 
 local function extract_github_repo(url: string): string

--- a/lib/cosmic/fetch.tl
+++ b/lib/cosmic/fetch.tl
@@ -10,8 +10,12 @@
 --     return nil, result.error
 --   end
 --   -- use result.status, result.headers, result.body
+--
+-- With retry:
+--   local result = fetch.FetchWithRetry(url, opts, {max_attempts = 4})
 
 local cosmo = require("cosmo")
+local unix = require("cosmo.unix")
 
 local record Opts
   method: string
@@ -26,6 +30,12 @@ local record Result
   headers: {string:string}
   body: string
   error: string
+end
+
+local record RetryOpts
+  max_attempts: number
+  max_delay: number
+  retry_on_status: function(number): boolean
 end
 
 -- Fetch wraps cosmo.Fetch to return a structured result table.
@@ -56,14 +66,45 @@ local function Fetch(url: string, opts?: Opts): Result
   }
 end
 
+-- FetchWithRetry wraps Fetch with exponential backoff retry logic.
+-- Retries on network errors and optionally on specific HTTP status codes.
+-- Default: 4 attempts, 30s max delay, retry on 5xx status codes.
+local function FetchWithRetry(url: string, opts: Opts, retry_opts?: RetryOpts): Result
+  local max_attempts = (retry_opts and retry_opts.max_attempts) or 4
+  local max_delay = (retry_opts and retry_opts.max_delay) or 30
+  local retry_on_status = retry_opts and retry_opts.retry_on_status
+
+  local result: Result
+  for attempt = 1, max_attempts do
+    result = Fetch(url, opts)
+
+    if result.ok then
+      if not retry_on_status or not retry_on_status(result.status) then
+        return result
+      end
+      result = {ok = false, error = "HTTP " .. tostring(result.status)}
+    end
+
+    if attempt < max_attempts then
+      local delay = math.min(max_delay, 2 ^ attempt)
+      unix.nanosleep(delay, 0)
+    end
+  end
+
+  return result
+end
+
 local record fetch
   Fetch: function(url: string, opts?: Opts): Result
+  FetchWithRetry: function(url: string, opts: Opts, retry_opts?: RetryOpts): Result
   Opts: Opts
   Result: Result
+  RetryOpts: RetryOpts
 end
 
 local M: fetch = {
   Fetch = Fetch,
+  FetchWithRetry = FetchWithRetry,
 }
 
 return M

--- a/lib/cosmic/fetch.tl
+++ b/lib/cosmic/fetch.tl
@@ -12,17 +12,11 @@
 --   -- use result.status, result.headers, result.body
 --
 -- With retry:
---   local result = fetch.FetchWithRetry(url, opts, {max_attempts = 4})
+--   local result = fetch.Fetch(url, {max_attempts = 4})
+--   local result = fetch.Fetch(url, {should_retry = function(r) return r.status >= 500 end})
 
 local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
-
-local record Opts
-  method: string
-  headers: {string:string}
-  body: string
-  maxresponse: number
-end
 
 local record Result
   ok: boolean
@@ -32,16 +26,17 @@ local record Result
   error: string
 end
 
-local record RetryOpts
+local record Opts
+  method: string
+  headers: {string:string}
+  body: string
+  maxresponse: number
   max_attempts: number
   max_delay: number
-  retry_on_status: function(number): boolean
+  should_retry: function(Result): boolean
 end
 
--- Fetch wraps cosmo.Fetch to return a structured result table.
--- On success: ok=true, status=200, headers={...}, body="..."
--- On failure: ok=false, error="error message"
-local function Fetch(url: string, opts?: Opts): Result
+local function do_fetch(url: string, opts?: Opts): Result
   local status: number
   local headers_or_err: {string:string} | string
   local body: string
@@ -49,45 +44,35 @@ local function Fetch(url: string, opts?: Opts): Result
   status, headers_or_err, body = cosmo.Fetch(url, opts as {string:any})
 
   if not status then
-    -- Fetch failed: headers_or_err contains error message
-    return {
-      ok = false,
-      error = tostring(headers_or_err or "unknown error"),
-    }
+    return {ok = false, error = tostring(headers_or_err or "unknown error")}
   end
 
-  -- Fetch succeeded: headers_or_err is the headers table
   return {
     ok = true,
     status = status,
     headers = headers_or_err as {string:string},
     body = body,
-    error = nil,
   }
 end
 
--- FetchWithRetry wraps Fetch with exponential backoff retry logic.
--- Retries on network errors and optionally on specific HTTP status codes.
--- Default: 4 attempts, 30s max delay, retry on 5xx status codes.
-local function FetchWithRetry(url: string, opts: Opts, retry_opts?: RetryOpts): Result
-  local max_attempts = (retry_opts and retry_opts.max_attempts) or 4
-  local max_delay = (retry_opts and retry_opts.max_delay) or 30
-  local retry_on_status = retry_opts and retry_opts.retry_on_status
+-- Fetch wraps cosmo.Fetch with structured results and optional retry.
+-- Set max_attempts > 1 for retry with exponential backoff.
+-- Set should_retry to control which results trigger retry.
+local function Fetch(url: string, opts?: Opts): Result
+  local max_attempts = (opts and opts.max_attempts) or 1
+  local max_delay = (opts and opts.max_delay) or 30
+  local should_retry = opts and opts.should_retry
 
   local result: Result
   for attempt = 1, max_attempts do
-    result = Fetch(url, opts)
+    result = do_fetch(url, opts)
 
-    if result.ok then
-      if not retry_on_status or not retry_on_status(result.status) then
-        return result
-      end
-      result = {ok = false, error = "HTTP " .. tostring(result.status)}
+    if not result.ok or not should_retry or not should_retry(result) then
+      return result
     end
 
     if attempt < max_attempts then
-      local delay = math.min(max_delay, 2 ^ attempt)
-      unix.nanosleep(delay, 0)
+      unix.nanosleep(math.min(max_delay, 2 ^ attempt), 0)
     end
   end
 
@@ -96,15 +81,12 @@ end
 
 local record fetch
   Fetch: function(url: string, opts?: Opts): Result
-  FetchWithRetry: function(url: string, opts: Opts, retry_opts?: RetryOpts): Result
   Opts: Opts
   Result: Result
-  RetryOpts: RetryOpts
 end
 
 local M: fetch = {
   Fetch = Fetch,
-  FetchWithRetry = FetchWithRetry,
 }
 
 return M

--- a/lib/home/bootstrap.tl
+++ b/lib/home/bootstrap.tl
@@ -5,6 +5,7 @@
 local cosmo = require("cosmo")
 local path = require("cosmo.path")
 local spawn = require("cosmic.spawn")
+local fetch = require("cosmic.fetch")
 
 local REPO <const> = "whilp/world"
 local API_URL <const> = "https://api.github.com"
@@ -43,37 +44,46 @@ local function detect_platform(): string, string
 end
 
 local function fetch_json(url: string): any, string
-  local status, _, body = cosmo.Fetch(url, {
+  local result = fetch.Fetch(url, {
     headers = {
       ["User-Agent"] = "curl/8.0",
       ["Accept"] = "application/vnd.github+json",
     },
   })
-  if not status or status ~= 200 then
-    return nil, "fetch failed: " .. tostring(status)
+  if not result.ok then
+    return nil, "fetch failed: " .. result.error
   end
-  return cosmo.DecodeJson(body)
+  if result.status ~= 200 then
+    return nil, "fetch failed: HTTP " .. tostring(result.status)
+  end
+  return cosmo.DecodeJson(result.body)
 end
 
 local function fetch_text(url: string): string, string
-  local status, _, body = cosmo.Fetch(url, {
+  local result = fetch.Fetch(url, {
     headers = {["User-Agent"] = "curl/8.0"},
   })
-  if not status or status ~= 200 then
-    return nil, "fetch failed: " .. tostring(status)
+  if not result.ok then
+    return nil, "fetch failed: " .. result.error
   end
-  return body
+  if result.status ~= 200 then
+    return nil, "fetch failed: HTTP " .. tostring(result.status)
+  end
+  return result.body
 end
 
 local function fetch_binary(url: string): string, string
-  local status, _, body = cosmo.Fetch(url, {
+  local result = fetch.Fetch(url, {
     headers = {["User-Agent"] = "curl/8.0"},
     maxresponse = 200 * 1024 * 1024,
   })
-  if not status or status ~= 200 then
-    return nil, "fetch failed: " .. tostring(status)
+  if not result.ok then
+    return nil, "fetch failed: " .. result.error
   end
-  return body
+  if result.status ~= 200 then
+    return nil, "fetch failed: HTTP " .. tostring(result.status)
+  end
+  return result.body
 end
 
 local function find_asset(release: Release, name: string): ReleaseAsset

--- a/lib/skill/pr.tl
+++ b/lib/skill/pr.tl
@@ -19,6 +19,7 @@ Environment variables:
 local cosmo = require("cosmo")
 local path = require("cosmo.path")
 local spawn_mod = require("cosmic.spawn")
+local fetch_mod = require("cosmic.fetch")
 
 local type SpawnHandle = require("cosmic.spawn").SpawnHandle
 
@@ -28,7 +29,8 @@ local record FetchOpts
   body: string
 end
 
-local type FetchFn = function(url: string, opts?: FetchOpts): number, {string:string} | string, string
+local type FetchResult = require("cosmic.fetch").Result
+local type FetchFn = function(url: string, opts?: FetchOpts): FetchResult
 
 local record SpawnOpts
   spawn: function({string}): SpawnHandle
@@ -142,8 +144,8 @@ local function parse_pr_md(content: string): ParsedPr, string
   return {title = title, body = body}
 end
 
-local function default_fetch(url: string, opts?: FetchOpts): number, {string:string} | string, string
-  return cosmo.Fetch(url, opts as {string:any})
+local function default_fetch(url: string, opts?: FetchOpts): FetchResult
+  return fetch_mod.Fetch(url, opts as {string:any})
 end
 
 local function github_request(method: string, endpoint: string, token: string, body: {string:string}, opts?: RequestOpts): number, GitHubPr | string
@@ -173,17 +175,17 @@ local function github_request(method: string, endpoint: string, token: string, b
     fetch_opts.headers["Content-Type"] = "application/json"
   end
 
-  local status, headers, response_body = fetch(url, fetch_opts)
-  if not status then
-    return nil, "fetch failed: " .. tostring(headers)
+  local result = fetch(url, fetch_opts)
+  if not result.ok then
+    return nil, "fetch failed: " .. result.error
   end
 
-  local decoded_ok, decoded = pcall(cosmo.DecodeJson, response_body as string)
+  local decoded_ok, decoded = pcall(cosmo.DecodeJson, result.body)
   if not decoded_ok then
     return nil, "json decode failed: " .. tostring(decoded)
   end
 
-  return status, decoded as GitHubPr
+  return result.status, decoded as GitHubPr
 end
 
 

--- a/lib/skill/pr_comments.tl
+++ b/lib/skill/pr_comments.tl
@@ -1,4 +1,4 @@
--- Fetches review comments on a GitHub PR using cosmo.Fetch
+-- Fetches review comments on a GitHub PR using cosmic.fetch
 --
 -- GitHub API endpoints:
 --   /repos/{owner}/{repo}/pulls/{number}/comments - line-level review comments
@@ -12,6 +12,7 @@
 local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
 local getopt = require("cosmo.getopt")
+local fetch = require("cosmic.fetch")
 
 local record FetchOpts
   method: string
@@ -66,19 +67,17 @@ end
 
 local function fetch_with_retry(url: string, opts: FetchOpts, max_attempts: number): number, {string:string}, string
   max_attempts = max_attempts or 4
-  local status: number
-  local headers: {string:string}
-  local body: string
+  local result: require("cosmic.fetch").Result
   local last_err: string
 
   for attempt = 1, max_attempts do
-    status, headers, body = cosmo.Fetch(url, opts as {string:any})
-    if not status then
-      last_err = "fetch failed: " .. tostring(headers)
-    elseif status >= 500 then
-      last_err = "server error: " .. tostring(status)
+    result = fetch.Fetch(url, opts as {string:any})
+    if not result.ok then
+      last_err = "fetch failed: " .. result.error
+    elseif result.status >= 500 then
+      last_err = "server error: " .. tostring(result.status)
     else
-      return status, headers, body
+      return result.status, result.headers, result.body
     end
     if attempt < max_attempts then
       unix.nanosleep(2 ^ attempt, 0)

--- a/lib/skill/pr_comments.tl
+++ b/lib/skill/pr_comments.tl
@@ -14,6 +14,8 @@ local unix = require("cosmo.unix")
 local getopt = require("cosmo.getopt")
 local fetch = require("cosmic.fetch")
 
+local type FetchResult = require("cosmic.fetch").Result
+
 local record FetchOpts
   method: string
   headers: {string:string}
@@ -67,7 +69,7 @@ end
 
 local function fetch_with_retry(url: string, opts: FetchOpts, max_attempts: number): number, {string:string}, string
   max_attempts = max_attempts or 4
-  local result: require("cosmic.fetch").Result
+  local result: FetchResult
   local last_err: string
 
   for attempt = 1, max_attempts do

--- a/lib/skill/pr_comments.tl
+++ b/lib/skill/pr_comments.tl
@@ -10,16 +10,8 @@
 --   cosmic --skill pr_comments --url <github_pr_url> [--json]
 
 local cosmo = require("cosmo")
-local unix = require("cosmo.unix")
 local getopt = require("cosmo.getopt")
 local fetch = require("cosmic.fetch")
-
-local type FetchResult = require("cosmic.fetch").Result
-
-local record FetchOpts
-  method: string
-  headers: {string:string}
-end
 
 local record User
   login: string
@@ -67,33 +59,11 @@ local record JsonResult
   review_comments: {ReviewComment}
 end
 
-local function fetch_with_retry(url: string, opts: FetchOpts, max_attempts: number): number, {string:string}, string
-  max_attempts = max_attempts or 4
-  local result: FetchResult
-  local last_err: string
-
-  for attempt = 1, max_attempts do
-    result = fetch.Fetch(url, opts as {string:any})
-    if not result.ok then
-      last_err = "fetch failed: " .. result.error
-    elseif result.status >= 500 then
-      last_err = "server error: " .. tostring(result.status)
-    else
-      return result.status, result.headers, result.body
-    end
-    if attempt < max_attempts then
-      unix.nanosleep(2 ^ attempt, 0)
-    end
-  end
-
-  return nil, nil, last_err
-end
-
 local function github_request(endpoint: string): number, any
   local api_url = os.getenv("GITHUB_API_URL") or "https://api.github.com"
   local url = api_url .. endpoint
 
-  local fetch_opts: FetchOpts = {
+  local opts: fetch.Opts = {
     method = "GET",
     headers = {
       ["Accept"] = "application/vnd.github+json",
@@ -104,26 +74,28 @@ local function github_request(endpoint: string): number, any
 
   local token = os.getenv("GITHUB_TOKEN")
   if token and token ~= "" then
-    fetch_opts.headers["Authorization"] = "Bearer " .. token
+    opts.headers["Authorization"] = "Bearer " .. token
   end
 
-  local status, _, body = fetch_with_retry(url, fetch_opts, nil)
-  if not status then
-    return nil, body
+  local result = fetch.FetchWithRetry(url, opts, {
+    retry_on_status = function(status: number): boolean return status >= 500 end,
+  })
+  if not result.ok then
+    return nil, result.error
   end
 
-  local ok, decoded = pcall(cosmo.DecodeJson, body)
+  local ok, decoded = pcall(cosmo.DecodeJson, result.body)
   if not ok then
     return nil, "json decode failed: " .. tostring(decoded)
   end
 
-  if status ~= 200 then
+  if result.status ~= 200 then
     local api_err = decoded as ApiError
     local msg = api_err and api_err.message or "unknown error"
-    return nil, string.format("api error %d: %s", status, msg)
+    return nil, string.format("api error %d: %s", result.status, msg)
   end
 
-  return status, decoded
+  return result.status, decoded
 end
 
 local function get_review_comments(owner: string, repo: string, pr_number: number): number, {ReviewComment}

--- a/lib/skill/pr_comments.tl
+++ b/lib/skill/pr_comments.tl
@@ -70,6 +70,8 @@ local function github_request(endpoint: string): number, any
       ["X-GitHub-Api-Version"] = "2022-11-28",
       ["User-Agent"] = "pr-comments.lua/1.0",
     },
+    max_attempts = 4,
+    should_retry = function(r: fetch.Result): boolean return r.status >= 500 end,
   }
 
   local token = os.getenv("GITHUB_TOKEN")
@@ -77,9 +79,7 @@ local function github_request(endpoint: string): number, any
     opts.headers["Authorization"] = "Bearer " .. token
   end
 
-  local result = fetch.FetchWithRetry(url, opts, {
-    retry_on_status = function(status: number): boolean return status >= 500 end,
-  })
+  local result = fetch.Fetch(url, opts)
   if not result.ok then
     return nil, result.error
   end

--- a/lib/skill/test_pr.tl
+++ b/lib/skill/test_pr.tl
@@ -38,7 +38,15 @@ local record FetchOpts
   body: string
 end
 
-local type FetchFn = function(url: string, opts?: FetchOpts): number, {string:string}, string
+local record FetchResult
+  ok: boolean
+  status: number
+  headers: {string:string}
+  body: string
+  error: string
+end
+
+local type FetchFn = function(url: string, opts?: FetchOpts): FetchResult
 
 local record ParsedPr
   title: string
@@ -136,9 +144,9 @@ test_timestamp_replace_existing()
 --------------------------------------------------------------------------------
 
 local function test_github_request_success()
-  local mock_fetch: FetchFn = function(_: string, opts: FetchOpts): number, {string:string}, string
+  local mock_fetch: FetchFn = function(_: string, opts: FetchOpts): FetchResult
     assert(opts.headers["Authorization"]:match("Bearer"), "expected bearer")
-    return 200, {}, cosmo.EncodeJson({number = 42})
+    return {ok = true, status = 200, headers = {}, body = cosmo.EncodeJson({number = 42})}
   end
   local status, data = pr.github_request("GET", "/test", "token", nil, {fetch = mock_fetch})
   assert(status == 200, "expected 200")
@@ -148,7 +156,9 @@ end
 test_github_request_success()
 
 local function test_github_request_failure()
-  local mock_fetch: FetchFn = function(_: string, _opts: FetchOpts): number, {string:string}, string return nil, nil, "connection refused" end
+  local mock_fetch: FetchFn = function(_: string, _opts: FetchOpts): FetchResult
+    return {ok = false, error = "connection refused"}
+  end
   local status, err = pr.github_request("GET", "/test", "token", nil, {fetch = mock_fetch})
   assert(not status, "expected no status")
   assert((err as string):match("fetch failed"), "expected error")
@@ -156,8 +166,8 @@ end
 test_github_request_failure()
 
 local function test_get_pr()
-  local mock_fetch: FetchFn = function(_: string, _opts: FetchOpts): number, {string:string}, string
-    return 200, {}, cosmo.EncodeJson({number = 42, title = "Test", body = "Body"})
+  local mock_fetch: FetchFn = function(_: string, _opts: FetchOpts): FetchResult
+    return {ok = true, status = 200, headers = {}, body = cosmo.EncodeJson({number = 42, title = "Test", body = "Body"})}
   end
   local data = pr.get_pr("owner", "repo", 42, "token", {fetch = mock_fetch}) as GitHubPr
   assert(data.number == 42, "expected pr number")
@@ -166,9 +176,9 @@ test_get_pr()
 
 local function test_update_pr()
   local captured: {string:string}
-  local mock_fetch: FetchFn = function(_: string, opts: FetchOpts): number, {string:string}, string
+  local mock_fetch: FetchFn = function(_: string, opts: FetchOpts): FetchResult
     captured = cosmo.DecodeJson(opts.body) as {string:string}
-    return 200, {}, cosmo.EncodeJson({number = 42})
+    return {ok = true, status = 200, headers = {}, body = cosmo.EncodeJson({number = 42})}
   end
   local ok = pr.update_pr("owner", "repo", 42, "Title", "Body", "token", {fetch = mock_fetch})
   assert(ok, "expected success")
@@ -242,11 +252,11 @@ test_pr_file_from_branch_multiple()
 --------------------------------------------------------------------------------
 
 local function test_do_update_with_changes()
-  local mock_fetch: FetchFn = function(_: string, opts: FetchOpts): number, {string:string}, string
+  local mock_fetch: FetchFn = function(_: string, opts: FetchOpts): FetchResult
     if opts.method == "GET" then
-      return 200, {}, cosmo.EncodeJson({number = 42, title = "Old", body = "Old body"})
+      return {ok = true, status = 200, headers = {}, body = cosmo.EncodeJson({number = 42, title = "Old", body = "Old body"})}
     else
-      return 200, {}, cosmo.EncodeJson({number = 42})
+      return {ok = true, status = 200, headers = {}, body = cosmo.EncodeJson({number = 42})}
     end
   end
 
@@ -276,12 +286,12 @@ test_do_update_with_changes()
 
 local function test_main_with_single_file()
   local patch_called = false
-  local mock_fetch: FetchFn = function(_: string, opts: FetchOpts): number, {string:string}, string
+  local mock_fetch: FetchFn = function(_: string, opts: FetchOpts): FetchResult
     if opts.method == "GET" then
-      return 200, {}, cosmo.EncodeJson({number = 42, title = "Old", body = "Old body"})
+      return {ok = true, status = 200, headers = {}, body = cosmo.EncodeJson({number = 42, title = "Old", body = "Old body"})}
     else
       patch_called = true
-      return 200, {}, cosmo.EncodeJson({number = 42})
+      return {ok = true, status = 200, headers = {}, body = cosmo.EncodeJson({number = 42})}
     end
   end
 


### PR DESCRIPTION
Replace cosmo.Fetch calls with cosmic.fetch throughout the codebase to leverage structured result handling and prevent accidentally discarding error messages.

Changes:
- lib/skill/pr.tl: update github_request to use Result type
- lib/home/bootstrap.tl: refactor fetch_json, fetch_text, fetch_binary
- lib/box/claude.tl: update install function fetch logic
- lib/box/bootstrap.tl: refactor fetch_json, fetch_text, fetch_binary
- lib/build/build-fetch.tl: update download with retry logic
- lib/build/check-update.tl: refactor fetch_json, fetch_text
- lib/skill/pr_comments.tl: update fetch_with_retry function

All functions now return structured Result with ok/error fields instead of multi-value returns that could be mishandled.