### PR TITLE
box: fix scp download calling wait() twice

### DIFF
--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -102,8 +102,7 @@ local function download(name: string, src: string, dst: string): backend.Result
   if not handle then
     return err("sprite binary not found")
   end
-  local read_ok, content = handle:read()
-  local exit_code = handle:wait()
+  local read_ok, content, exit_code = handle:read()  -- read() calls wait() internally
   if exit_code ~= 0 then
     return err("download failed: exit " .. tostring(exit_code))
   end


### PR DESCRIPTION
## Summary
- Fix `box scp` download failing with `bad argument #1 to 'read' (number expected, got nil)`
- `handle:read()` already calls `wait()` internally, so calling `wait()` again tried to read from already-closed pipes

## Test plan
- [x] Manually tested `box --sprite beta scp :/tmp/url .` works