### PR TITLE
zshrc: fix prompt variable expansion

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,6 +1,7 @@
 export STRIPE_DO_NOT_MANAGE=1
 
-export PS1='${WHEREAMI##* } '
+setopt PROMPT_SUBST
+export PS1='${WHEREAMI: -1} '
 set -o vi
 
 # Set terminal title


### PR DESCRIPTION
## Summary
- Enable `PROMPT_SUBST` for zsh to expand variables in PS1
- Change `${WHEREAMI##* }` to `${WHEREAMI: -1}` to get last character instead of text after last space

## Test plan
- Source `~/.zshrc` and verify prompt shows last character of `$WHEREAMI`