### PR TITLE
box: create instance if needed for run command

### DIFF
--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -449,6 +449,10 @@ local function main(args: {string}): integer, string
     if not ok then return 1, err end
     return 0
   elseif parsed.cmd == "run" then
+    if not be.exists(parsed.name) then
+      ok, err = cmd_new(be, parsed.name)
+      if not ok then return 1, err end
+    end
     ok, err = cmd_run(be, parsed.name, parsed.env_path, parsed.repo, parsed.release, parsed.prerelease)
     if not ok then return 1, err end
     return 0


### PR DESCRIPTION
## Summary
- Fix `box <name> run` failing when the instance doesn't exist
- Now creates the instance first if needed, matching the default ssh behavior

## Test plan
- [x] Tested with `./o/bin/box --backend sprite alpha run` on non-existent instance