### PR TITLE
clasp: fix sed -i for macos compatibility

### DIFF
--- a/3p/clasp/cook.mk
+++ b/3p/clasp/cook.mk
@@ -20,6 +20,6 @@ $(clasp_bin): $$(clasp_staged) $$(bun_staged) $(clasp_lock)
 	@rm -f $(clasp_dir)/package-lock.json
 	@cp $(clasp_lock) $(clasp_dir)/bun.lock
 	@cd $(clasp_dir) && $(CURDIR)/$(bun_dir)/bin/bun install --ignore-scripts --frozen-lockfile >/dev/null
-	@sed -i 's/var msgId = messageDescriptor.id/var msgId = messageDescriptor.id || "auto"/' $(clasp_dir)/node_modules/@formatjs/intl/src/message.js
-	@sed -i 's/var msgId = messageDescriptor.id/var msgId = messageDescriptor.id || "auto"/' $(clasp_dir)/node_modules/@formatjs/intl/lib/src/message.js
+	@perl -i -pe 's/var msgId = messageDescriptor\.id(?! \|\|)/var msgId = messageDescriptor.id || "auto"/' $(clasp_dir)/node_modules/@formatjs/intl/src/message.js
+	@perl -i -pe 's/var msgId = messageDescriptor\.id(?! \|\|)/var msgId = messageDescriptor.id || "auto"/' $(clasp_dir)/node_modules/@formatjs/intl/lib/src/message.js
 	@cd $(clasp_dir) && $(CURDIR)/$(bun_dir)/bin/bun build --compile src/index.ts --outfile $(CURDIR)/$@ >/dev/null


### PR DESCRIPTION
## Summary
- Replace `sed -i` with `perl -i` in clasp build for macOS compatibility
- BSD sed (macOS) requires `sed -i ''` while GNU sed uses `sed -i`
- Perl's `-i` flag works identically on both platforms

Fixes https://github.com/whilp/world/actions/runs/21153900648/job/60835115298