### PR TITLE
Fix teal loader crash when stderr is piped

### DIFF
--- a/lib/cosmic/main.tl
+++ b/lib/cosmic/main.tl
@@ -1,6 +1,45 @@
 -- cosmic-lua dispatcher
 -- entry point for cosmic binary that handles special args and dispatches to features
 
+-- Protect io.stderr to handle pipe failures gracefully
+-- When stderr is a pipe and the reader closes it, writes can fail
+-- This is especially important for teal's debug hooks which write to stderr
+do
+  local original_stderr = io.stderr
+  local safe_stderr = {}
+
+  -- Wrap write to catch and ignore pipe errors
+  function safe_stderr:write(...)
+    local ok, err = pcall(function(...)
+      return original_stderr:write(...)
+    end, ...)
+    if not ok then
+      -- Silently ignore write errors (pipe closed, etc)
+      return nil
+    end
+    return err
+  end
+
+  -- Wrap flush to catch and ignore pipe errors
+  function safe_stderr:flush()
+    local ok = pcall(function()
+      return original_stderr:flush()
+    end)
+    if not ok then
+      -- Silently ignore flush errors
+      return nil
+    end
+    return true
+  end
+
+  -- Forward other methods to original stderr
+  setmetatable(safe_stderr, {
+    __index = original_stderr,
+  })
+
+  io.stderr = safe_stderr as FILE
+end
+
 require("tl").loader()
 
 local getopt = require("cosmo.getopt")


### PR DESCRIPTION
Wrap io.stderr with error handling before loading the teal module to prevent failures when stderr is a pipe. The teal loader's debug hooks write to stderr without error handling, which can cause silent failures (exit code 1) when stderr is piped and the reader closes the pipe.

This fix wraps io.stderr.write() and io.stderr.flush() in pcall to catch and ignore pipe errors, ensuring cosmic-lua processes work correctly even when spawned with stderr capture.

Fixes issue where cosmic-lua child processes exit with code 1 when spawned with stderr=-1 (pipe capture).