### PR TITLE
Improve SSH shell handling and use sh instead of bash

### DIFF
--- a/lib/box/example-backend
+++ b/lib/box/example-backend
@@ -46,8 +46,8 @@ case "$cmd" in
     # Connect to box via SSH - for demo, just echo
     echo "SSHing to box: $name with args: $*" >&2
     # In a real backend, you would:
-    # - If $1 is provided (user's preferred shell), exec ssh user@host "$1"
-    # - Otherwise, exec ssh user@host (uses default shell)
+    # - If $1 is provided (shell from box), exec ssh user@host "$1"
+    # - Otherwise, exec ssh user@host (uses remote default shell)
     # Note: use exec to replace this process with ssh
     exit 0
     ;;

--- a/lib/box/example-backend
+++ b/lib/box/example-backend
@@ -46,7 +46,8 @@ case "$cmd" in
     # Connect to box via SSH - for demo, just echo
     echo "SSHing to box: $name with args: $*" >&2
     # In a real backend, you would:
-    # - exec ssh user@host "$@"
+    # - If $1 is provided (user's preferred shell), exec ssh user@host "$1"
+    # - Otherwise, exec ssh user@host (uses default shell)
     # Note: use exec to replace this process with ssh
     exit 0
     ;;

--- a/lib/box/example-backend
+++ b/lib/box/example-backend
@@ -61,7 +61,7 @@ case "$cmd" in
     # Execute command on box - for demo, just echo
     echo "Executing on $name: $cmd_to_run" >&2
     # In a real backend, you would:
-    # - ssh user@host -- bash -c "$cmd_to_run"
+    # - ssh user@host -- sh -c "$cmd_to_run"
     # - Pass through stdout/stderr
     exit 0
     ;;

--- a/lib/box/example-backend
+++ b/lib/box/example-backend
@@ -62,7 +62,7 @@ case "$cmd" in
     # Execute command on box - for demo, just echo
     echo "Executing on $name: $cmd_to_run" >&2
     # In a real backend, you would:
-    # - ssh user@host -- sh -c "$cmd_to_run"
+    # - ssh user@host -- bash -c "$cmd_to_run"
     # - Pass through stdout/stderr
     exit 0
     ;;

--- a/lib/box/generic.tl
+++ b/lib/box/generic.tl
@@ -73,17 +73,8 @@ end
 local function ssh(self: Generic, name: string, ...: string): backend.Result
   local cmd = {self.exe, "ssh", name}
   local extra = {...}
-
-  -- If no command specified, use user's preferred shell from $SHELL
-  if #extra == 0 then
-    local shell = os.getenv("SHELL")
-    if shell then
-      cmd[#cmd + 1] = shell
-    end
-  else
-    for i = 1, #extra do
-      cmd[#cmd + 1] = extra[i]
-    end
+  for i = 1, #extra do
+    cmd[#cmd + 1] = extra[i]
   end
 
   -- ssh is interactive, use execvp for full passthrough

--- a/lib/box/generic.tl
+++ b/lib/box/generic.tl
@@ -73,8 +73,17 @@ end
 local function ssh(self: Generic, name: string, ...: string): backend.Result
   local cmd = {self.exe, "ssh", name}
   local extra = {...}
-  for i = 1, #extra do
-    cmd[#cmd + 1] = extra[i]
+
+  -- If no command specified, use user's preferred shell from $SHELL
+  if #extra == 0 then
+    local shell = os.getenv("SHELL")
+    if shell then
+      cmd[#cmd + 1] = shell
+    end
+  else
+    for i = 1, #extra do
+      cmd[#cmd + 1] = extra[i]
+    end
   end
 
   -- ssh is interactive, use execvp for full passthrough

--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -326,7 +326,17 @@ end
 
 local function cmd_ssh(be: backend.Backend, name: string, extra_args: {string}): boolean, string
   io.stderr:write("==> connecting to " .. name .. "\n")
-  local result = be.ssh(name, table.unpack(extra_args))
+
+  -- If no command specified, use user's preferred shell from $SHELL
+  local args = extra_args
+  if #extra_args == 0 then
+    local shell = os.getenv("SHELL")
+    if shell then
+      args = {shell}
+    end
+  end
+
+  local result = be.ssh(name, table.unpack(args))
   if not result.ok then
     return false, result.err or "unknown error"
   end

--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -43,9 +43,19 @@ end
 
 local function ssh(name: string, ...: string): backend.Result
   local args = {"sprite", "console", "-s", name}
-  for i = 1, select("#", ...) do
-    local a = select(i, ...)
-    table.insert(args, a)
+  local extra_args = {...}
+
+  -- If no command specified, use user's preferred shell from $SHELL
+  if #extra_args == 0 then
+    local shell = os.getenv("SHELL")
+    if shell then
+      table.insert(args, "--")
+      table.insert(args, shell)
+    end
+  else
+    for i = 1, #extra_args do
+      table.insert(args, extra_args[i])
+    end
   end
 
   unix.execvp("sprite", args)

--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -45,14 +45,8 @@ local function ssh(name: string, ...: string): backend.Result
   local args = {"sprite", "console", "-s", name}
   local extra_args = {...}
 
-  -- If no command specified, use user's preferred shell from $SHELL
-  if #extra_args == 0 then
-    local shell = os.getenv("SHELL")
-    if shell then
-      table.insert(args, "--")
-      table.insert(args, shell)
-    end
-  else
+  if #extra_args > 0 then
+    table.insert(args, "--")
     for i = 1, #extra_args do
       table.insert(args, extra_args[i])
     end

--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -58,7 +58,7 @@ end
 
 local function exec(name: string, cmd: string): backend.Result
   -- stdin required to avoid exit 255 from sprite exec
-  local handle = spawn({"sprite", "exec", "-s", name, "--", "sh", "-c", cmd}, {
+  local handle = spawn({"sprite", "exec", "-s", name, "--", "bash", "-c", cmd}, {
     stdin = 0,
     stdout = 1,
     stderr = 2,
@@ -76,7 +76,7 @@ end
 local function upload(name: string, src: string, dst: string): backend.Result
   -- sprite -file doesn't handle relative paths correctly, resolve to absolute
   if not dst:match("^/") then
-    local home_handle = spawn({"sprite", "exec", "-s", name, "--", "sh", "-c", "echo $HOME"})
+    local home_handle = spawn({"sprite", "exec", "-s", name, "--", "bash", "-c", "echo $HOME"})
     if not home_handle then
       return err("sprite binary not found")
     end

--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -54,7 +54,7 @@ end
 
 local function exec(name: string, cmd: string): backend.Result
   -- stdin required to avoid exit 255 from sprite exec
-  local handle = spawn({"sprite", "exec", "-s", name, "--", "bash", "-c", cmd}, {
+  local handle = spawn({"sprite", "exec", "-s", name, "--", "sh", "-c", cmd}, {
     stdin = 0,
     stdout = 1,
     stderr = 2,
@@ -72,7 +72,7 @@ end
 local function upload(name: string, src: string, dst: string): backend.Result
   -- sprite -file doesn't handle relative paths correctly, resolve to absolute
   if not dst:match("^/") then
-    local home_handle = spawn({"sprite", "exec", "-s", name, "--", "bash", "-c", "echo $HOME"})
+    local home_handle = spawn({"sprite", "exec", "-s", name, "--", "sh", "-c", "echo $HOME"})
     if not home_handle then
       return err("sprite binary not found")
     end


### PR DESCRIPTION
## Summary
This PR improves SSH shell handling in the box backend and standardizes on using `sh` instead of `bash` for better portability across different systems.

## Key Changes

- **SSH shell preference**: When connecting to a box without specifying a command, the SSH connection now respects the user's `$SHELL` environment variable instead of relying solely on the remote default shell
- **Shell standardization**: Replaced all `bash` invocations with `sh` for better compatibility across systems that may not have bash installed
- **SSH argument handling**: Improved the sprite SSH backend to properly handle optional command arguments by only adding the `--` separator when extra arguments are provided
- **Documentation updates**: Clarified in example-backend comments that the SSH command behavior differs based on whether a shell argument is provided

## Implementation Details

- In `init.tl`, the `cmd_ssh` function now checks if extra arguments are provided, and if not, uses the `$SHELL` environment variable to establish a shell session
- In `sprite.tl`, the `ssh` function was refactored to build the argument list more cleanly and only include the `--` separator when needed
- All `bash -c` invocations in `sprite.tl` were changed to `sh -c` for consistency and portability