### PR TITLE
box: auto-create box if it doesn't exist

### DIFF
--- a/lib/box/backend.tl
+++ b/lib/box/backend.tl
@@ -14,6 +14,7 @@ local record Backend
   download: function(name: string, src: string, dst: string): Result
   destroy: function(name: string): Result
   list: function(): Result
+  exists: function(name: string): boolean  -- check if box exists
   bootstrap: function(name: string): Result  -- optional, called after generic bootstrap
 end
 

--- a/lib/box/generic.tl
+++ b/lib/box/generic.tl
@@ -91,6 +91,11 @@ local function list(self: Generic): backend.Result
   return exec_backend(self.exe, "list", {}, true)
 end
 
+local function exists(self: Generic, name: string): boolean
+  local result = exec_backend(self.exe, "exists", {name}, false)
+  return result.ok
+end
+
 local function bootstrap(self: Generic, name: string): backend.Result
   return exec_backend(self.exe, "bootstrap", {name}, true)
 end
@@ -133,6 +138,7 @@ local function load(exe_path: string): backend.Backend, string
     download = function(...: string): backend.Result return download(g, ...) end,
     destroy = function(...: string): backend.Result return destroy(g, ...) end,
     list = function(): backend.Result return list(g) end,
+    exists = function(name: string): boolean return exists(g, name) end,
     bootstrap = function(name: string): backend.Result return bootstrap(g, name) end,
   } as backend.Backend, nil
 end

--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -37,15 +37,15 @@ options:
 commands:
   new                   create box only
   run                   bootstrap only
-  ssh                   connect only (default)
+  ssh                   connect only
   scp <src> <dst>       copy files (: prefix = remote)
   zap                   destroy box
   list                  list boxes
 
-If no command given, connects via ssh.
+If no command given, creates box if needed then connects via ssh (default).
 
 examples:
-  box --sprite dev           # ssh to existing sprite
+  box --sprite dev           # ssh to sprite, creating if needed
   box --sprite dev new       # create sprite only
   box --sprite dev run       # bootstrap sprite only
   box --sprite dev zap       # destroy sprite
@@ -456,7 +456,16 @@ local function main(args: {string}): integer, string
     if not ok then return 1, err end
     return 0
   elseif parsed.cmd == nil then
-    -- Default: ssh to existing box
+    -- Default: ssh to box, creating if it doesn't exist
+    if not be.exists(parsed.name) then
+      -- Create and bootstrap
+      ok, err = cmd_new(be, parsed.name)
+      if not ok then return 1, err end
+      ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.repo, parsed.release)
+      if not ok then return 1, err end
+      cmd_backend_bootstrap(be, parsed.name)
+    end
+    -- SSH to the box
     ok, err = cmd_ssh(be, parsed.name, parsed.extra_args)
     if not ok then return 1, err end
     return 0

--- a/lib/box/mac.tl
+++ b/lib/box/mac.tl
@@ -17,4 +17,5 @@ return {
   download = function(_: string, _: string, _: string): backend.Result return not_implemented() end,
   destroy = function(_: string): backend.Result return not_implemented() end,
   list = function(): backend.Result return not_implemented() end,
+  exists = function(_: string): boolean return false end,
 } as backend.Backend

--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -130,6 +130,16 @@ local function destroy(name: string): backend.Result
   return ok()
 end
 
+local function exists(name: string): boolean
+  -- Use sprite api to check if sprite exists explicitly
+  local handle = spawn({"sprite", "api", "-s", name, "/"})
+  if not handle then
+    return false
+  end
+  local exit_code = handle:wait()
+  return exit_code == 0
+end
+
 local function list(): backend.Result
   unix.execvp("sprite", {"sprite", "list"})
   return err("failed to exec sprite list")
@@ -173,5 +183,6 @@ return {
   download = download,
   destroy = destroy,
   list = list,
+  exists = exists,
   bootstrap = bootstrap,
 } as backend.Backend


### PR DESCRIPTION
## Summary
- `box beta` now automatically creates and bootstraps the box if it doesn't exist
- If the box exists, it simply SSHs to it
- The `zap` command is never called automatically - boxes must be explicitly destroyed

## Test plan
- [x] `make test` passes
- [ ] Test `box --sprite <name>` with a new name (should create + bootstrap + SSH)
- [ ] Test `box --sprite <name>` with existing box (should just SSH)