### PR TITLE
box: add generic backend bootstrap support via bootstrap-remote

### DIFF
--- a/lib/box/backend.tl
+++ b/lib/box/backend.tl
@@ -15,7 +15,8 @@ local record Backend
   destroy: function(name: string): Result
   list: function(): Result
   exists: function(name: string): boolean  -- check if box exists
-  bootstrap: function(name: string): Result  -- optional, called after generic bootstrap
+  bootstrap: function(name: string): Result  -- optional, called after generic bootstrap on remote
+  bootstrap_remote_script: function(name: string): string, string  -- optional, returns script to run on remote
 end
 
 local record Git

--- a/lib/box/backend.tl
+++ b/lib/box/backend.tl
@@ -15,7 +15,6 @@ local record Backend
   destroy: function(name: string): Result
   list: function(): Result
   exists: function(name: string): boolean  -- check if box exists
-  bootstrap: function(name: string): Result  -- optional, called after generic bootstrap on remote
   bootstrap_remote_script: function(name: string): string, string  -- optional, returns script to run on remote
 end
 

--- a/lib/box/example-backend
+++ b/lib/box/example-backend
@@ -10,9 +10,15 @@
 #   download <name> <src> <dst> - Download file from box
 #   destroy <name>           - Destroy box
 #   list                     - List all boxes
+#   bootstrap-remote <name>  - (Optional) Emit bootstrap script for remote execution
 #
 # Exit code 0 indicates success, non-zero indicates failure.
 # Error messages should be written to stderr.
+#
+# The bootstrap-remote subcommand should output a script (to stdout) with a shebang:
+#   - For shell scripts: #!/bin/sh or #!/bin/bash
+#   - For Lua scripts: #!/usr/bin/env lua (gets access to box modules)
+# If not implemented, the backend has no remote bootstrap behavior.
 
 set -u
 
@@ -122,9 +128,64 @@ case "$cmd" in
     exit 0
     ;;
 
+  bootstrap-remote)
+    name="${1:-}"
+    if [[ -z "$name" ]]; then
+      echo "error: bootstrap-remote requires box name" >&2
+      exit 1
+    fi
+    # Emit bootstrap script to stdout
+    # The script can be shell or Lua (shebang determines execution)
+
+    # Example 1: Shell script
+    cat <<'EOF'
+#!/bin/bash
+# Remote bootstrap script for example-backend
+set -euo pipefail
+
+echo "Running example backend bootstrap on remote" >&2
+
+# Example: Install custom tools
+# sudo apt-get update && sudo apt-get install -y custom-tool
+
+# Example: Configure environment
+# mkdir -p ~/.config/myapp
+# echo "config=value" > ~/.config/myapp/config
+
+echo "Bootstrap complete" >&2
+EOF
+
+    # Example 2: Lua script (commented out)
+    # Uncomment to use Lua with access to box modules:
+    # cat <<'EOF'
+# #!/usr/bin/env lua
+# -- Remote bootstrap script using Lua
+#
+# -- Has access to box modules: box.claude, box.github, box.git
+# local claude = require("box.claude")
+# local github = require("box.github")
+#
+# io.stderr:write("Installing claude...\n")
+# local ok, err = claude.install()
+# if not ok then
+#   error("claude install failed: " .. (err or "unknown"))
+# end
+#
+# io.stderr:write("Configuring github...\n")
+# ok, err = github.configure()
+# if not ok then
+#   error("github config failed: " .. (err or "unknown"))
+# end
+#
+# io.stderr:write("Bootstrap complete\n")
+# EOF
+
+    exit 0
+    ;;
+
   *)
     echo "error: unknown command: $cmd" >&2
-    echo "usage: $0 {new|ssh|exec|upload|download|destroy|list}" >&2
+    echo "usage: $0 {new|ssh|exec|upload|download|destroy|list|bootstrap-remote}" >&2
     exit 1
     ;;
 esac

--- a/lib/box/example-backend
+++ b/lib/box/example-backend
@@ -17,7 +17,7 @@
 #
 # The bootstrap-remote subcommand should output a script (to stdout) with a shebang:
 #   - For shell scripts: #!/bin/sh or #!/bin/bash
-#   - For Lua scripts: #!/usr/bin/env lua (gets access to box modules)
+#   - For Lua scripts with box modules: #!/usr/bin/env box
 # If not implemented, the backend has no remote bootstrap behavior.
 
 set -u
@@ -158,8 +158,8 @@ EOF
     # Example 2: Lua script (commented out)
     # Uncomment to use Lua with access to box modules:
     # cat <<'EOF'
-# #!/usr/bin/env lua
-# -- Remote bootstrap script using Lua
+# #!/usr/bin/env box
+# -- Remote bootstrap script using Lua with box modules
 #
 # -- Has access to box modules: box.claude, box.github, box.git
 # local claude = require("box.claude")

--- a/lib/box/generic.tl
+++ b/lib/box/generic.tl
@@ -107,8 +107,28 @@ local function exists(self: Generic, name: string): boolean
   return result.ok
 end
 
-local function bootstrap(self: Generic, name: string): backend.Result
-  return exec_backend(self.exe, "bootstrap", {name}, true)
+-- Get bootstrap script from backend for remote execution
+-- Returns: script_content, error
+local function get_bootstrap_script(exe: string, name: string): string, string
+  local handle = spawn({exe, "bootstrap-remote", name})
+  if not handle then
+    return nil, "failed to spawn: " .. exe
+  end
+
+  local read_ok, content = handle:read()
+  local exit_code = handle:wait()
+
+  if exit_code ~= 0 then
+    -- Not an error if bootstrap-remote isn't implemented
+    -- Just means this backend doesn't support remote bootstrap
+    return nil, nil
+  end
+
+  if not read_ok or not content then
+    return nil, "failed to read bootstrap script"
+  end
+
+  return content as string, nil
 end
 
 local function load(exe_path: string): backend.Backend, string
@@ -150,7 +170,8 @@ local function load(exe_path: string): backend.Backend, string
     destroy = function(name: string): backend.Result return destroy(g, name) end,
     list = function(): backend.Result return list(g) end,
     exists = function(name: string): boolean return exists(g, name) end,
-    bootstrap = function(name: string): backend.Result return bootstrap(g, name) end,
+    -- Return bootstrap script for remote execution
+    bootstrap_remote_script = function(name: string): string, string return get_bootstrap_script(g.exe, name) end,
   } as backend.Backend, nil
 end
 

--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -265,6 +265,23 @@ local function cmd_run(be: backend.Backend, name: string, env_dir: string, repo:
     return false, "failed to rename env directory"
   end
 
+  -- Get bootstrap script from backend if available
+  if be.bootstrap_remote_script then
+    io.stderr:write("==> getting bootstrap script from backend\n")
+    local script, script_err = be.bootstrap_remote_script(name)
+    if script_err then
+      cleanup()
+      return false, "failed to get bootstrap script: " .. script_err
+    end
+    if script and #script > 0 then
+      local bootstrap_file = path.join(tmpdir, "bootstrap.sh")
+      if not cosmo.Barf(bootstrap_file, script, tonumber("755", 8)) then
+        cleanup()
+        return false, "failed to write bootstrap script"
+      end
+    end
+  end
+
   -- Extract bundled zip tool to temp
   local zip_data = cosmo.Slurp("/zip/zip")
   if not zip_data then
@@ -284,14 +301,20 @@ local function cmd_run(be: backend.Backend, name: string, env_dir: string, repo:
     return false, "failed to copy box"
   end
 
-  -- Zip env.d directory into the box binary copy
+  -- Zip env.d directory and bootstrap script (if present) into the box binary copy
   -- Must chdir since spawn doesn't support cwd option
   local orig_dir = unix.getcwd()
   if not unix.chdir(tmpdir) then
     cleanup()
     return false, "failed to chdir to temp directory"
   end
-  local handle = spawn({tmp_zip, "-qr", tmp_box, "env.d"})
+  local zip_args = {tmp_zip, "-qr", tmp_box, "env.d"}
+  -- Add bootstrap.sh to zip if it exists
+  local bootstrap_file = path.join(tmpdir, "bootstrap.sh")
+  if unix.stat(bootstrap_file) then
+    table.insert(zip_args, "bootstrap.sh")
+  end
+  local handle = spawn(zip_args)
   local exit_code: number = -1
   if handle then
     exit_code = handle:wait()

--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -427,6 +427,48 @@ local function cmd_local_run(name: string, kind: string): integer, string
 end
 
 local function main(args: {string}): integer, string
+  -- Check if being invoked as interpreter (e.g., #!/usr/bin/env box script.lua)
+  -- This happens when first arg is a file path that exists
+  if #args > 0 then
+    local first_arg = args[1]
+    -- Not a flag and not a known command
+    if not first_arg:match("^%-%-") and first_arg ~= "list" then
+      local stat = unix.stat(first_arg)
+      if stat and unix.S_ISREG(stat:mode()) then
+        -- Execute as Lua script
+        local script_content = cosmo.Slurp(first_arg)
+        if not script_content then
+          return 1, "failed to read script: " .. first_arg
+        end
+
+        -- Strip shebang if present
+        if script_content:match("^#!") then
+          script_content = script_content:gsub("^#![^\n]*\n", "")
+        end
+
+        -- Set up arg array for the script (remove script path, keep remaining args)
+        local script_args = {}
+        for i = 2, #args do
+          script_args[i - 1] = args[i]
+        end
+        _G.arg = script_args
+
+        -- Load and execute the script
+        local chunk, load_err = load(script_content, "@" .. first_arg)
+        if not chunk then
+          return 1, "failed to load script: " .. (load_err or "unknown")
+        end
+
+        local ok, run_err = pcall(chunk)
+        if not ok then
+          return 1, "script failed: " .. tostring(run_err)
+        end
+
+        return 0
+      end
+    end
+  end
+
   local parsed, err = parse_args(args)
   if not parsed then
     return 1, err

--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -274,7 +274,7 @@ local function cmd_run(be: backend.Backend, name: string, env_dir: string, repo:
       return false, "failed to get bootstrap script: " .. script_err
     end
     if script and #script > 0 then
-      local bootstrap_file = path.join(tmpdir, "bootstrap.sh")
+      local bootstrap_file = path.join(tmpdir, "bootstrap")
       if not cosmo.Barf(bootstrap_file, script, tonumber("755", 8)) then
         cleanup()
         return false, "failed to write bootstrap script"
@@ -309,10 +309,10 @@ local function cmd_run(be: backend.Backend, name: string, env_dir: string, repo:
     return false, "failed to chdir to temp directory"
   end
   local zip_args = {tmp_zip, "-qr", tmp_box, "env.d"}
-  -- Add bootstrap.sh to zip if it exists
-  local bootstrap_file = path.join(tmpdir, "bootstrap.sh")
+  -- Add bootstrap to zip if it exists
+  local bootstrap_file = path.join(tmpdir, "bootstrap")
   if unix.stat(bootstrap_file) then
-    table.insert(zip_args, "bootstrap.sh")
+    table.insert(zip_args, "bootstrap")
   end
   local handle = spawn(zip_args)
   local exit_code: number = -1

--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -427,46 +427,43 @@ local function cmd_local_run(name: string, kind: string): integer, string
 end
 
 local function main(args: {string}): integer, string
-  -- Check if being invoked as interpreter (e.g., #!/usr/bin/env box script.lua)
-  -- This happens when first arg is a file path that exists
-  if #args > 0 then
-    local first_arg = args[1]
-    -- Not a flag and not a known command
-    if not first_arg:match("^%-%-") and first_arg ~= "list" then
-      local stat = unix.stat(first_arg)
-      if stat and unix.S_ISREG(stat:mode()) then
-        -- Execute as Lua script
-        local script_content = cosmo.Slurp(first_arg)
-        if not script_content then
-          return 1, "failed to read script: " .. first_arg
-        end
-
-        -- Strip shebang if present
-        if script_content:match("^#!") then
-          script_content = script_content:gsub("^#![^\n]*\n", "")
-        end
-
-        -- Set up arg array for the script (remove script path, keep remaining args)
-        local script_args = {}
-        for i = 2, #args do
-          script_args[i - 1] = args[i]
-        end
-        _G.arg = script_args
-
-        -- Load and execute the script
-        local chunk, load_err = load(script_content, "@" .. first_arg)
-        if not chunk then
-          return 1, "failed to load script: " .. (load_err or "unknown")
-        end
-
-        local ok, run_err = pcall(chunk)
-        if not ok then
-          return 1, "script failed: " .. tostring(run_err)
-        end
-
-        return 0
-      end
+  -- Check if being invoked as interpreter via BOX_INTERPRETER_MODE env var
+  -- This is set when scripts use #!/usr/bin/env box as their shebang
+  if os.getenv("BOX_INTERPRETER_MODE") == "1" then
+    if #args == 0 then
+      return 1, "interpreter mode requires a script path"
     end
+
+    local script_path = args[1]
+    local script_content = cosmo.Slurp(script_path)
+    if not script_content then
+      return 1, "failed to read script: " .. script_path
+    end
+
+    -- Strip shebang if present
+    if script_content:match("^#!") then
+      script_content = script_content:gsub("^#![^\n]*\n", "")
+    end
+
+    -- Set up arg array for the script (remove script path, keep remaining args)
+    local script_args = {}
+    for i = 2, #args do
+      script_args[i - 1] = args[i]
+    end
+    _G.arg = script_args
+
+    -- Load and execute the script
+    local chunk, load_err = load(script_content, "@" .. script_path)
+    if not chunk then
+      return 1, "failed to load script: " .. (load_err or "unknown")
+    end
+
+    local ok, run_err = pcall(chunk)
+    if not ok then
+      return 1, "script failed: " .. tostring(run_err)
+    end
+
+    return 0
   end
 
   local parsed, err = parse_args(args)

--- a/lib/box/run.tl
+++ b/lib/box/run.tl
@@ -154,12 +154,12 @@ local function run_bootstrap_script(): boolean, string
     return false, "failed to create box symlink"
   end
 
-  -- Execute script with modified PATH using env command
+  -- Execute script with modified PATH and interpreter mode flag
   local spawn = require("cosmic.spawn")
   local old_path = os.getenv("PATH") or ""
   local new_path = tmpdir .. ":" .. old_path
 
-  local handle = spawn({"env", "PATH=" .. new_path, script_path}, {
+  local handle = spawn({"env", "PATH=" .. new_path, "BOX_INTERPRETER_MODE=1", script_path}, {
     stdout = 1,
     stderr = 2,
   })

--- a/lib/box/run.tl
+++ b/lib/box/run.tl
@@ -131,6 +131,57 @@ local function load_backend(kind: string): backend.Backend
   return nil
 end
 
+local function run_bootstrap_script(): boolean, string
+  local script_path = "/zip/bootstrap.sh"
+  local stat = unix.stat(script_path)
+  if not stat then
+    return true -- no script to run
+  end
+
+  -- Read script to detect shebang
+  local script_content = cosmo.Slurp(script_path)
+  if not script_content then
+    return false, "failed to read bootstrap script"
+  end
+
+  -- Check shebang to determine how to execute
+  local shebang = script_content:match("^#!([^\n]+)")
+  if not shebang then
+    return false, "bootstrap script missing shebang"
+  end
+
+  io.stderr:write("==> running generic backend bootstrap\n")
+
+  -- If shebang contains "lua", execute as Lua code
+  if shebang:match("lua") then
+    -- Execute as Lua with access to box modules
+    local chunk, load_err = load(script_content, "@/zip/bootstrap.sh")
+    if not chunk then
+      return false, "failed to load bootstrap script: " .. (load_err or "unknown")
+    end
+    local ok, run_err = pcall(chunk)
+    if not ok then
+      return false, "bootstrap script failed: " .. (run_err or "unknown")
+    end
+  else
+    -- Execute as shell script
+    local spawn = require("cosmic.spawn")
+    local handle = spawn({"/bin/sh", script_path}, {
+      stdout = 1,
+      stderr = 2,
+    })
+    if not handle then
+      return false, "failed to spawn bootstrap script"
+    end
+    local exit_code = handle:wait()
+    if exit_code ~= 0 then
+      return false, "bootstrap script failed with exit code " .. tostring(exit_code)
+    end
+  end
+
+  return true
+end
+
 local function bootstrap(env_vars: {string:string}, name: string, kind: string): integer, string
   io.stderr:write("==> running bootstrap\n")
 
@@ -165,6 +216,12 @@ local function bootstrap(env_vars: {string:string}, name: string, kind: string):
       local result = be.bootstrap(name)
       if not result.ok then
         return 1, result.err or "backend bootstrap failed"
+      end
+    elseif not be then
+      -- Backend couldn't be loaded (generic backend), try bundled script
+      ok, err = run_bootstrap_script()
+      if not ok then
+        return 1, err or "generic bootstrap script failed"
       end
     end
   end

--- a/lib/box/run.tl
+++ b/lib/box/run.tl
@@ -120,17 +120,6 @@ local function write_box_info(name: string, kind: string): boolean, string
   return true
 end
 
-local backend = require("box.backend")
-
-local function load_backend(kind: string): backend.Backend
-  if kind == "sprite" then
-    return require("box.sprite") as backend.Backend
-  elseif kind == "mac" then
-    return require("box.mac") as backend.Backend
-  end
-  return nil
-end
-
 local function run_bootstrap_script(): boolean, string
   local script_path = "/zip/bootstrap"
   local stat = unix.stat(script_path)
@@ -138,7 +127,7 @@ local function run_bootstrap_script(): boolean, string
     return true -- no script to run
   end
 
-  io.stderr:write("==> running generic backend bootstrap\n")
+  io.stderr:write("==> running backend bootstrap\n")
 
   -- Set up box in PATH so scripts can use #!/usr/bin/env box
   -- Create temp directory for box symlink
@@ -206,21 +195,10 @@ local function bootstrap(env_vars: {string:string}, name: string, kind: string):
   end
 
   -- Step 2: Run backend-specific bootstrap (installs claude, configures credentials)
-  if kind and kind ~= "" then
-    local be = load_backend(kind)
-    if be and be.bootstrap then
-      io.stderr:write("==> running backend bootstrap\n")
-      local result = be.bootstrap(name)
-      if not result.ok then
-        return 1, result.err or "backend bootstrap failed"
-      end
-    elseif not be then
-      -- Backend couldn't be loaded (generic backend), try bundled script
-      ok, err = run_bootstrap_script()
-      if not ok then
-        return 1, err or "generic bootstrap script failed"
-      end
-    end
+  -- All backends now use the bootstrap script approach
+  ok, err = run_bootstrap_script()
+  if not ok then
+    return 1, err or "bootstrap script failed"
   end
 
   io.stderr:write("==> bootstrap complete\n")

--- a/lib/box/run.tl
+++ b/lib/box/run.tl
@@ -132,51 +132,48 @@ local function load_backend(kind: string): backend.Backend
 end
 
 local function run_bootstrap_script(): boolean, string
-  local script_path = "/zip/bootstrap.sh"
+  local script_path = "/zip/bootstrap"
   local stat = unix.stat(script_path)
   if not stat then
     return true -- no script to run
   end
 
-  -- Read script to detect shebang
-  local script_content = cosmo.Slurp(script_path)
-  if not script_content then
-    return false, "failed to read bootstrap script"
-  end
-
-  -- Check shebang to determine how to execute
-  local shebang = script_content:match("^#!([^\n]+)")
-  if not shebang then
-    return false, "bootstrap script missing shebang"
-  end
-
   io.stderr:write("==> running generic backend bootstrap\n")
 
-  -- If shebang contains "lua", execute as Lua code
-  if shebang:match("lua") then
-    -- Execute as Lua with access to box modules
-    local chunk, load_err = load(script_content, "@/zip/bootstrap.sh")
-    if not chunk then
-      return false, "failed to load bootstrap script: " .. (load_err or "unknown")
-    end
-    local ok, run_err = pcall(chunk)
-    if not ok then
-      return false, "bootstrap script failed: " .. (run_err or "unknown")
-    end
-  else
-    -- Execute as shell script
-    local spawn = require("cosmic.spawn")
-    local handle = spawn({"/bin/sh", script_path}, {
-      stdout = 1,
-      stderr = 2,
-    })
-    if not handle then
-      return false, "failed to spawn bootstrap script"
-    end
-    local exit_code = handle:wait()
-    if exit_code ~= 0 then
-      return false, "bootstrap script failed with exit code " .. tostring(exit_code)
-    end
+  -- Set up box in PATH so scripts can use #!/usr/bin/env box
+  -- Create temp directory for box symlink
+  local tmpdir = unix.mkdtemp("/tmp/box-bootstrap-XXXXXX")
+  if not tmpdir then
+    return false, "failed to create temp directory for bootstrap"
+  end
+
+  -- Symlink /tmp/box to tmpdir/box
+  local box_link = path.join(tmpdir, "box")
+  if not unix.symlink("/tmp/box", box_link) then
+    unix.rmrf(tmpdir)
+    return false, "failed to create box symlink"
+  end
+
+  -- Execute script with modified PATH using env command
+  local spawn = require("cosmic.spawn")
+  local old_path = os.getenv("PATH") or ""
+  local new_path = tmpdir .. ":" .. old_path
+
+  local handle = spawn({"env", "PATH=" .. new_path, script_path}, {
+    stdout = 1,
+    stderr = 2,
+  })
+
+  if not handle then
+    unix.rmrf(tmpdir)
+    return false, "failed to spawn bootstrap script"
+  end
+
+  local exit_code = handle:wait()
+  unix.rmrf(tmpdir)
+
+  if exit_code ~= 0 then
+    return false, "bootstrap script failed with exit code " .. tostring(exit_code)
   end
 
   return true

--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -5,9 +5,6 @@ local spawn = require("cosmic.spawn")
 local cosmo = require("cosmo")
 
 local backend = require("box.backend")
-local claude = require("box.claude")
-local github = require("box.github")
-local git = require("box.git")
 
 local function ok(): backend.Result
   return {ok = true}
@@ -152,33 +149,41 @@ local function list(): backend.Result
   return err("failed to exec sprite list")
 end
 
-local function bootstrap(name: string): backend.Result
-  -- Install claude binary
-  io.stderr:write("installing claude...\n")
-  local install_ok, install_err = claude.install()
-  if not install_ok then
-    return err(install_err or "claude install failed")
-  end
+local function bootstrap_remote_script(name: string): string, string
+  -- Emit Lua script that runs on remote with box module access
+  return [[#!/usr/bin/env box
+-- Sprite backend bootstrap script
+-- Has access to box modules: box.claude, box.github, box.git
 
-  -- Configure gh auth
-  local cfg_ok, cfg_err = github.configure()
-  if not cfg_ok then
-    return err(cfg_err or "github config failed")
-  end
+local claude = require("box.claude")
+local github = require("box.github")
+local git = require("box.git")
 
-  -- Configure git identity
-  cfg_ok, cfg_err = git.configure()
-  if not cfg_ok then
-    return err(cfg_err or "git config failed")
-  end
+-- Install claude binary
+io.stderr:write("installing claude...\n")
+local ok, err = claude.install()
+if not ok then
+  error(err or "claude install failed")
+end
 
-  -- Configure claude credentials
-  cfg_ok, cfg_err = claude.configure()
-  if not cfg_ok then
-    return err(cfg_err or "claude config failed")
-  end
+-- Configure gh auth
+ok, err = github.configure()
+if not ok then
+  error(err or "github config failed")
+end
 
-  return ok()
+-- Configure git identity
+ok, err = git.configure()
+if not ok then
+  error(err or "git config failed")
+end
+
+-- Configure claude credentials
+ok, err = claude.configure()
+if not ok then
+  error(err or "claude config failed")
+end
+]], nil
 end
 
 return {
@@ -191,5 +196,5 @@ return {
   destroy = destroy,
   list = list,
   exists = exists,
-  bootstrap = bootstrap,
+  bootstrap_remote_script = bootstrap_remote_script,
 } as backend.Backend


### PR DESCRIPTION
Generic backends can now participate in remote bootstrapping by
implementing a bootstrap-remote subcommand that emits a script to stdout.

Flow:
1. Local: backend bootstrap-remote <name> outputs script with shebang
2. Local: box bundles script as /zip/bootstrap.sh in uploaded binary
3. Remote: box detects shebang and executes accordingly:
   - Shell shebang (#!/bin/bash, #!/bin/sh) -> run with /bin/sh
   - Lua shebang (#!/usr/bin/env lua) -> execute with Lua, has access
     to box modules (box.claude, box.github, box.git, etc.)

This allows external backends to:
- Install and configure tools on the remote
- Reuse existing box infrastructure for common tasks (claude install,
  github auth, etc.)
- Define backend-specific setup without modifying box source

Updated example-backend with both shell and Lua examples.