### PR TITLE
Fix Neovim Treesitter JSON loading error

### DIFF
--- a/.config/nvim/plugin/treesitter.tl
+++ b/.config/nvim/plugin/treesitter.tl
@@ -7,8 +7,12 @@ if not ok then
   return
 end
 
+-- Find bundled site directory (same logic as init.tl)
+local version_dir = vim.fn.fnamemodify(vim.v.progpath, ":h:h")
+local bundled_site = version_dir .. "/share/nvim/site"
+
 ts.setup({
-  install_dir = vim.fn.stdpath("data") .. "/site",
+  install_dir = bundled_site,
 })
 
 vim.api.nvim_create_autocmd("FileType", {


### PR DESCRIPTION
The install_dir was pointing to stdpath("data")/site, but parsers are actually bundled in the nvim installation at share/nvim/site. This caused "Parser could not be created" errors when opening JSON files.

Updated to use the same bundled_site path logic as init.tl.