### PR TITLE
whereami: extract backend from generic:backend kind format

### DIFF
--- a/lib/whereami/init.tl
+++ b/lib/whereami/init.tl
@@ -116,6 +116,11 @@ local function get(): string
   local box_name = get_box_name()
   local box_kind = get_box_kind()
   if box_name and box_name ~= '' and box_kind and box_kind ~= '' then
+    -- kind may be "generic:backend" - use backend as the kind
+    local backend = box_kind:match(':(.+)$')
+    if backend then
+      box_kind = backend
+    end
     return box_name .. "." .. box_kind
   end
 

--- a/lib/whereami/test_whereami.tl
+++ b/lib/whereami/test_whereami.tl
@@ -64,3 +64,30 @@ local function test_whereami_box_name_kind()
   package.loaded["whereami"] = nil
 end
 test_whereami_box_name_kind()
+
+local function test_whereami_generic_backend()
+  local tmpdir = os.getenv("TEST_TMPDIR")
+  if not tmpdir then
+    print("skipping test_whereami_generic_backend (no TEST_TMPDIR)")
+    return
+  end
+
+  -- Create fake home with .config/box/{name,kind} using generic:backend format
+  local fake_home = path.join(tmpdir, "home2")
+  local box_dir = path.join(fake_home, ".config", "box")
+  unix.makedirs(box_dir)
+  cosmo.Barf(path.join(box_dir, "name"), "alpha\n")
+  cosmo.Barf(path.join(box_dir, "kind"), "generic:devbox\n")
+
+  local orig_home = os.getenv("HOME")
+  unix.setenv("HOME", fake_home)
+  package.loaded["whereami"] = nil
+  local fresh_whereami = require("whereami")
+
+  local result = fresh_whereami.get()
+  assert(result == "alpha.devbox", "expected 'alpha.devbox', got '" .. result .. "'")
+
+  unix.setenv("HOME", orig_home)
+  package.loaded["whereami"] = nil
+end
+test_whereami_generic_backend()


### PR DESCRIPTION
## Summary
- When box kind is `generic:devbox`, whereami now returns `alpha.devbox` instead of `alpha.generic:devbox`
- Extracts the backend portion after the colon when the kind contains a colon

## Test plan
- [x] Added test `test_whereami_generic_backend` to verify the transformation
- [x] `make clean test` passes