### PR TITLE
assimilate: use -ae flag for darwin-arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,6 +347,8 @@ build: home cosmic box
 # Assimilated (native) binaries for current platform
 assimilate_bins := box cosmic
 assimilated := $(foreach b,$(assimilate_bins),$(o)/assimilated/$(b)-$(platform))
+# darwin-arm64 needs -ae flag to create ARM64 ELF (loaded by ape-m1.c)
+assimilate_flags := $(if $(filter darwin-arm64,$(platform)),-ae,)
 
 .PHONY: assimilated
 ## Build assimilated (native) binaries for current platform
@@ -355,7 +357,7 @@ assimilated: $(assimilated)
 $(o)/assimilated/%-$(platform): $(o)/bin/% $$(cosmos_staged)
 	@mkdir -p $(@D)
 	@cp $< $@
-	@$(cosmos_assimilate) $@
+	@$(cosmos_assimilate) $(assimilate_flags) $@
 	@rm -f $@.bak
 
 .PHONY: release


### PR DESCRIPTION
## Summary
- Add `-ae` flag when assimilating on darwin-arm64
- APE binaries on Apple Silicon run as ARM64 ELF loaded by ape-m1.c, not native Mach-O
- The assimilate tool doesn't support creating Mach-O for arm64

Fixes https://github.com/whilp/world/actions/runs/21154004701/job/60835401310