### PR TITLE
Add custom release URL option to box

### DIFF
--- a/lib/box/backend.tl
+++ b/lib/box/backend.tl
@@ -21,15 +21,22 @@ local record Git
   email: string
 end
 
+local record Bootstrap
+  repo: string
+  release: string
+end
+
 local record Env
   github: {string: any}
   git: Git
   claude: {string: any}
+  bootstrap: Bootstrap
 end
 
 return {
   Result = Result,
   Backend = Backend,
   Git = Git,
+  Bootstrap = Bootstrap,
   Env = Env,
 }

--- a/lib/box/bootstrap.tl
+++ b/lib/box/bootstrap.tl
@@ -107,15 +107,17 @@ local function parse_sha256sums(content: string): {string:string}
 end
 
 local function get_release(): Release, string
-  local custom_url = os.getenv("BOX_RELEASE_URL")
+  local custom_repo = os.getenv("BOX_REPO")
+  local custom_release = os.getenv("BOX_RELEASE")
+  local repo = custom_repo or REPO
   local url: string
 
-  if custom_url and custom_url ~= "" then
-    io.stderr:write("using custom release url\n")
-    url = custom_url
+  if custom_release and custom_release ~= "" then
+    io.stderr:write("fetching release " .. custom_release .. " from " .. repo .. "...\n")
+    url = API_URL .. "/repos/" .. repo .. "/releases/tags/" .. custom_release
   else
-    io.stderr:write("fetching latest release...\n")
-    url = API_URL .. "/repos/" .. REPO .. "/releases/latest"
+    io.stderr:write("fetching latest release from " .. repo .. "...\n")
+    url = API_URL .. "/repos/" .. repo .. "/releases/latest"
   end
 
   local data, err = fetch_json(url)

--- a/lib/box/bootstrap.tl
+++ b/lib/box/bootstrap.tl
@@ -106,34 +106,13 @@ local function parse_sha256sums(content: string): {string:string}
   return sums
 end
 
-local function parse_release_url(url_or_tag: string): string
-  -- Handle various URL formats:
-  -- 1. GitHub release page: https://github.com/owner/repo/releases/tag/v1.2.3
-  -- 2. GitHub API URL: https://api.github.com/repos/owner/repo/releases/tags/v1.2.3
-  -- 3. Just a tag: v1.2.3
-
-  -- If it's a GitHub release page URL, extract the tag
-  local tag = url_or_tag:match("github%.com/[^/]+/[^/]+/releases/tag/([^/]+)$")
-  if tag then
-    return API_URL .. "/repos/" .. REPO .. "/releases/tags/" .. tag
-  end
-
-  -- If it's already a GitHub API URL, use it as-is
-  if url_or_tag:match("^https?://api%.github%.com/") then
-    return url_or_tag
-  end
-
-  -- Otherwise, treat it as a tag name
-  return API_URL .. "/repos/" .. REPO .. "/releases/tags/" .. url_or_tag
-end
-
 local function get_release(): Release, string
   local custom_url = os.getenv("BOX_RELEASE_URL")
   local url: string
 
   if custom_url and custom_url ~= "" then
-    io.stderr:write("using custom release: " .. custom_url .. "\n")
-    url = parse_release_url(custom_url)
+    io.stderr:write("using custom release url\n")
+    url = custom_url
   else
     io.stderr:write("fetching latest release...\n")
     url = API_URL .. "/repos/" .. REPO .. "/releases/latest"

--- a/lib/box/bootstrap.tl
+++ b/lib/box/bootstrap.tl
@@ -106,9 +106,39 @@ local function parse_sha256sums(content: string): {string:string}
   return sums
 end
 
+local function parse_release_url(url_or_tag: string): string
+  -- Handle various URL formats:
+  -- 1. GitHub release page: https://github.com/owner/repo/releases/tag/v1.2.3
+  -- 2. GitHub API URL: https://api.github.com/repos/owner/repo/releases/tags/v1.2.3
+  -- 3. Just a tag: v1.2.3
+
+  -- If it's a GitHub release page URL, extract the tag
+  local tag = url_or_tag:match("github%.com/[^/]+/[^/]+/releases/tag/([^/]+)$")
+  if tag then
+    return API_URL .. "/repos/" .. REPO .. "/releases/tags/" .. tag
+  end
+
+  -- If it's already a GitHub API URL, use it as-is
+  if url_or_tag:match("^https?://api%.github%.com/") then
+    return url_or_tag
+  end
+
+  -- Otherwise, treat it as a tag name
+  return API_URL .. "/repos/" .. REPO .. "/releases/tags/" .. url_or_tag
+end
+
 local function get_release(): Release, string
-  io.stderr:write("fetching latest release...\n")
-  local url = API_URL .. "/repos/" .. REPO .. "/releases/latest"
+  local custom_url = os.getenv("BOX_RELEASE_URL")
+  local url: string
+
+  if custom_url and custom_url ~= "" then
+    io.stderr:write("using custom release: " .. custom_url .. "\n")
+    url = parse_release_url(custom_url)
+  else
+    io.stderr:write("fetching latest release...\n")
+    url = API_URL .. "/repos/" .. REPO .. "/releases/latest"
+  end
+
   local data, err = fetch_json(url)
   if not data then
     return nil, err

--- a/lib/box/bootstrap.tl
+++ b/lib/box/bootstrap.tl
@@ -106,15 +106,28 @@ local function parse_sha256sums(content: string): {string:string}
   return sums
 end
 
+local record BootstrapConfig
+  repo: string
+  release: string
+end
+
+local function load_bootstrap_config(): BootstrapConfig
+  local ok, env = pcall(dofile, "/zip/env.lua")
+  if ok and env and type(env) == "table" and env.bootstrap then
+    return env.bootstrap as BootstrapConfig
+  end
+  return {}
+end
+
 local function get_release(): Release, string
-  local custom_repo = os.getenv("BOX_REPO")
-  local custom_release = os.getenv("BOX_RELEASE")
-  local repo = custom_repo or REPO
+  local config = load_bootstrap_config()
+  local repo = config.repo or REPO
+  local release_tag = config.release
   local url: string
 
-  if custom_release and custom_release ~= "" then
-    io.stderr:write("fetching release " .. custom_release .. " from " .. repo .. "...\n")
-    url = API_URL .. "/repos/" .. repo .. "/releases/tags/" .. custom_release
+  if release_tag and release_tag ~= "" then
+    io.stderr:write("fetching release " .. release_tag .. " from " .. repo .. "...\n")
+    url = API_URL .. "/repos/" .. repo .. "/releases/tags/" .. release_tag
   else
     io.stderr:write("fetching latest release from " .. repo .. "...\n")
     url = API_URL .. "/repos/" .. repo .. "/releases/latest"

--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -16,7 +16,7 @@ local record ParsedArgs
   cmd: string           -- "new", "run", "ssh", "zap", "list", or nil for all-in-one
   env_path: string      -- path to env.lua
   local_run: boolean    -- running remotely after upload
-  release_url: string   -- custom release URL instead of latest
+  release: string       -- custom release URL instead of latest
   extra_args: {string}  -- extra args to pass to ssh
 end
 
@@ -30,7 +30,7 @@ backends (pick one):
 
 options:
   --env <path>          credentials file (default: ~/.config/box/env.lua)
-  --release-url <url>   custom release URL (default: latest from github)
+  --release <url>       github release API URL (default: latest)
 
 commands:
   new                   create box only
@@ -49,7 +49,7 @@ examples:
   box --sprite dev scp file.txt :/tmp/file.txt   # upload
   box --sprite dev scp :/tmp/file.txt file.txt   # download
   box --backend pay.lua dev  # use custom backend
-  box --sprite --release-url https://github.com/whilp/world/releases/tag/2026.01.16 dev
+  box --sprite --release https://api.github.com/repos/whilp/world/releases/tags/2026.01.16 dev
 ]])
 end
 
@@ -60,7 +60,7 @@ local function parse_args(args: {string}): ParsedArgs
     cmd = nil,
     env_path = path.join(os.getenv("HOME") or "", ".config", "box", "env.lua"),
     local_run = false,
-    release_url = nil,
+    release = nil,
     extra_args = {},
   }
 
@@ -69,7 +69,7 @@ local function parse_args(args: {string}): ParsedArgs
     {"mac", "none"},
     {"backend", "required"},
     {"env", "required"},
-    {"release-url", "required"},
+    {"release", "required"},
     {"local-run", "none"},
     {"help", "none"},
   }
@@ -88,8 +88,8 @@ local function parse_args(args: {string}): ParsedArgs
       result.backend_type = optarg
     elseif opt == "env" then
       result.env_path = optarg
-    elseif opt == "release-url" then
-      result.release_url = optarg
+    elseif opt == "release" then
+      result.release = optarg
     elseif opt == "local-run" then
       result.local_run = true
     elseif opt == "h" or opt == "help" then
@@ -208,7 +208,7 @@ local function cmd_new(be: backend_mod.Backend, name: string): boolean, string
   return true
 end
 
-local function cmd_run(be: backend_mod.Backend, name: string, env_path: string, release_url: string): boolean, string
+local function cmd_run(be: backend_mod.Backend, name: string, env_path: string, release: string): boolean, string
   io.stderr:write("==> bootstrapping " .. name .. "\n")
 
   -- Get path to self (the box binary)
@@ -292,9 +292,9 @@ local function cmd_run(be: backend_mod.Backend, name: string, env_path: string, 
 
   -- Run bootstrap on remote (pass name and kind for env.lua function support)
   local cmd = "chmod +x /tmp/box"
-  if release_url and release_url ~= "" then
+  if release and release ~= "" then
     -- Escape single quotes for shell: ' -> '\''
-    local escaped_url = release_url:gsub("'", "'\\''")
+    local escaped_url = release:gsub("'", "'\\''")
     cmd = cmd .. " && BOX_RELEASE_URL='" .. escaped_url .. "'"
   end
   cmd = cmd .. " /tmp/box --local-run " .. name .. " " .. be.name
@@ -445,7 +445,7 @@ local function main(args: {string}): integer, string
     if not ok then return 1, err end
     return 0
   elseif parsed.cmd == "run" then
-    ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.release_url)
+    ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.release)
     if not ok then return 1, err end
     return 0
   elseif parsed.cmd == "ssh" then
@@ -466,7 +466,7 @@ local function main(args: {string}): integer, string
     -- All-in-one: new + run + ssh (skip ssh if no tty)
     ok, err = cmd_new(be, parsed.name)
     if not ok then return 1, err end
-    ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.release_url)
+    ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.release)
     if not ok then return 1, err end
     if unix.isatty(0) then
       ok, err = cmd_ssh(be, parsed.name, parsed.extra_args)

--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -205,11 +205,16 @@ local function cmd_run(be: backend.Backend, name: string, env_path: string, repo
     return false, "cannot find self at: " .. self_path
   end
 
-  -- Verify env.lua exists
-  local env_data = cosmo.Slurp(env_path)
-  if not env_data then
-    return false, "failed to open env: " .. env_path
+  -- Load env.lua and add bootstrap config
+  local env, err = load_env(env_path, name)
+  if not env then
+    return false, err
   end
+  env.bootstrap = {
+    repo = repo,
+    release = release,
+  }
+  local env_data = "return " .. cosmo.EncodeLua(env)
 
   -- Create temp directory for work
   local tmpdir = unix.mkdtemp("/tmp/box.XXXXXX")
@@ -266,19 +271,8 @@ local function cmd_run(be: backend.Backend, name: string, env_path: string, repo
     return false, "upload failed: " .. (result.err or "unknown")
   end
 
-  -- Run bootstrap on remote (pass name and kind for env.lua function support)
-  local cmd = "chmod +x /tmp/box"
-  if repo and repo ~= "" then
-    -- Escape single quotes for shell: ' -> '\''
-    local escaped_repo = repo:gsub("'", "'\\''")
-    cmd = cmd .. " && BOX_REPO='" .. escaped_repo .. "'"
-  end
-  if release and release ~= "" then
-    -- Escape single quotes for shell: ' -> '\''
-    local escaped_release = release:gsub("'", "'\\''")
-    cmd = cmd .. " && BOX_RELEASE='" .. escaped_release .. "'"
-  end
-  cmd = cmd .. " /tmp/box --local-run " .. name .. " " .. be.name
+  -- Run bootstrap on remote
+  local cmd = "chmod +x /tmp/box && /tmp/box --local-run " .. name .. " " .. be.name
   result = be.exec(name, cmd)
   cleanup()
   if not result.ok then

--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -16,6 +16,7 @@ local record ParsedArgs
   cmd: string           -- "new", "run", "ssh", "zap", "list", or nil for all-in-one
   env_path: string      -- path to env.lua
   local_run: boolean    -- running remotely after upload
+  release_url: string   -- custom release URL instead of latest
   extra_args: {string}  -- extra args to pass to ssh
 end
 
@@ -29,6 +30,7 @@ backends (pick one):
 
 options:
   --env <path>          credentials file (default: ~/.config/box/env.lua)
+  --release-url <url>   custom release URL (default: latest from github)
 
 commands:
   new                   create box only
@@ -47,6 +49,7 @@ examples:
   box --sprite dev scp file.txt :/tmp/file.txt   # upload
   box --sprite dev scp :/tmp/file.txt file.txt   # download
   box --backend pay.lua dev  # use custom backend
+  box --sprite --release-url https://github.com/whilp/world/releases/tag/2026.01.16 dev
 ]])
 end
 
@@ -57,6 +60,7 @@ local function parse_args(args: {string}): ParsedArgs
     cmd = nil,
     env_path = path.join(os.getenv("HOME") or "", ".config", "box", "env.lua"),
     local_run = false,
+    release_url = nil,
     extra_args = {},
   }
 
@@ -65,6 +69,7 @@ local function parse_args(args: {string}): ParsedArgs
     {"mac", "none"},
     {"backend", "required"},
     {"env", "required"},
+    {"release-url", "required"},
     {"local-run", "none"},
     {"help", "none"},
   }
@@ -83,6 +88,8 @@ local function parse_args(args: {string}): ParsedArgs
       result.backend_type = optarg
     elseif opt == "env" then
       result.env_path = optarg
+    elseif opt == "release-url" then
+      result.release_url = optarg
     elseif opt == "local-run" then
       result.local_run = true
     elseif opt == "h" or opt == "help" then
@@ -201,7 +208,7 @@ local function cmd_new(be: backend_mod.Backend, name: string): boolean, string
   return true
 end
 
-local function cmd_run(be: backend_mod.Backend, name: string, env_path: string): boolean, string
+local function cmd_run(be: backend_mod.Backend, name: string, env_path: string, release_url: string): boolean, string
   io.stderr:write("==> bootstrapping " .. name .. "\n")
 
   -- Get path to self (the box binary)
@@ -284,7 +291,14 @@ local function cmd_run(be: backend_mod.Backend, name: string, env_path: string):
   end
 
   -- Run bootstrap on remote (pass name and kind for env.lua function support)
-  result = be.exec(name, "chmod +x /tmp/box && /tmp/box --local-run " .. name .. " " .. be.name)
+  local cmd = "chmod +x /tmp/box"
+  if release_url and release_url ~= "" then
+    -- Escape single quotes for shell: ' -> '\''
+    local escaped_url = release_url:gsub("'", "'\\''")
+    cmd = cmd .. " && BOX_RELEASE_URL='" .. escaped_url .. "'"
+  end
+  cmd = cmd .. " /tmp/box --local-run " .. name .. " " .. be.name
+  result = be.exec(name, cmd)
   cleanup()
   if not result.ok then
     return false, "bootstrap failed: " .. (result.err or "unknown")
@@ -431,7 +445,7 @@ local function main(args: {string}): integer, string
     if not ok then return 1, err end
     return 0
   elseif parsed.cmd == "run" then
-    ok, err = cmd_run(be, parsed.name, parsed.env_path)
+    ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.release_url)
     if not ok then return 1, err end
     return 0
   elseif parsed.cmd == "ssh" then
@@ -452,7 +466,7 @@ local function main(args: {string}): integer, string
     -- All-in-one: new + run + ssh (skip ssh if no tty)
     ok, err = cmd_new(be, parsed.name)
     if not ok then return 1, err end
-    ok, err = cmd_run(be, parsed.name, parsed.env_path)
+    ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.release_url)
     if not ok then return 1, err end
     if unix.isatty(0) then
       ok, err = cmd_ssh(be, parsed.name, parsed.extra_args)

--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -16,7 +16,8 @@ local record ParsedArgs
   cmd: string           -- "new", "run", "ssh", "zap", "list", or nil for all-in-one
   env_path: string      -- path to env.lua
   local_run: boolean    -- running remotely after upload
-  release: string       -- custom release URL instead of latest
+  repo: string          -- github repo (owner/name)
+  release: string       -- release tag
   extra_args: {string}  -- extra args to pass to ssh
 end
 
@@ -30,7 +31,8 @@ backends (pick one):
 
 options:
   --env <path>          credentials file (default: ~/.config/box/env.lua)
-  --release <url>       github release API URL (default: latest)
+  --repo <owner/name>   github repo (default: whilp/world)
+  --release <tag>       release tag (default: latest)
 
 commands:
   new                   create box only
@@ -49,7 +51,7 @@ examples:
   box --sprite dev scp file.txt :/tmp/file.txt   # upload
   box --sprite dev scp :/tmp/file.txt file.txt   # download
   box --backend pay.lua dev  # use custom backend
-  box --sprite --release https://api.github.com/repos/whilp/world/releases/tags/2026.01.16 dev
+  box --sprite --release 2026.01.16 dev
 ]])
 end
 
@@ -60,6 +62,7 @@ local function parse_args(args: {string}): ParsedArgs
     cmd = nil,
     env_path = path.join(os.getenv("HOME") or "", ".config", "box", "env.lua"),
     local_run = false,
+    repo = nil,
     release = nil,
     extra_args = {},
   }
@@ -69,6 +72,7 @@ local function parse_args(args: {string}): ParsedArgs
     {"mac", "none"},
     {"backend", "required"},
     {"env", "required"},
+    {"repo", "required"},
     {"release", "required"},
     {"local-run", "none"},
     {"help", "none"},
@@ -88,6 +92,8 @@ local function parse_args(args: {string}): ParsedArgs
       result.backend_type = optarg
     elseif opt == "env" then
       result.env_path = optarg
+    elseif opt == "repo" then
+      result.repo = optarg
     elseif opt == "release" then
       result.release = optarg
     elseif opt == "local-run" then
@@ -208,7 +214,7 @@ local function cmd_new(be: backend_mod.Backend, name: string): boolean, string
   return true
 end
 
-local function cmd_run(be: backend_mod.Backend, name: string, env_path: string, release: string): boolean, string
+local function cmd_run(be: backend_mod.Backend, name: string, env_path: string, repo: string, release: string): boolean, string
   io.stderr:write("==> bootstrapping " .. name .. "\n")
 
   -- Get path to self (the box binary)
@@ -292,10 +298,15 @@ local function cmd_run(be: backend_mod.Backend, name: string, env_path: string, 
 
   -- Run bootstrap on remote (pass name and kind for env.lua function support)
   local cmd = "chmod +x /tmp/box"
+  if repo and repo ~= "" then
+    -- Escape single quotes for shell: ' -> '\''
+    local escaped_repo = repo:gsub("'", "'\\''")
+    cmd = cmd .. " && BOX_REPO='" .. escaped_repo .. "'"
+  end
   if release and release ~= "" then
     -- Escape single quotes for shell: ' -> '\''
-    local escaped_url = release:gsub("'", "'\\''")
-    cmd = cmd .. " && BOX_RELEASE_URL='" .. escaped_url .. "'"
+    local escaped_release = release:gsub("'", "'\\''")
+    cmd = cmd .. " && BOX_RELEASE='" .. escaped_release .. "'"
   end
   cmd = cmd .. " /tmp/box --local-run " .. name .. " " .. be.name
   result = be.exec(name, cmd)
@@ -445,7 +456,7 @@ local function main(args: {string}): integer, string
     if not ok then return 1, err end
     return 0
   elseif parsed.cmd == "run" then
-    ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.release)
+    ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.repo, parsed.release)
     if not ok then return 1, err end
     return 0
   elseif parsed.cmd == "ssh" then
@@ -466,7 +477,7 @@ local function main(args: {string}): integer, string
     -- All-in-one: new + run + ssh (skip ssh if no tty)
     ok, err = cmd_new(be, parsed.name)
     if not ok then return 1, err end
-    ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.release)
+    ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.repo, parsed.release)
     if not ok then return 1, err end
     if unix.isatty(0) then
       ok, err = cmd_ssh(be, parsed.name, parsed.extra_args)


### PR DESCRIPTION
Add support for specifying a custom release URL instead of always using the latest release from GitHub. The --release-url option accepts:
- GitHub release page URLs (https://github.com/owner/repo/releases/tag/v1.2.3)
- GitHub API URLs (https://api.github.com/repos/owner/repo/releases/tags/v1.2.3)
- Tag names (v1.2.3)

The URL is passed to the remote bootstrap via the BOX_RELEASE_URL environment variable.