### PR TITLE
box: add scp command for file transfer

### DIFF
--- a/lib/box/backend.tl
+++ b/lib/box/backend.tl
@@ -11,6 +11,7 @@ local record Backend
   ssh: function(name: string, ...: string): Result
   exec: function(name: string, cmd: string): Result
   upload: function(name: string, src: string, dst: string): Result
+  download: function(name: string, src: string, dst: string): Result
   destroy: function(name: string): Result
   list: function(): Result
 end

--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -34,6 +34,7 @@ commands:
   new                   create box only
   run                   bootstrap only
   ssh                   connect only
+  scp <src> <dst>       copy files (: prefix = remote)
   zap                   destroy box
   list                  list boxes
 
@@ -43,6 +44,8 @@ examples:
   box --sprite dev           # create, bootstrap, and ssh to sprite
   box --sprite dev new       # create sprite only
   box --sprite dev zap       # destroy sprite
+  box --sprite dev scp file.txt :/tmp/file.txt   # upload
+  box --sprite dev scp :/tmp/file.txt file.txt   # download
   box --backend pay.lua dev  # use custom backend
 ]])
 end
@@ -316,6 +319,40 @@ local function cmd_list(be: backend_mod.Backend): boolean, string
   return true
 end
 
+local function cmd_scp(be: backend_mod.Backend, name: string, src: string, dst: string): boolean, string
+  if not src or not dst then
+    return false, "scp requires source and destination arguments"
+  end
+
+  local src_remote = src:sub(1, 1) == ":"
+  local dst_remote = dst:sub(1, 1) == ":"
+
+  if src_remote and dst_remote then
+    return false, "cannot copy between two remote paths"
+  end
+  if not src_remote and not dst_remote then
+    return false, "one of source or destination must be remote (prefix with :)"
+  end
+
+  local result: backend_mod.Result
+  if src_remote then
+    -- download: remote -> local
+    local remote_path = src:sub(2)
+    io.stderr:write("==> downloading " .. remote_path .. " from " .. name .. "\n")
+    result = be.download(name, remote_path, dst)
+  else
+    -- upload: local -> remote
+    local remote_path = dst:sub(2)
+    io.stderr:write("==> uploading " .. src .. " to " .. name .. "\n")
+    result = be.upload(name, src, remote_path)
+  end
+
+  if not result.ok then
+    return false, result.err or "unknown error"
+  end
+  return true
+end
+
 local function cmd_local_run(name: string, kind: string): integer, string
   -- Running on remote after upload
   -- Load env from /zip/env.lua (zipped into self before upload)
@@ -394,6 +431,12 @@ local function main(args: {string}): integer, string
     return 0
   elseif parsed.cmd == "zap" then
     ok, err = cmd_zap(be, parsed.name)
+    if not ok then return 1, err end
+    return 0
+  elseif parsed.cmd == "scp" then
+    local src = parsed.extra_args[1]
+    local dst = parsed.extra_args[2]
+    ok, err = cmd_scp(be, parsed.name, src, dst)
     if not ok then return 1, err end
     return 0
   elseif parsed.cmd == nil then

--- a/lib/box/mac.tl
+++ b/lib/box/mac.tl
@@ -14,6 +14,7 @@ return {
   ssh = function(_: string, ...: string): backend.Result return not_implemented() end,
   exec = function(_: string, _: string): backend.Result return not_implemented() end,
   upload = function(_: string, _: string, _: string): backend.Result return not_implemented() end,
+  download = function(_: string, _: string, _: string): backend.Result return not_implemented() end,
   destroy = function(_: string): backend.Result return not_implemented() end,
   list = function(): backend.Result return not_implemented() end,
 } as backend.Backend

--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -1,5 +1,6 @@
 -- box/sprite.tl: sprites.dev backend for box
 
+local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
 local spawn = require("cosmic.spawn")
 
@@ -76,6 +77,25 @@ local function upload(name: string, src: string, dst: string): backend.Result
   return ok()
 end
 
+local function download(name: string, src: string, dst: string): backend.Result
+  local handle = spawn({"sprite", "exec", "-s", name, "--", "cat", src})
+  if not handle then
+    return err("sprite binary not found")
+  end
+  local read_ok, content = handle:read()
+  local exit_code = handle:wait()
+  if exit_code ~= 0 then
+    return err("download failed: exit " .. tostring(exit_code))
+  end
+  if not read_ok or not content then
+    return err("failed to read remote file")
+  end
+  if not cosmo.Barf(dst, content as string) then
+    return err("failed to write local file: " .. dst)
+  end
+  return ok()
+end
+
 local function destroy(name: string): backend.Result
   local handle = spawn({"sprite", "destroy", "-s", name, "-force"})
   if not handle then
@@ -99,6 +119,7 @@ return {
   ssh = ssh,
   exec = exec,
   upload = upload,
+  download = download,
   destroy = destroy,
   list = list,
 } as backend.Backend


### PR DESCRIPTION
## Summary
- Adds `scp` command to box for uploading and downloading files
- Uses `:` prefix to indicate remote paths (similar to rsync/scp syntax)
- Implements `download` method in Backend interface and sprite backend

## Test plan
- [x] `make test` passes
- [ ] Test upload: `box --sprite dev scp file.txt :/tmp/file.txt`
- [ ] Test download: `box --sprite dev scp :/tmp/file.txt file.txt`