### PR TITLE
box: add optional backend bootstrap command

### DIFF
--- a/lib/box/backend.tl
+++ b/lib/box/backend.tl
@@ -14,6 +14,7 @@ local record Backend
   download: function(name: string, src: string, dst: string): Result
   destroy: function(name: string): Result
   list: function(): Result
+  bootstrap: function(name: string): Result  -- optional, called after generic bootstrap
 end
 
 local record Git

--- a/lib/box/generic.tl
+++ b/lib/box/generic.tl
@@ -91,6 +91,10 @@ local function list(self: Generic): backend.Result
   return exec_backend(self.exe, "list", {}, true)
 end
 
+local function bootstrap(self: Generic, name: string): backend.Result
+  return exec_backend(self.exe, "bootstrap", {name}, true)
+end
+
 local function load(exe_path: string): backend.Backend, string
   local resolved_path = exe_path
 
@@ -129,6 +133,7 @@ local function load(exe_path: string): backend.Backend, string
     download = function(...: string): backend.Result return download(g, ...) end,
     destroy = function(...: string): backend.Result return destroy(g, ...) end,
     list = function(): backend.Result return list(g) end,
+    bootstrap = function(name: string): backend.Result return bootstrap(g, name) end,
   } as backend.Backend, nil
 end
 

--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -308,6 +308,14 @@ local function cmd_list(be: backend.Backend): boolean, string
   return true
 end
 
+local function cmd_backend_bootstrap(be: backend.Backend, name: string)
+  -- Call optional backend-specific bootstrap (ignore errors)
+  if be.bootstrap then
+    io.stderr:write("==> running backend bootstrap\n")
+    be.bootstrap(name)
+  end
+end
+
 local function cmd_scp(be: backend.Backend, name: string, src: string, dst: string): boolean, string
   if not src or not dst then
     return false, "scp requires source and destination arguments"
@@ -422,6 +430,7 @@ local function main(args: {string}): integer, string
   elseif parsed.cmd == "run" then
     ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.repo, parsed.release)
     if not ok then return 1, err end
+    cmd_backend_bootstrap(be, parsed.name)
     return 0
   elseif parsed.cmd == "ssh" then
     ok, err = cmd_ssh(be, parsed.name, parsed.extra_args)
@@ -443,6 +452,7 @@ local function main(args: {string}): integer, string
     if not ok then return 1, err end
     ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.repo, parsed.release)
     if not ok then return 1, err end
+    cmd_backend_bootstrap(be, parsed.name)
     if unix.isatty(0) then
       ok, err = cmd_ssh(be, parsed.name, parsed.extra_args)
       if not ok then return 1, err end


### PR DESCRIPTION
## Summary
- Add optional `bootstrap` command to the backend interface
- After generic bootstrap completes, call `be.bootstrap(name)` if the backend supports it
- Allows backends like paybox to run additional setup (e.g., setting shell to zsh)

## Test plan
- [ ] Verify existing box commands still work
- [ ] Test with paybox backend that implements bootstrap