### PR TITLE
sprite: check response for errors in exists()

### DIFF
--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -136,8 +136,15 @@ local function exists(name: string): boolean
   if not handle then
     return false
   end
-  local exit_code = handle:wait()
-  return exit_code == 0
+  local read_ok, output, exit_code = handle:read()
+  if exit_code ~= 0 or not read_ok or not output then
+    return false
+  end
+  -- sprite api returns exit 0 even for missing sprites, check for error in response
+  if (output as string):find('"error"', 1, true) then
+    return false
+  end
+  return true
 end
 
 local function list(): backend.Result


### PR DESCRIPTION
## Summary
- Fix `exists()` to check response body for errors instead of relying on exit code
- The sprite API returns exit 0 even for missing sprites, so we need to parse the response

## Test plan
- Test with existing and non-existing sprite names