### PR TITLE
box: move claude install to sprite backend

### DIFF
--- a/lib/box/claude.tl
+++ b/lib/box/claude.tl
@@ -1,8 +1,10 @@
--- box/claude.tl: install Claude binary
+-- box/claude.tl: install and configure Claude
 local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 local fetch = require("cosmic.fetch")
+
+local backend = require("box.backend")
 
 local record ClaudeVersionPlatform
   sha: string
@@ -113,7 +115,66 @@ local function install(): boolean, string
   return true
 end
 
+local function write_file(filepath: string, content: string, mode: number): boolean, string
+  local dir = path.dirname(filepath)
+  if not unix.makedirs(dir) then
+    return false, "failed to create directory: " .. dir
+  end
+
+  if not cosmo.Barf(filepath, content, mode or tonumber("0600", 8)) then
+    return false, "failed to write: " .. filepath
+  end
+  return true
+end
+
+local function configure(env: backend.Env): boolean, string
+  if not env.claude then
+    return true -- no claude config
+  end
+
+  local home = os.getenv("HOME")
+  if not home then
+    return false, "HOME not set"
+  end
+
+  io.stderr:write("configuring claude...\n")
+
+  local claude_dir = path.join(home, ".claude")
+  unix.makedirs(claude_dir)
+
+  -- Write credentials if provided (Lua table -> JSON)
+  local credentials = env.claude["credentials"]
+  if credentials then
+    local creds_file = path.join(claude_dir, ".credentials.json")
+    local json = cosmo.EncodeJson(credentials)
+    local ok, err = write_file(creds_file, json, tonumber("0600", 8))
+    if not ok then
+      return false, "failed to write credentials: " .. (err or "unknown")
+    end
+  end
+
+  -- Write settings to skip onboarding
+  local settings_file = path.join(claude_dir, "settings.json")
+  if not unix.stat(settings_file) then
+    local settings = {
+      numStartups = 1,
+      installMethod = "unknown",
+      autoUpdates = false,
+      theme = "dark-daltonized",
+      hasCompletedOnboarding = true,
+      bypassPermissionsModeAccepted = true,
+    }
+    local ok, err = write_file(settings_file, cosmo.EncodeJson(settings), tonumber("0644", 8))
+    if not ok then
+      return false, "failed to write settings: " .. (err or "unknown")
+    end
+  end
+
+  return true
+end
+
 return {
   install = install,
+  configure = configure,
   detect_platform = detect_platform,
 }

--- a/lib/box/env.tl
+++ b/lib/box/env.tl
@@ -1,0 +1,37 @@
+-- box/env.tl: load env configuration
+
+local cosmo = require("cosmo")
+local path = require("cosmo.path")
+
+local backend = require("box.backend")
+
+local function load(): backend.Env
+  local home = os.getenv("HOME")
+  if not home then
+    return nil
+  end
+
+  local env_path = path.join(home, ".config", "box", "env.lua")
+  local content = cosmo.Slurp(env_path)
+  if not content then
+    return nil
+  end
+
+  local chunk, load_err = load(content, "@" .. env_path)
+  if not chunk then
+    io.stderr:write("warning: failed to load env: " .. (load_err or "unknown") .. "\n")
+    return nil
+  end
+
+  local call_ok, env = pcall(chunk)
+  if not call_ok then
+    io.stderr:write("warning: failed to execute env: " .. tostring(env) .. "\n")
+    return nil
+  end
+
+  return env as backend.Env
+end
+
+return {
+  load = load,
+}

--- a/lib/box/git.tl
+++ b/lib/box/git.tl
@@ -1,0 +1,35 @@
+-- box/git.tl: configure git identity
+
+local spawn = require("cosmic.spawn")
+
+local backend = require("box.backend")
+
+local function configure(env: backend.Env): boolean, string
+  if not env.git then
+    return true -- no git config
+  end
+
+  if env.git.name then
+    io.stderr:write("configuring git user.name...\n")
+    local handle = spawn({"git", "config", "--global", "user.name", env.git.name})
+    local exit_code = handle:wait()
+    if exit_code ~= 0 then
+      io.stderr:write("warning: git config user.name failed (exit " .. tostring(exit_code) .. ")\n")
+    end
+  end
+
+  if env.git.email then
+    io.stderr:write("configuring git user.email...\n")
+    local handle = spawn({"git", "config", "--global", "user.email", env.git.email})
+    local exit_code = handle:wait()
+    if exit_code ~= 0 then
+      io.stderr:write("warning: git config user.email failed (exit " .. tostring(exit_code) .. ")\n")
+    end
+  end
+
+  return true
+end
+
+return {
+  configure = configure,
+}

--- a/lib/box/github.tl
+++ b/lib/box/github.tl
@@ -1,0 +1,48 @@
+-- box/github.tl: configure gh auth
+
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
+local spawn = require("cosmic.spawn")
+
+local backend = require("box.backend")
+
+local function configure(env: backend.Env): boolean, string
+  if not env.github then
+    return true -- no github config
+  end
+
+  local home = os.getenv("HOME")
+  if not home then
+    return false, "HOME not set"
+  end
+
+  local gh_bin = path.join(home, ".local", "share", "gh", "bin", "gh")
+  local st = unix.stat(gh_bin)
+  if not st then
+    io.stderr:write("warning: gh not found at " .. gh_bin .. "\n")
+    return true -- not an error, just skip
+  end
+
+  for host, token in pairs(env.github) do
+    io.stderr:write("configuring gh auth for " .. host .. "...\n")
+
+    local args: {string} = {gh_bin, "auth", "login", "-h", host, "--with-token"}
+    local handle = spawn(args)
+
+    if handle.stdin then
+      handle.stdin:write(token .. "\n")
+      handle.stdin:close()
+    end
+
+    local exit_code = handle:wait()
+    if exit_code ~= 0 then
+      io.stderr:write("warning: gh auth login failed for " .. host .. " (exit " .. tostring(exit_code) .. ")\n")
+    end
+  end
+
+  return true
+end
+
+return {
+  configure = configure,
+}

--- a/lib/box/run.tl
+++ b/lib/box/run.tl
@@ -6,7 +6,6 @@
 local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
-local spawn = require("cosmic.spawn")
 
 local backend = require("box.backend")
 
@@ -21,115 +20,6 @@ local function write_file(filepath: string, content: string, mode: number): bool
   if not cosmo.Barf(filepath, content, mode or tonumber("0600", 8)) then
     return false, "failed to write: " .. filepath
   end
-  return true
-end
-
-local function configure_gh(env: backend.Env): boolean, string
-  if not env.github then
-    return true -- no github config
-  end
-
-  local home = os.getenv("HOME")
-  if not home then
-    return false, "HOME not set"
-  end
-
-  local gh_bin = path.join(home, ".local", "share", "gh", "bin", "gh")
-  local st = unix.stat(gh_bin)
-  if not st then
-    io.stderr:write("warning: gh not found at " .. gh_bin .. "\n")
-    return true -- not an error, just skip
-  end
-
-  for host, token in pairs(env.github) do
-    io.stderr:write("configuring gh auth for " .. host .. "...\n")
-
-    local args: {string} = {gh_bin, "auth", "login", "-h", host, "--with-token"}
-    local handle = spawn(args)
-
-    if handle.stdin then
-      handle.stdin:write(token .. "\n")
-      handle.stdin:close()
-    end
-
-    local exit_code = handle:wait()
-    if exit_code ~= 0 then
-      io.stderr:write("warning: gh auth login failed for " .. host .. " (exit " .. tostring(exit_code) .. ")\n")
-    end
-  end
-
-  return true
-end
-
-local function configure_git(env: backend.Env): boolean, string
-  if not env.git then
-    return true -- no git config
-  end
-
-  if env.git.name then
-    io.stderr:write("configuring git user.name...\n")
-    local handle = spawn({"git", "config", "--global", "user.name", env.git.name})
-    local exit_code = handle:wait()
-    if exit_code ~= 0 then
-      io.stderr:write("warning: git config user.name failed (exit " .. tostring(exit_code) .. ")\n")
-    end
-  end
-
-  if env.git.email then
-    io.stderr:write("configuring git user.email...\n")
-    local handle = spawn({"git", "config", "--global", "user.email", env.git.email})
-    local exit_code = handle:wait()
-    if exit_code ~= 0 then
-      io.stderr:write("warning: git config user.email failed (exit " .. tostring(exit_code) .. ")\n")
-    end
-  end
-
-  return true
-end
-
-local function configure_claude(env: backend.Env): boolean, string
-  if not env.claude then
-    return true -- no claude config
-  end
-
-  local home = os.getenv("HOME")
-  if not home then
-    return false, "HOME not set"
-  end
-
-  io.stderr:write("configuring claude...\n")
-
-  local claude_dir = path.join(home, ".claude")
-  unix.makedirs(claude_dir)
-
-  -- Write credentials if provided (Lua table -> JSON)
-  local credentials = env.claude["credentials"]
-  if credentials then
-    local creds_file = path.join(claude_dir, ".credentials.json")
-    local json = cosmo.EncodeJson(credentials)
-    local ok, err = write_file(creds_file, json, tonumber("0600", 8))
-    if not ok then
-      return false, "failed to write credentials: " .. (err or "unknown")
-    end
-  end
-
-  -- Write settings to skip onboarding
-  local settings_file = path.join(claude_dir, "settings.json")
-  if not unix.stat(settings_file) then
-    local settings = {
-      numStartups = 1,
-      installMethod = "unknown",
-      autoUpdates = false,
-      theme = "dark-daltonized",
-      hasCompletedOnboarding = true,
-      bypassPermissionsModeAccepted = true,
-    }
-    local ok, err = write_file(settings_file, cosmo.EncodeJson(settings), tonumber("0644", 8))
-    if not ok then
-      return false, "failed to write settings: " .. (err or "unknown")
-    end
-  end
-
   return true
 end
 
@@ -213,31 +103,10 @@ local function bootstrap(env: backend.Env, name: string, kind: string): integer,
     return 1, err or "bootstrap failed"
   end
 
-  -- Step 2: Configure gh auth for each github host
-  ok, err = configure_gh(env)
-  if not ok then
-    return 1, err or "gh config failed"
-  end
-
-  -- Step 3: Configure git identity
-  ok, err = configure_git(env)
-  if not ok then
-    return 1, err or "git config failed"
-  end
-
-  -- Step 4: Configure claude credentials
-  ok, err = configure_claude(env)
-  if not ok then
-    return 1, err or "claude config failed"
-  end
-
   io.stderr:write("==> bootstrap complete\n")
   return 0
 end
 
 return {
   bootstrap = bootstrap,
-  configure_gh = configure_gh,
-  configure_git = configure_git,
-  configure_claude = configure_claude,
 }

--- a/lib/box/run.tl
+++ b/lib/box/run.tl
@@ -9,7 +9,6 @@ local path = require("cosmo.path")
 local spawn = require("cosmic.spawn")
 
 local backend = require("box.backend")
-local claude = require("box.claude")
 
 local ENV_PATH <const> = "/zip/env.lua"
 
@@ -214,25 +213,19 @@ local function bootstrap(env: backend.Env, name: string, kind: string): integer,
     return 1, err or "bootstrap failed"
   end
 
-  -- Step 2: Install Claude binary
-  ok, err = claude.install()
-  if not ok then
-    return 1, err or "claude install failed"
-  end
-
-  -- Step 3: Configure gh auth for each github host
+  -- Step 2: Configure gh auth for each github host
   ok, err = configure_gh(env)
   if not ok then
     return 1, err or "gh config failed"
   end
 
-  -- Step 4: Configure git identity
+  -- Step 3: Configure git identity
   ok, err = configure_git(env)
   if not ok then
     return 1, err or "git config failed"
   end
 
-  -- Step 5: Configure claude credentials
+  -- Step 4: Configure claude credentials
   ok, err = configure_claude(env)
   if not ok then
     return 1, err or "claude config failed"

--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -5,6 +5,7 @@ local unix = require("cosmo.unix")
 local spawn = require("cosmic.spawn")
 
 local backend = require("box.backend")
+local claude = require("box.claude")
 
 local function ok(): backend.Result
   return {ok = true}
@@ -132,6 +133,15 @@ local function list(): backend.Result
   return err("failed to exec sprite list")
 end
 
+local function bootstrap(name: string): backend.Result
+  io.stderr:write("installing claude...\n")
+  local install_ok, install_err = claude.install()
+  if not install_ok then
+    return err(install_err or "claude install failed")
+  end
+  return ok()
+end
+
 return {
   name = "sprite",
   new = new,
@@ -141,4 +151,5 @@ return {
   download = download,
   destroy = destroy,
   list = list,
+  bootstrap = bootstrap,
 } as backend.Backend

--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -6,6 +6,8 @@ local spawn = require("cosmic.spawn")
 
 local backend = require("box.backend")
 local claude = require("box.claude")
+local github = require("box.github")
+local git = require("box.git")
 
 local function ok(): backend.Result
   return {ok = true}
@@ -133,12 +135,61 @@ local function list(): backend.Result
   return err("failed to exec sprite list")
 end
 
+local function load_env(): backend.Env
+  local home = os.getenv("HOME")
+  if not home then
+    return nil
+  end
+
+  local env_path = home .. "/.config/box/env.lua"
+  local content = cosmo.Slurp(env_path)
+  if not content then
+    return nil
+  end
+
+  local chunk, load_err = load(content, "@" .. env_path)
+  if not chunk then
+    io.stderr:write("warning: failed to load env: " .. (load_err or "unknown") .. "\n")
+    return nil
+  end
+
+  local call_ok, env = pcall(chunk)
+  if not call_ok then
+    io.stderr:write("warning: failed to execute env: " .. tostring(env) .. "\n")
+    return nil
+  end
+
+  return env as backend.Env
+end
+
 local function bootstrap(name: string): backend.Result
+  local env = load_env() or {} as backend.Env
+
+  -- Install claude binary
   io.stderr:write("installing claude...\n")
   local install_ok, install_err = claude.install()
   if not install_ok then
     return err(install_err or "claude install failed")
   end
+
+  -- Configure gh auth
+  local cfg_ok, cfg_err = github.configure(env)
+  if not cfg_ok then
+    return err(cfg_err or "github config failed")
+  end
+
+  -- Configure git identity
+  cfg_ok, cfg_err = git.configure(env)
+  if not cfg_ok then
+    return err(cfg_err or "git config failed")
+  end
+
+  -- Configure claude credentials
+  cfg_ok, cfg_err = claude.configure(env)
+  if not cfg_ok then
+    return err(cfg_err or "claude config failed")
+  end
+
   return ok()
 end
 

--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -1,10 +1,11 @@
 -- box/sprite.tl: sprites.dev backend for box
 
-local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
 local spawn = require("cosmic.spawn")
+local cosmo = require("cosmo")
 
 local backend = require("box.backend")
+local env = require("box.env")
 local claude = require("box.claude")
 local github = require("box.github")
 local git = require("box.git")
@@ -135,35 +136,8 @@ local function list(): backend.Result
   return err("failed to exec sprite list")
 end
 
-local function load_env(): backend.Env
-  local home = os.getenv("HOME")
-  if not home then
-    return nil
-  end
-
-  local env_path = home .. "/.config/box/env.lua"
-  local content = cosmo.Slurp(env_path)
-  if not content then
-    return nil
-  end
-
-  local chunk, load_err = load(content, "@" .. env_path)
-  if not chunk then
-    io.stderr:write("warning: failed to load env: " .. (load_err or "unknown") .. "\n")
-    return nil
-  end
-
-  local call_ok, env = pcall(chunk)
-  if not call_ok then
-    io.stderr:write("warning: failed to execute env: " .. tostring(env) .. "\n")
-    return nil
-  end
-
-  return env as backend.Env
-end
-
 local function bootstrap(name: string): backend.Result
-  local env = load_env() or {} as backend.Env
+  local cfg = env.load() or {} as backend.Env
 
   -- Install claude binary
   io.stderr:write("installing claude...\n")
@@ -173,19 +147,19 @@ local function bootstrap(name: string): backend.Result
   end
 
   -- Configure gh auth
-  local cfg_ok, cfg_err = github.configure(env)
+  local cfg_ok, cfg_err = github.configure(cfg)
   if not cfg_ok then
     return err(cfg_err or "github config failed")
   end
 
   -- Configure git identity
-  cfg_ok, cfg_err = git.configure(env)
+  cfg_ok, cfg_err = git.configure(cfg)
   if not cfg_ok then
     return err(cfg_err or "git config failed")
   end
 
   -- Configure claude credentials
-  cfg_ok, cfg_err = claude.configure(env)
+  cfg_ok, cfg_err = claude.configure(cfg)
   if not cfg_ok then
     return err(cfg_err or "claude config failed")
   end


### PR DESCRIPTION
## Summary
- Move Claude binary install from generic `run.tl` bootstrap to sprite-specific `sprite.tl` bootstrap
- Claude binaries are only available for x86/darwin, not arm64/linux (hot n ready devboxes)
- This fixes bootstrap failures on devboxes that use Graviton/ARM

## Test plan
- [x] Tested devbox bootstrap with `box --backend devbox` - no longer fails on claude install
- [x] Sprite backend still has claude install in its bootstrap function