### PR TITLE
box/sprite: use sprite exec for ssh with commands

### DIFF
--- a/lib/aerosnap/init.tl
+++ b/lib/aerosnap/init.tl
@@ -52,7 +52,7 @@ local function get_focused_window(): Window, string
   local handle = spawn({
     "aerospace", "list-windows", "--focused",
     "--format", "%{window-id}\t%{app-bundle-id}\t%{app-name}\t%{workspace}\t%{window-title}"
-  })
+  }, {env = unix.environ()})
   if not handle then return nil, "failed to get focused window" end
   local _, output = handle:read()
   if not output or output == "" then
@@ -77,7 +77,7 @@ local function get_all_windows(): {Window}, string
   local handle = spawn({
     "aerospace", "list-windows", "--all",
     "--format", "%{window-id}\t%{app-bundle-id}\t%{app-name}\t%{workspace}\t%{window-title}"
-  })
+  }, {env = unix.environ()})
   if not handle then return nil, "failed to get windows" end
   local _, output = handle:read()
   if not output or output == "" then
@@ -180,7 +180,7 @@ local function cmd_load(_args: {string}): number
 
     if target_workspace and target_workspace ~= win.workspace then
       spawn({"aerospace", "move-node-to-workspace", target_workspace,
-             "--window-id", tostring(win["window-id"])}):wait()
+             "--window-id", tostring(win["window-id"])}, {env = unix.environ()}):wait()
       moved = moved + 1
       io.write(string.format("moved (%s): %s '%s' -> %s\n",
         match_type,

--- a/lib/box/git.tl
+++ b/lib/box/git.tl
@@ -1,14 +1,17 @@
 -- box/git.tl: configure git identity
 
+local unix = require("cosmo.unix")
 local spawn = require("cosmic.spawn")
 
 local function configure(): boolean, string
   local name = os.getenv("GIT_NAME")
   local email = os.getenv("GIT_EMAIL")
 
+  local env = unix.environ()
+
   if name then
     io.stderr:write("configuring git user.name...\n")
-    local handle = spawn({"git", "config", "--global", "user.name", name})
+    local handle = spawn({"git", "config", "--global", "user.name", name}, {env = env})
     local exit_code = handle:wait()
     if exit_code ~= 0 then
       io.stderr:write("warning: git config user.name failed (exit " .. tostring(exit_code) .. ")\n")
@@ -17,7 +20,7 @@ local function configure(): boolean, string
 
   if email then
     io.stderr:write("configuring git user.email...\n")
-    local handle = spawn({"git", "config", "--global", "user.email", email})
+    local handle = spawn({"git", "config", "--global", "user.email", email}, {env = env})
     local exit_code = handle:wait()
     if exit_code ~= 0 then
       io.stderr:write("warning: git config user.email failed (exit " .. tostring(exit_code) .. ")\n")

--- a/lib/box/github.tl
+++ b/lib/box/github.tl
@@ -59,7 +59,7 @@ local function auth_host(gh_bin: string, host: GitHubHost): boolean
   io.stderr:write("configuring gh auth for " .. host.hostname .. "...\n")
 
   local args: {string} = {gh_bin, "auth", "login", "-h", host.hostname, "--with-token"}
-  local handle = spawn(args)
+  local handle = spawn(args, {env = unix.environ()})
 
   if handle.stdin then
     handle.stdin:write(host.token .. "\n")

--- a/lib/box/init.tl
+++ b/lib/box/init.tl
@@ -327,16 +327,7 @@ end
 local function cmd_ssh(be: backend.Backend, name: string, extra_args: {string}): boolean, string
   io.stderr:write("==> connecting to " .. name .. "\n")
 
-  -- If no command specified, use user's preferred shell from $SHELL
-  local args = extra_args
-  if #extra_args == 0 then
-    local shell = os.getenv("SHELL")
-    if shell then
-      args = {shell}
-    end
-  end
-
-  local result = be.ssh(name, table.unpack(args))
+  local result = be.ssh(name, table.unpack(extra_args))
   if not result.ok then
     return false, result.err or "unknown error"
   end

--- a/lib/box/sprite.tl
+++ b/lib/box/sprite.tl
@@ -53,18 +53,33 @@ local function new(name: string, ...: string): backend.Result
 end
 
 local function ssh(name: string, ...: string): backend.Result
-  local args = {"sprite", "console", "-s", name}
   local extra_args = {...}
 
-  if #extra_args > 0 then
-    table.insert(args, "--")
-    for i = 1, #extra_args do
-      table.insert(args, extra_args[i])
-    end
+  if #extra_args == 0 then
+    -- Interactive shell - sprite console handles shell detection via $SHELL
+    unix.execvp("sprite", {"sprite", "console", "-s", name})
+    return err("failed to exec sprite console")
   end
 
-  unix.execvp("sprite", args)
-  return err("failed to exec sprite console")
+  -- Run specific command
+  local args = {"sprite", "exec", "-s", name, "--"}
+  for i = 1, #extra_args do
+    table.insert(args, extra_args[i])
+  end
+  local handle = spawn(args, {
+    env = sprite_env(),
+    stdin = 0,
+    stdout = 1,
+    stderr = 2,
+  })
+  if not handle then
+    return err("sprite binary not found")
+  end
+  local exit_code = handle:wait()
+  if exit_code ~= 0 then
+    return err("command failed: exit " .. tostring(exit_code))
+  end
+  return ok()
 end
 
 local function exec(name: string, cmd: string): backend.Result

--- a/lib/build/build-stage.tl
+++ b/lib/build/build-stage.tl
@@ -88,7 +88,7 @@ end
 
 local function extract_zip(archive: string, dest_dir: string, strip: number): boolean, string
   local temp_dir = unix.mkdtemp(path.join(path.dirname(dest_dir), ".stage_XXXXXX"))
-  local handle = spawn({"/usr/bin/unzip", "-o", "-q", "-d", temp_dir, archive})
+  local handle = spawn({"/usr/bin/unzip", "-o", "-q", "-d", temp_dir, archive}, {env = unix.environ()})
   local exit_code = handle:wait()
   if exit_code ~= 0 then
     unix.rmrf(temp_dir)
@@ -101,7 +101,7 @@ end
 
 local function extract_targz(archive: string, dest_dir: string, strip: number): boolean, string
   local temp_dir = unix.mkdtemp(path.join(path.dirname(dest_dir), ".stage_XXXXXX"))
-  local handle = spawn({"tar", "-xzf", archive, "-C", temp_dir})
+  local handle = spawn({"tar", "-xzf", archive, "-C", temp_dir}, {env = unix.environ()})
   local exit_code = handle:wait()
   if exit_code ~= 0 then
     unix.rmrf(temp_dir)
@@ -135,7 +135,7 @@ local function extract_gz(archive: string, dest_dir: string, module_name: string
   local bin_dir = path.join(dest_dir, "bin")
   unix.makedirs(bin_dir)
   local dest = path.join(bin_dir, module_name)
-  local handle = spawn({"gunzip", "-c", archive})
+  local handle = spawn({"gunzip", "-c", archive}, {env = unix.environ()})
   local exit_code, content = handle:read()
   if not exit_code then
     return nil, "gunzip failed: " .. tostring(content)

--- a/lib/home/mac/init.tl
+++ b/lib/home/mac/init.tl
@@ -1,3 +1,4 @@
+local unix = require("cosmo.unix")
 local spawn = require("cosmic.spawn")
 
 local record M
@@ -11,19 +12,19 @@ local record M
 end
 
 function M.defaults(...: string): boolean
-	return spawn({"defaults", ...}):wait() == 0
+	return spawn({"defaults", ...}, {env = unix.environ()}):wait() == 0
 end
 
 function M.defaults_current_host(...: string): boolean
-	return spawn({"defaults", "-currentHost", ...}):wait() == 0
+	return spawn({"defaults", "-currentHost", ...}, {env = unix.environ()}):wait() == 0
 end
 
 function M.killall(name: string)
-	spawn({"killall", name}):wait()
+	spawn({"killall", name}, {env = unix.environ()}):wait()
 end
 
 function M.osascript(script: string): boolean
-	return spawn({"osascript", "-e", script}):wait() == 0
+	return spawn({"osascript", "-e", script}, {env = unix.environ()}):wait() == 0
 end
 
 local record MacModule

--- a/lib/home/main.tl
+++ b/lib/home/main.tl
@@ -340,7 +340,7 @@ local function cmd_unpack(dest: string, force: boolean, opts: UnpackOpts): integ
     if force then
       table.insert(unzip_args, 2, "-o")
     end
-    local result = spawn(unzip_args):wait()
+    local result = spawn(unzip_args, {env = unix.environ()}):wait()
 
     -- Cleanup temp zip
     if zip_src:match("^/zip/") then unix.unlink(tmp_zip) end

--- a/lib/home/setup/ai.tl
+++ b/lib/home/setup/ai.tl
@@ -6,6 +6,7 @@ local env_module = require("setup.env")
 
 local function run(env: env_module.Env): number
 	unix.chdir(env.DST)
+	local e = unix.environ()
 
 	if not unix.stat("./ai") then
 		local remote_base = env.REMOTE:match("(.+)/[^/]+$")
@@ -15,18 +16,18 @@ local function run(env: env_module.Env): number
 
 		local devnull = unix.open("/dev/null", unix.O_RDWR)
 		local clone_url = path.join(remote_base, "ai")
-		local status = spawn({"git", "clone", clone_url, "./ai"}, {stdout = devnull, stderr = devnull}):wait()
+		local status = spawn({"git", "clone", clone_url, "./ai"}, {stdout = devnull, stderr = devnull, env = e}):wait()
 		unix.close(devnull)
 		if status ~= 0 then
 			return 0
 		end
 	else
 		unix.chdir("./ai")
-		spawn({"git", "fetch"}):wait()
+		spawn({"git", "fetch"}, {env = e}):wait()
 		unix.chdir(env.DST)
 	end
 
-	spawn({"claude", "plugin", "marketplace", "add", "./ai"}):wait()
+	spawn({"claude", "plugin", "marketplace", "add", "./ai"}, {env = e}):wait()
 
 	return 0
 end

--- a/lib/home/setup/env.tl
+++ b/lib/home/setup/env.tl
@@ -44,7 +44,7 @@ local function get(): Env
 
 	env.SHELLINIT = path.join(env.DST, ".config", "shellinit")
 
-	local ok, output = spawn({"git", "config", "--get", "remote.origin.url"}):read()
+	local ok, output = spawn({"git", "config", "--get", "remote.origin.url"}, {env = unix.environ()}):read()
 	if ok and output then
 		env.REMOTE = (output as string):gsub("%s+$", "")
 	else

--- a/lib/home/setup/extras.tl
+++ b/lib/home/setup/extras.tl
@@ -12,22 +12,23 @@ local function run(env: env_module.Env): number
 
 	local extras = path.join(remote_base, "extras")
 	unix.chdir(env.DST)
+	local e = unix.environ()
 
 	if not unix.stat("extras") then
 		local devnull = unix.open("/dev/null", unix.O_RDWR)
-		local status = spawn({"git", "clone", extras, "extras"}, {stdout = devnull, stderr = devnull}):wait()
+		local status = spawn({"git", "clone", extras, "extras"}, {stdout = devnull, stderr = devnull, env = e}):wait()
 		unix.close(devnull)
 		if status == 0 then
 			unix.chdir("extras")
 			if unix.stat("./setup.sh") and unix.access("./setup.sh", unix.X_OK) then
-				spawn({"./setup.sh"}):wait()
+				spawn({"./setup.sh"}, {env = e}):wait()
 			end
 		end
 	else
 		unix.chdir("./extras")
-		spawn({"git", "fetch"}):wait()
+		spawn({"git", "fetch"}, {env = e}):wait()
 		if unix.stat("./setup.sh") and unix.access("./setup.sh", unix.X_OK) then
-			spawn({"./setup.sh"}):wait()
+			spawn({"./setup.sh"}, {env = e}):wait()
 		end
 	end
 

--- a/lib/home/setup/git.tl
+++ b/lib/home/setup/git.tl
@@ -9,13 +9,14 @@ local function run(env: env_module.Env): number
 	unix.rmrf(path.join(env.DST, ".git"))
 	util.copy_tree(path.join(env.SRC, ".git"), path.join(env.DST, ".git"))
 	unix.chdir(env.DST)
-	spawn({"git", "checkout", "."}):wait()
-	spawn({"git", "config", "user.email", "189851+whilp@users.noreply.github.com"}):wait()
-	spawn({"git", "config", "core.fsmonitor", "false"}):wait()
+	local e = unix.environ()
+	spawn({"git", "checkout", "."}, {env = e}):wait()
+	spawn({"git", "config", "user.email", "189851+whilp@users.noreply.github.com"}, {env = e}):wait()
+	spawn({"git", "config", "core.fsmonitor", "false"}, {env = e}):wait()
 
 	if unix.commandv("watchman") then
 		local devnull = unix.open("/dev/null", unix.O_RDWR)
-		spawn({"watchman", "watch-project", env.DST}, {stdin = devnull, stdout = devnull, stderr = devnull})
+		spawn({"watchman", "watch-project", env.DST}, {stdin = devnull, stdout = devnull, stderr = devnull, env = e})
 		unix.close(devnull)
 	end
 

--- a/lib/home/setup/shell.tl
+++ b/lib/home/setup/shell.tl
@@ -5,7 +5,8 @@ local spawn = require("cosmic.spawn")
 local env_module = require("setup.env")
 
 local function run(env: env_module.Env): number
-	local ok, output = spawn({"id", "-un"}):read()
+	local e = unix.environ()
+	local ok, output = spawn({"id", "-un"}, {env = e}):read()
 	if not ok then
 		return 1
 	end
@@ -13,7 +14,7 @@ local function run(env: env_module.Env): number
 
 	local zsh_path = unix.commandv("zsh")
 	if zsh_path then
-		spawn({"sudo", "chsh", username, "--shell", zsh_path}):wait()
+		spawn({"sudo", "chsh", username, "--shell", zsh_path}, {env = e}):wait()
 	end
 
 	local bashrc = path.join(env.DST, ".bashrc")

--- a/lib/home/setup/util.tl
+++ b/lib/home/setup/util.tl
@@ -1,7 +1,8 @@
+local unix = require("cosmo.unix")
 local spawn = require("cosmic.spawn")
 
 local function copy_tree(src: string, dst: string): boolean
-	local status = spawn({"cp", "-ra", src, dst}):wait()
+	local status = spawn({"cp", "-ra", src, dst}, {env = unix.environ()}):wait()
 	return status == 0
 end
 


### PR DESCRIPTION
## Summary
- Fix `box --sprite <name> ssh -- <command>` which was broken because `sprite console` doesn't accept command arguments
- Split ssh function: use `sprite console` for interactive shell, `sprite exec` for running commands
- Remove unnecessary `$SHELL` handling from init.tl since sprite console handles shell detection

## Test plan
- [x] `box --sprite beta ssh` - interactive shell works
- [x] `box --sprite beta ssh -- echo "test"` - command execution works
- [x] `box --sprite beta run` - bootstrap works