### PR TITLE
nvim: extract tl.lua from cosmic for release tests

### DIFF
--- a/3p/nvim/cook.mk
+++ b/3p/nvim/cook.mk
@@ -18,7 +18,7 @@ nvim_pack_dir := $(nvim_bundle_out)/share/nvim/site/pack/core/opt
 .PHONY: nvim-bundle
 nvim-bundle: $(nvim_bundle)
 
-$(nvim_bundle): $$(nvim_staged) $$(nvim-conform_staged) $$(nvim-mini_staged) $$(nvim-lspconfig_staged) $$(nvim-treesitter_staged) $$(nvim-parsers_parsers)
+$(nvim_bundle): $$(nvim_staged) $$(nvim-conform_staged) $$(nvim-mini_staged) $$(nvim-lspconfig_staged) $$(nvim-treesitter_staged) $$(nvim-parsers_parsers) $$(cosmic_bin)
 	@rm -rf $(nvim_bundle_out) $@
 	@mkdir -p $(dir $(nvim_bundle_out))
 	@cp -rL $(nvim_staged) $(nvim_bundle_out)
@@ -28,6 +28,7 @@ $(nvim_bundle): $$(nvim_staged) $$(nvim-conform_staged) $$(nvim-mini_staged) $$(
 	@cp -rL $(nvim-lspconfig_staged) $(nvim_pack_dir)/nvim-lspconfig
 	@cp -rL $(nvim-treesitter_staged) $(nvim_pack_dir)/nvim-treesitter
 	@cp -r $(o)/nvim-parsers/parser $(nvim_bundle_out)/share/nvim/site/
+	@unzip -p $(cosmic_bin) .lua/tl.lua > $(nvim_bundle_out)/share/nvim/runtime/lua/tl.lua
 	@echo "generating helptags"
 	@$(nvim_bundle_out)/bin/nvim --headless "+helptags ALL" "+qa" 2>/dev/null || echo "  skipped"
 	@touch $@
@@ -37,7 +38,7 @@ $(nvim_bundle): $$(nvim_staged) $$(nvim-conform_staged) $$(nvim-mini_staged) $$(
 nvim-release-tests: $(nvim_release_tested)
 
 # Release tests: depend on compiled .lua (Make handles compilation)
-$(o)/3p/nvim/%.tl.release.ok: $(o)/3p/nvim/%.lua $(nvim_bundle) $$(tl_staged) | $(bootstrap_files)
+$(o)/3p/nvim/%.tl.release.ok: $(o)/3p/nvim/%.lua $(nvim_bundle) | $(bootstrap_files)
 	@mkdir -p $(@D)
 	@[ -x $< ] || chmod a+x $<
-	@TEST_DIR=$(nvim_bundle_out) TL_DIR=$(tl_dir) $(test_runner) $< > $@
+	@TEST_DIR=$(nvim_bundle_out) $(test_runner) $< > $@

--- a/3p/nvim/test_teal.tl
+++ b/3p/nvim/test_teal.tl
@@ -7,15 +7,11 @@ local unix = require("cosmo.unix")
 global TEST_DIR: string
 global TEST_TMPDIR: string
 
--- Test that the teal library is available in the bundle
+-- Test that the teal library is bundled with nvim
 local function test_teal_library_exists()
-  local tl_staged = os.getenv("TL_DIR")
-  assert(tl_staged, "TL_DIR environment variable not set")
-
-  local tl_lib = path.join(tl_staged, "tl.lua")
+  local tl_lib = path.join(TEST_DIR, "share", "nvim", "runtime", "lua", "tl.lua")
   assert(unix.stat(tl_lib), "tl.lua should exist at: " .. tl_lib)
-
-  print("✓ teal library is available")
+  print("✓ teal library is bundled")
 end
 test_teal_library_exists()
 
@@ -23,21 +19,13 @@ test_teal_library_exists()
 local function test_nvim_can_load_teal()
   local nvim = path.join(TEST_DIR, "bin", "nvim")
 
-  -- Create a simple test that loads teal
+  -- Write test script that loads teal and writes result to file
   local test_script = path.join(TEST_TMPDIR, "test.lua")
   local f = io.open(test_script, "w")
   assert(f, "failed to create test script")
 
-  -- Copy tl.lua to a location nvim can find it
-  local tl_staged = os.getenv("TL_DIR")
-  local tl_dest = path.join(TEST_TMPDIR, "tl.lua")
-  local ok = spawn({"cp", path.join(tl_staged, "tl.lua"), tl_dest}):wait()
-  assert(ok, "failed to copy tl.lua")
-
-  -- Write test script that loads teal and writes result to file
   local result_file = path.join(TEST_TMPDIR, "teal-test-result.txt")
   f:write([[
-package.path = "]] .. TEST_TMPDIR .. [[/?.lua;" .. package.path
 local tl = require("tl")
 tl.loader()
 

--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,8 @@ $(foreach m,$(modules),$(if $($(m)_version),\
   $(eval $(m)_staged := $(o)/$(m)/.staged)\
   $(if $($(m)_dir),,$(eval $(m)_dir := $(o)/$(m)/.staged))))
 
-# define *_zip for tool modules (excludes cosmos, tl, bootstrap infrastructure)
-zip_excluded := cosmos tl bootstrap
+# define *_zip for tool modules (excludes cosmos, bootstrap infrastructure)
+zip_excluded := cosmos bootstrap
 $(foreach m,$(filter-out $(zip_excluded),$(modules)),$(if $($(m)_version),\
   $(eval $(m)_zip := $(o)/$(m)/.zip)))
 


### PR DESCRIPTION
## Summary
- Bundle tl.lua with nvim by extracting it from cosmic's embedded `/zip/.lua/tl.lua`
- Place tl.lua at `share/nvim/runtime/lua/tl.lua` so nvim can `require("tl")`
- Update test to verify tl.lua is in the bundle and nvim can load it
- Clean up unused `tl` reference from `zip_excluded` in Makefile

This enables nvim to load teal (.tl) configuration files.

## Test plan
- `make check test` passes locally
- Release test `o/3p/nvim/test_teal.tl.release.ok` passes