### PR TITLE
box: run backend bootstrap on remote, load env.d in claude wrapper

### DIFF
--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -330,14 +330,6 @@ local function cmd_list(be: backend.Backend): boolean, string
   return true
 end
 
-local function cmd_backend_bootstrap(be: backend.Backend, name: string)
-  -- Call optional backend-specific bootstrap (ignore errors)
-  if be.bootstrap then
-    io.stderr:write("==> running backend bootstrap\n")
-    be.bootstrap(name)
-  end
-end
-
 local function cmd_scp(be: backend.Backend, name: string, src: string, dst: string): boolean, string
   if not src or not dst then
     return false, "scp requires source and destination arguments"
@@ -439,7 +431,6 @@ local function main(args: {string}): integer, string
   elseif parsed.cmd == "run" then
     ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.repo, parsed.release)
     if not ok then return 1, err end
-    cmd_backend_bootstrap(be, parsed.name)
     return 0
   elseif parsed.cmd == "ssh" then
     ok, err = cmd_ssh(be, parsed.name, parsed.extra_args)
@@ -463,7 +454,6 @@ local function main(args: {string}): integer, string
       if not ok then return 1, err end
       ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.repo, parsed.release)
       if not ok then return 1, err end
-      cmd_backend_bootstrap(be, parsed.name)
     end
     -- SSH to the box
     ok, err = cmd_ssh(be, parsed.name, parsed.extra_args)

--- a/lib/box/run.tl
+++ b/lib/box/run.tl
@@ -120,6 +120,17 @@ local function write_box_info(name: string, kind: string): boolean, string
   return true
 end
 
+local backend = require("box.backend")
+
+local function load_backend(kind: string): backend.Backend
+  if kind == "sprite" then
+    return require("box.sprite") as backend.Backend
+  elseif kind == "mac" then
+    return require("box.mac") as backend.Backend
+  end
+  return nil
+end
+
 local function bootstrap(env_vars: {string:string}, name: string, kind: string): integer, string
   io.stderr:write("==> running bootstrap\n")
 
@@ -144,6 +155,18 @@ local function bootstrap(env_vars: {string:string}, name: string, kind: string):
   ok, err = run_bootstrap()
   if not ok then
     return 1, err or "bootstrap failed"
+  end
+
+  -- Step 2: Run backend-specific bootstrap (installs claude, configures credentials)
+  if kind and kind ~= "" then
+    local be = load_backend(kind)
+    if be and be.bootstrap then
+      io.stderr:write("==> running backend bootstrap\n")
+      local result = be.bootstrap(name)
+      if not result.ok then
+        return 1, result.err or "backend bootstrap failed"
+      end
+    end
   end
 
   io.stderr:write("==> bootstrap complete\n")

--- a/lib/claude/main.tl
+++ b/lib/claude/main.tl
@@ -18,6 +18,46 @@ local function debug_log(msg: string)
   end
 end
 
+local function load_box_env()
+  local HOME = os.getenv("HOME")
+  if not HOME then return end
+
+  local env_dir = path.join(HOME, ".config", "box", "env.d")
+  local handle = unix.opendir(env_dir) as DirHandle
+  if not handle then return end
+
+  -- Collect and sort entries
+  local entries: {string} = {}
+  while true do
+    local name = handle:read()
+    if not name then break end
+    if name ~= "." and name ~= ".." then
+      table.insert(entries, name)
+    end
+  end
+  handle:close()
+  table.sort(entries)
+
+  -- Read each file and set env vars
+  for _, entry in ipairs(entries) do
+    local filepath = path.join(env_dir, entry)
+    local f = io.open(filepath, "r")
+    if f then
+      for line in f:lines() do
+        local trimmed = line:match("^%s*(.-)%s*$")
+        if trimmed ~= "" and not trimmed:match("^#") then
+          local key, value = trimmed:match("^([^=]+)=(.*)$")
+          if key and value then
+            unix.setenv(key, value)
+            debug_log("loaded " .. key .. " from " .. entry)
+          end
+        end
+      end
+      f:close()
+    end
+  end
+end
+
 local function find_claude_binary(paths: {string}): string
   for i = 1, #paths do
     local p = paths[i]
@@ -156,6 +196,8 @@ local function main(args: {string})
   debug_log("execve argv[1..]: " .. table.concat(argv, " "))
 
   if unix.stat("/.sprite") then
+    -- Load env vars from box env.d (contains CLAUDE_CODE_OAUTH_TOKEN etc)
+    load_box_env()
     local token = os.getenv("CLAUDE_CODE_OAUTH_TOKEN") or os.getenv("CLAUDE_TOKEN")
     if token then
       unix.setenv("CLAUDE_CODE_OAUTH_TOKEN", token)


### PR DESCRIPTION
## Summary
- Fix sprite backend not configuring Claude correctly on the remote
- Backend bootstrap (claude.install, claude.configure) was running locally instead of on the sprite
- Claude wrapper wasn't loading CLAUDE_CODE_OAUTH_TOKEN from ~/.config/box/env.d/

## Test plan
- [x] `box --backend sprite gamma zap && box --backend sprite gamma`
- [x] Verify "==> running backend bootstrap" and "installing claude..." appear
- [x] Verify `~/.local/share/claude/` is created on sprite
- [x] Verify `CLAUDE_WRAPPER_DEBUG=1 claude --help` shows env vars loaded from env.d