### PR TITLE
nvim: fix environment variable parsing in daemon

### DIFF
--- a/lib/nvim/main.tl
+++ b/lib/nvim/main.tl
@@ -31,8 +31,8 @@ end
 
 local function current_environ(): {string}
   local result: {string} = {}
-  for key, value in pairs(unix.environ()) do
-    table.insert(result, key .. "=" .. value)
+  for _, entry in ipairs(unix.environ()) do
+    table.insert(result, entry)
   end
   return result
 end
@@ -145,8 +145,11 @@ end
 
 local function setup_nvim_environment(nvim_bin: string): {string}
   local env_table: {string:string} = {}
-  for key, value in pairs(unix.environ()) do
-    env_table[key] = value
+  for _, entry in ipairs(unix.environ()) do
+    local key, value = entry:match("^([^=]+)=(.*)$")
+    if key then
+      env_table[key] = value
+    end
   end
   env_table["NVIM_SERVER_MODE"] = "1"
   env_table["WHEREAMI"] = whereami.get_with_emoji()


### PR DESCRIPTION
## Summary

- Fix `unix.environ()` parsing in `current_environ()` and `setup_nvim_environment()`
- `unix.environ()` returns an array of `"KEY=VALUE"` strings with numeric indices
- The old code treated these as a key-value map, creating malformed env vars like `"1=HOME=/home/user"`

## Problem

The nvim headless server wasn't receiving proper environment variables. This caused `os.getenv("HOME")` to return `nil` in the server, breaking config files like `editing.tl` that relied on `HOME`:

```
E5113: Lua chunk: .config/nvim/plugin/editing.tl:41: attempt to concatenate a nil value
```

Line 41: `opt.undodir = os.getenv("HOME") .. "/.config/nvim/undodir"`

## Test plan

- [x] Verified `os.getenv("HOME")` returns `nil` in current server
- [ ] Restart nvim server after fix and verify `HOME` is available
- [ ] Verify `nvim --remote-ui` works without config errors