### PR TITLE
cosmos: bump to 2026.01.18-7ac057bf4

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format="zip",
-  platforms={["*"]={sha="5f10a044d5f12406e3c83b3ec3d8345309e59feffb1b1443d406aad3591d5363"}},
+  platforms={["*"]={sha="ff379551031d0daaa0cccf54937c6b03d68e7d3adf7efb9d882e53d7e214b5cc"}},
   strip_components=0,
   url="https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version="2026.01.18-9df0a3c58"
+  version="2026.01.18-7ac057bf4"
 }


### PR DESCRIPTION
## Summary
- Bump cosmos from 2026.01.18-9df0a3c58 to 2026.01.18-7ac057bf4

## Test plan
- [ ] CI passes