### PR TITLE
box: fix scp with relative destination paths

### DIFF
--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -343,6 +343,15 @@ local function cmd_scp(be: backend_mod.Backend, name: string, src: string, dst: 
   else
     -- upload: local -> remote
     local remote_path = dst:sub(2)
+    -- if dest is a directory (. or ends with /), append source basename
+    if remote_path == "." or remote_path == "" or remote_path:sub(-1) == "/" then
+      local basename = path.basename(src)
+      if remote_path == "" then
+        remote_path = basename
+      else
+        remote_path = path.join(remote_path, basename)
+      end
+    end
     io.stderr:write("==> uploading " .. src .. " to " .. name .. "\n")
     result = be.upload(name, src, remote_path)
   end

--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -65,6 +65,26 @@ local function exec(name: string, cmd: string): backend.Result
 end
 
 local function upload(name: string, src: string, dst: string): backend.Result
+  -- sprite -file doesn't handle relative paths correctly, resolve to absolute
+  if not dst:match("^/") then
+    local home_handle = spawn({"sprite", "exec", "-s", name, "--", "bash", "-c", "echo $HOME"})
+    if not home_handle then
+      return err("sprite binary not found")
+    end
+    local read_ok, home = home_handle:read()  -- read() calls wait() internally
+    if not read_ok or not home then
+      return err("failed to get remote home directory")
+    end
+    home = (home as string):gsub("%s+$", "")
+    if dst == "." or dst == "./" then
+      dst = home
+    elseif dst:sub(1, 2) == "./" then
+      dst = home .. dst:sub(2)
+    else
+      dst = home .. "/" .. dst
+    end
+  end
+
   local file_arg = src .. ":" .. dst
   local handle = spawn({"sprite", "exec", "-s", name, "-file", file_arg, "--", "true"})
   if not handle then


### PR DESCRIPTION
## Summary
- Fix `box scp file :.` failing with "upload failed: exit 1"
- Handle directory destinations (`.` or trailing `/`) by appending source basename
- Resolve relative paths to absolute in sprite backend (sprite `-file` doesn't handle relative paths correctly)

## Test plan
- [x] `box --sprite beta scp /tmp/testfile :.` uploads to `~/testfile`
- [x] `box --sprite beta scp /tmp/testfile :/tmp/` uploads to `/tmp/testfile`