### PR TITLE
Make Bun and Clasp test dependencies optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,13 @@ include 3p/nvim-parsers/cook.mk
 include 3p/nvim/cook.mk
 include 3p/cosmic/cook.mk
 
+ifdef TEST_BUN
 include 3p/bun/cook.mk
+endif
+
+ifdef TEST_CLASP
 include 3p/clasp/cook.mk
+endif
 
 include cook.mk
 

--- a/lib/cook.mk
+++ b/lib/cook.mk
@@ -24,7 +24,11 @@ o/teal/lib/%.lua: lib/%.tl $(types_files) | $(bootstrap_files)
 	@$(bootstrap_cosmic) /zip/tl-gen.lua $< -o $@
 
 include lib/aerosnap/cook.mk
+ifdef TEST_BUN
+ifdef TEST_CLASP
 include lib/appscript/cook.mk
+endif
+endif
 include lib/box/cook.mk
 include lib/build/cook.mk
 include lib/checker/cook.mk


### PR DESCRIPTION
## Summary
This change makes the Bun and Clasp test dependencies optional by conditionally including their build recipes only when explicitly enabled via `TEST_BUN` and `TEST_CLASP` flags.

## Key Changes
- Wrapped `3p/bun/cook.mk` inclusion in `ifdef TEST_BUN` guard in root Makefile
- Wrapped `3p/clasp/cook.mk` inclusion in `ifdef TEST_CLASP` guard in root Makefile
- Wrapped `lib/appscript/cook.mk` inclusion in both `ifdef TEST_BUN` and `ifdef TEST_CLASP` guards in lib/cook.mk (since appscript depends on both)

## Details
The appscript library appears to have dependencies on both Bun and Clasp, so its inclusion is now guarded by both flags. This allows developers and CI systems to skip building these optional test dependencies when not needed, reducing build time and complexity for users who don't require these specific tools.