### PR TITLE
box: pass stdin through in sprite exec

### DIFF
--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -53,8 +53,10 @@ local function ssh(name: string, ...: string): backend.Result
 end
 
 local function exec(name: string, cmd: string): backend.Result
+  -- stdin required to avoid exit 255 from sprite exec
   local handle = spawn({"sprite", "exec", "-s", name, "--", "bash", "-c", cmd}, {
-    stdout = 1,  -- pass through to terminal
+    stdin = 0,
+    stdout = 1,
     stderr = 2,
   })
   if not handle then


### PR DESCRIPTION
## Summary
- Pass stdin through in sprite exec to fix exit 255 errors during bootstrap

## Test plan
- [x] Tested full bootstrap with `box --backend sprite alpha zap && box --backend sprite alpha run`