### PR TITLE
box: add hostname filter to github.configure

### DIFF
--- a/lib/box/github.tl
+++ b/lib/box/github.tl
@@ -75,10 +75,25 @@ local function auth_host(gh_bin: string, host: GitHubHost): boolean
   return true
 end
 
-local function configure(): boolean, string
+local function configure(hostnames: {string}): boolean, string
   local hosts = discover_hosts()
+
+  -- Filter to specific hostnames if provided
+  if hostnames then
+    local filtered: {GitHubHost} = {}
+    for _, host in ipairs(hosts) do
+      for _, allowed in ipairs(hostnames) do
+        if host.hostname == allowed then
+          table.insert(filtered, host)
+          break
+        end
+      end
+    end
+    hosts = filtered
+  end
+
   if #hosts == 0 then
-    return true -- no github config
+    return true -- no matching github config
   end
 
   local home = os.getenv("HOME")

--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -160,8 +160,8 @@ local function bootstrap(name: string): backend.Result
     return err(install_err or "claude install failed")
   end
 
-  -- Configure gh auth
-  local cfg_ok, cfg_err = github.configure()
+  -- Configure gh auth (github.com only)
+  local cfg_ok, cfg_err = github.configure({"github.com"})
   if not cfg_ok then
     return err(cfg_err or "github config failed")
   end


### PR DESCRIPTION
## Summary
- Add optional `hostnames` parameter to `github.configure()` that filters which GitHub hosts to authenticate
- When provided, only hosts matching the specified hostnames are configured
- Update sprite backend to pass `{"github.com"}` to configure only the public GitHub host

## Test plan
- [x] `make test` passes (unrelated pre-existing failure in `lib/home/test_versioned.tl`)