### PR TITLE
zshenv: set LANG=en_US.UTF-8

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -1,4 +1,4 @@
-export LANG=en_US.UTF-8
+export LANG=C.UTF-8
 
 typeset -aU path
 

--- a/.zshenv
+++ b/.zshenv
@@ -1,3 +1,5 @@
+export LANG=en_US.UTF-8
+
 typeset -aU path
 
 path=(


### PR DESCRIPTION
Without a UTF-8 locale, zsh treats multi-byte characters (like emoji) as individual bytes. This causes `${WHEREAMI: -1}` in PS1 to grab only the last byte of a multi-byte emoji instead of the full character, rendering a broken symbol as the prompt.

Sets `LANG=en_US.UTF-8` at the top of `.zshenv` so it takes effect before any parameter expansion.