### PR TITLE
release: default to prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ on:
         description: 'Mark release as pre-release'
         required: false
         type: boolean
-        default: false
+        default: true
 
 env:
-  PRERELEASE: false
+  PRERELEASE: true
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Changes default prerelease setting from false to true in release workflow
- Affects both manual dispatch default and scheduled runs

## Test plan
- [ ] Verify workflow dispatch shows prerelease=true as default
- [ ] Trigger a test release to confirm --prerelease flag is applied