### PR TITLE
nvim: load plugin .tl files at runtime

### DIFF
--- a/.config/nvim/init.tl
+++ b/.config/nvim/init.tl
@@ -22,3 +22,18 @@ vim.cmd.packadd('mini.nvim')
 vim.cmd.packadd('nvim-lspconfig')
 vim.cmd.packadd('conform.nvim')
 vim.cmd.packadd('nvim-treesitter')
+
+-- Load plugin/*.tl files (nvim only auto-sources .lua/.vim from plugin/)
+-- Add config dir and plugin dir to package.path for teal loader
+local config_dir = vim.fn.stdpath("config") as string
+local plugin_dir = config_dir .. "/plugin"
+package.path = config_dir .. "/?.tl;" .. config_dir .. "/?.lua;" .. plugin_dir .. "/?.tl;" .. plugin_dir .. "/?.lua;" .. package.path
+
+if vim.fn.isdirectory(plugin_dir) == 1 then
+  for _, file in ipairs(vim.fn.readdir(plugin_dir)) do
+    if file:match("%.tl$") then
+      local module = file:gsub("%.tl$", "")
+      require(module)
+    end
+  end
+end

--- a/.config/nvim/plugin/treesitter.tl
+++ b/.config/nvim/plugin/treesitter.tl
@@ -1,5 +1,6 @@
 -- luacheck ignore: neovim runtime
-local lang = dofile(vim.fn.stdpath("config") .. "/parsers.lua")
+-- package.path is set up in init.tl to include config dir
+local lang = require("parsers")
 
 local ok, ts = pcall(require, "nvim-treesitter")
 if not ok then


### PR DESCRIPTION
Load .tl files from plugin/ directory at runtime using the teal loader instead of requiring pre-compilation to .lua.

After commit 67a155b4, plugin/*.tl files weren't loading because nvim only auto-sources .lua/.vim files.

This manually loads .tl plugin files after the teal loader is initialized.