### PR TITLE
unix: fix environ() type and usage

### DIFF
--- a/lib/box/github.tl
+++ b/lib/box/github.tl
@@ -21,24 +21,26 @@ local record GitHubHost
 end
 
 local function discover_hosts(): {GitHubHost}
-  local env = unix.environ()
   local hosts_by_name: {string:GitHubHost} = {}
 
-  for key, value in pairs(env) do
-    local name = key:match("^GH_(.+)_HOSTNAME$")
-    if name then
-      if not hosts_by_name[name] then
-        hosts_by_name[name] = {name = name}
+  for _, entry in ipairs(unix.environ()) do
+    local key, value = entry:match("^([^=]+)=(.*)$")
+    if key then
+      local name = key:match("^GH_(.+)_HOSTNAME$")
+      if name then
+        if not hosts_by_name[name] then
+          hosts_by_name[name] = {name = name}
+        end
+        hosts_by_name[name].hostname = value
       end
-      hosts_by_name[name].hostname = value
-    end
 
-    name = key:match("^GH_(.+)_TOKEN$")
-    if name then
-      if not hosts_by_name[name] then
-        hosts_by_name[name] = {name = name}
+      name = key:match("^GH_(.+)_TOKEN$")
+      if name then
+        if not hosts_by_name[name] then
+          hosts_by_name[name] = {name = name}
+        end
+        hosts_by_name[name].token = value
       end
-      hosts_by_name[name].token = value
     end
   end
 

--- a/lib/claude/main.tl
+++ b/lib/claude/main.tl
@@ -163,10 +163,9 @@ local function main(args: {string})
     end
   end
 
-  -- Convert environ map to array of "KEY=VALUE" strings for execve
   local env_array: {string} = {}
-  for key, value in pairs(unix.environ()) do
-    table.insert(env_array, key .. "=" .. value)
+  for _, entry in ipairs(unix.environ()) do
+    table.insert(env_array, entry)
   end
   unix.execve(claude_bin, execve_argv, env_array)
 

--- a/lib/nvim/main.tl
+++ b/lib/nvim/main.tl
@@ -31,8 +31,8 @@ end
 
 local function current_environ(): {string}
   local result: {string} = {}
-  for key, value in pairs(unix.environ()) do
-    table.insert(result, key .. "=" .. value)
+  for _, entry in ipairs(unix.environ()) do
+    table.insert(result, entry)
   end
   return result
 end
@@ -145,8 +145,11 @@ end
 
 local function setup_nvim_environment(nvim_bin: string): {string}
   local env_table: {string:string} = {}
-  for key, value in pairs(unix.environ()) do
-    env_table[key] = value
+  for _, entry in ipairs(unix.environ()) do
+    local key, value = entry:match("^([^=]+)=(.*)$")
+    if key then
+      env_table[key] = value
+    end
   end
   env_table["NVIM_SERVER_MODE"] = "1"
   env_table["WHEREAMI"] = whereami.get_with_emoji()

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -57,7 +57,7 @@ local record unix
   stat: function(path: string, flags?: number): Stat
 
   -- environment
-  environ: function(): {string:string}
+  environ: function(): {string}
   setenv: function(name: string, value: string): boolean
   unsetenv: function(name: string): boolean
   commandv: function(cmd: string): string


### PR DESCRIPTION
## Summary

- Fix `unix.environ()` type definition from `{string:string}` back to `{string}`
- Fix all code that was changed to use the incorrect map iteration pattern

`unix.environ()` returns an array of `"KEY=VALUE"` strings, not a map. Commit 5a58747d incorrectly changed the type definition and then "fixed" code to match the wrong type.

This caused execve calls to pass malformed environment arrays like `"1=HOME=/home/user"` instead of `"HOME=/home/user"`, breaking `$HOME` and other environment variables in child processes.

## Test plan

- [x] `make teal` passes (127 passed, 0 failed)
- [x] `~/.local/bin/claude --version` works