### PR TITLE
bun: fix path to compiled checker script

### DIFF
--- a/3p/bun/cook.mk
+++ b/3p/bun/cook.mk
@@ -3,7 +3,7 @@ bun_version := 3p/bun/version.lua
 bun_tests := 3p/bun/test_bun.tl
 bun_tl_files := 3p/bun/run-bun.tl
 
-bun_check := $(o)/bin/run-bun.lua
+bun_check := $(o)/3p/bun/run-bun.lua
 bun_checker := $(bootstrap_cosmic) -- $(bun_check)
 
 # bun syntax check for .gs/.js files


### PR DESCRIPTION
## Summary
- Fix `bun_check` path from `$(o)/bin/run-bun.lua` to `$(o)/3p/bun/run-bun.lua`
- The tl file `3p/bun/run-bun.tl` compiles via the general rule to `o/3p/bun/run-bun.lua`, not `o/bin/`
- The vpath for `o/bin/%.lua` only includes `lib/build lib/test 3p/ast-grep`, so `3p/bun` was not found

## Test plan
- CI should pass with check and test targets